### PR TITLE
Add interactive ASCII art command to CLI

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { Command } from 'commander';
 import { readFileSync, writeFileSync } from 'fs';
-import { readFileSync } from 'fs';
+import chalk from 'chalk';
 import { fileURLToPath } from 'url';
 import { dirname, resolve } from 'path';
 import readline from 'node:readline/promises';
@@ -145,10 +145,49 @@ program
     } catch {
       console.log('No prompt.txt found to export.');
     }
-  .command('export')
-  .description('Export current prompt')
-  .action(() => {
-    console.log('Prompt exported (not implemented).');
+  });
+
+program
+  .command('ascii')
+  .description('Display interactive ASCII art')
+  .action(async () => {
+    const arts = {
+      1: { name: 'Prompt or Die', art: `
+ ____                        _       
+|  _ \\ ___ _ __   ___  _ __ | |_ ___ 
+| |_) / _ \\ '_ \\ / _ \\| '_ \\| __/ __|
+|  __/  __/ |_) | (_) | | | | |_\\__ \\
+|_|   \\___| .__/ \\___/|_| |_|\\__|___/
+          |_|                       
+` },
+      2: { name: 'Skull', art: `
+  .-''''-.
+ /        \\
+|  .--.  |
+| ( () ) |
+|  '--'  |
+ \\      /
+  '----'
+` },
+      3: { name: 'Triangle', art: `
+   /\\
+  /  \\
+ /____\\
+` }
+    };
+    console.log(chalk.blue('Choose an art style:'));
+    Object.entries(arts).forEach(([key, val]) => {
+      console.log(chalk.cyan(`${key}. ${val.name}`));
+    });
+    const rl = readline.createInterface({ input, output });
+    const choice = await rl.question(chalk.green('> '));
+    rl.close();
+    const selected = arts[choice.trim()];
+    if (selected) {
+      console.log(chalk.yellow(selected.art));
+    } else {
+      console.log(chalk.red('Invalid selection'));
+    }
   });
 
 program

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@supabase/supabase-js": "^2.39.6",
         "@tailwindcss/typography": "^0.5.15",
         "@tanstack/react-query": "^5.56.2",
+        "chalk": "^4.1.2",
         "class-variance-authority": "^0.7.1",
         "clipboardy": "^4.0.0",
         "clsx": "^2.1.1",
@@ -3612,7 +3613,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -5180,7 +5180,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7383,7 +7382,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@supabase/supabase-js": "^2.39.6",
     "@tailwindcss/typography": "^0.5.15",
     "@tanstack/react-query": "^5.56.2",
+    "chalk": "^4.1.2",
     "class-variance-authority": "^0.7.1",
     "clipboardy": "^4.0.0",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Summary
- remove duplicate fs import and add chalk
- fix `export` command block
- add `ascii` command for interactive ASCII art
- include `chalk` as a dependency

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68415107e0588330b915ca260f66eda6