### PR TITLE
[codex] add pod-scene scene entity reference bindings

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -216,5 +216,15 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cargo check -p pod-scene`
   - `cargo test -p pod-scene --lib`
 
-**Last updated**: Iteration 31
+### Iteration 32 — Scene Entity Reference Binding Pass
+
+- [x] Added authored entity reference bindings to `pod-scene` scene entities with stable selectors by scene entity UUID or unique scene entity name.
+- [x] Resolved entity references during scene instantiation against the pre-spawned scene entity map, so native components can bind deterministic runtime entity ids for fields like `FollowCameraController.target` and `Parent3D.parent`.
+- [x] Reused the prefab JSON path assignment logic as shared component-path mutation infrastructure for both prefab property overrides and scene entity reference application.
+- [x] Added deterministic tests covering direct-id entity references, prefab-backed named references, missing-target rejection, and ambiguous-name rejection.
+- [x] Validated touched crate:
+  - `cargo check -p pod-scene`
+  - `cargo test -p pod-scene --lib`
+
+**Last updated**: Iteration 32
 **Current focus**: Phase 7.5 scene-system parity and Phase 9 hardening backlog

--- a/crates/pod-scene/src/lib.rs
+++ b/crates/pod-scene/src/lib.rs
@@ -20,5 +20,8 @@ pub use asset::{AssetHandle, AssetLoader, AssetManager, AssetState, AssetStore};
 pub use binding::{NativeComponent, NativeComponentBinding};
 pub use prefab::{Prefab, PrefabComponent, PrefabDiff, PrefabMetadataDiff, PrefabRegistry};
 pub use save::{SaveData, SaveManager};
-pub use scene::{Scene, SceneGraph, SceneManager, SceneSpawnResult};
+pub use scene::{
+    EntityInstance, EntityReferenceBinding, EntityReferenceTarget, Scene, SceneGraph, SceneManager,
+    SceneSpawnResult, SpawnPoint,
+};
 pub use state::{GameState, StateStack, StateTransition};

--- a/crates/pod-scene/src/prefab.rs
+++ b/crates/pod-scene/src/prefab.rs
@@ -427,47 +427,70 @@ fn apply_property_override(
     path: &[&str],
     value: &serde_json::Value,
 ) {
+    let _ = set_component_path_value(component, path, value);
+}
+
+pub(crate) fn set_component_path_value(
+    component: &mut PrefabComponent,
+    path: &[&str],
+    value: &serde_json::Value,
+) -> Result<(), String> {
     if path.is_empty() {
-        return;
+        return Err("component path cannot be empty".to_string());
     }
 
     match component {
-        PrefabComponent::Json(json) => {
-            apply_json_override(json, path, value);
-        }
+        PrefabComponent::Json(json) => set_json_path_value(json, path, value),
     }
 }
 
-fn apply_json_override(current: &mut serde_json::Value, path: &[&str], value: &serde_json::Value) {
+fn set_json_path_value(
+    current: &mut serde_json::Value,
+    path: &[&str],
+    value: &serde_json::Value,
+) -> Result<(), String> {
     if path.is_empty() {
         *current = value.clone();
-        return;
+        return Ok(());
     }
 
     let key = path[0];
     if path.len() == 1 {
-        set_json_child(current, key, value.clone());
-        return;
+        return set_json_child(current, key, value.clone());
     }
 
     let next_key = path[1];
-    if let Some(child) = get_or_create_json_child(current, key, next_key) {
-        apply_json_override(child, &path[1..], value);
-    }
+    let child = get_or_create_json_child(current, key, next_key).ok_or_else(|| {
+        format!(
+            "cannot descend through '{}' on non-container JSON value",
+            key
+        )
+    })?;
+    set_json_path_value(child, &path[1..], value)
 }
 
-fn set_json_child(target: &mut serde_json::Value, key: &str, value: serde_json::Value) {
+fn set_json_child(
+    target: &mut serde_json::Value,
+    key: &str,
+    value: serde_json::Value,
+) -> Result<(), String> {
     if let Some(object) = target.as_object_mut() {
         object.insert(key.to_string(), value);
-        return;
+        return Ok(());
     }
 
     if let Some(array) = target.as_array_mut() {
         if let Some(index) = key_to_index(key) {
             ensure_array_len(array, index + 1);
             array[index] = value;
+            return Ok(());
         }
     }
+
+    Err(format!(
+        "cannot assign '{}' on JSON value that is neither an object field nor an addressable array slot",
+        key
+    ))
 }
 
 fn get_or_create_json_child<'a>(

--- a/crates/pod-scene/src/scene.rs
+++ b/crates/pod-scene/src/scene.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use uuid::Uuid;
 
 use crate::binding::{insert_bound_components, NativeComponentBinding};
-use crate::prefab::{PrefabComponent, PrefabRegistry};
+use crate::prefab::{set_component_path_value, PrefabComponent, PrefabRegistry};
 
 /// Represents a spawn point in a scene
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -115,6 +115,63 @@ impl Default for SceneMetadata {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum EntityReferenceTarget {
+    ById { id: Uuid },
+    ByName { name: String },
+}
+
+impl EntityReferenceTarget {
+    pub fn by_id(id: Uuid) -> Self {
+        Self::ById { id }
+    }
+
+    pub fn by_name(name: impl Into<String>) -> Self {
+        Self::ByName { name: name.into() }
+    }
+
+    fn describe(&self) -> String {
+        match self {
+            Self::ById { id } => format!("scene entity id {}", id),
+            Self::ByName { name } => format!("scene entity name '{}'", name),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EntityReferenceBinding {
+    pub component: String,
+    pub path: String,
+    pub target: EntityReferenceTarget,
+}
+
+impl EntityReferenceBinding {
+    pub fn new(
+        component: impl Into<String>,
+        path: impl Into<String>,
+        target: EntityReferenceTarget,
+    ) -> Self {
+        Self {
+            component: component.into(),
+            path: path.into(),
+            target,
+        }
+    }
+
+    pub fn by_id(component: impl Into<String>, path: impl Into<String>, id: Uuid) -> Self {
+        Self::new(component, path, EntityReferenceTarget::by_id(id))
+    }
+
+    pub fn by_name(
+        component: impl Into<String>,
+        path: impl Into<String>,
+        name: impl Into<String>,
+    ) -> Self {
+        Self::new(component, path, EntityReferenceTarget::by_name(name))
+    }
+}
+
 /// Entity instance in a scene with all its component data
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EntityInstance {
@@ -122,6 +179,8 @@ pub struct EntityInstance {
     pub name: String,
     pub prefab_ref: Option<String>, // Reference to a prefab, if this entity was created from one
     pub components: HashMap<String, PrefabComponent>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub entity_references: Vec<EntityReferenceBinding>,
 }
 
 impl EntityInstance {
@@ -131,6 +190,7 @@ impl EntityInstance {
             name: name.into(),
             prefab_ref: None,
             components: HashMap::new(),
+            entity_references: Vec::new(),
         }
     }
 
@@ -175,6 +235,28 @@ impl EntityInstance {
 
     pub fn remove_component(&mut self, name: &str) -> Option<PrefabComponent> {
         self.components.remove(name)
+    }
+
+    pub fn add_entity_reference(&mut self, reference: EntityReferenceBinding) {
+        self.entity_references.push(reference);
+    }
+
+    pub fn add_entity_reference_by_id(
+        &mut self,
+        component: impl Into<String>,
+        path: impl Into<String>,
+        id: Uuid,
+    ) {
+        self.add_entity_reference(EntityReferenceBinding::by_id(component, path, id));
+    }
+
+    pub fn add_entity_reference_by_name(
+        &mut self,
+        component: impl Into<String>,
+        path: impl Into<String>,
+        name: impl Into<String>,
+    ) {
+        self.add_entity_reference(EntityReferenceBinding::by_name(component, path, name));
     }
 }
 
@@ -282,6 +364,7 @@ impl Scene {
         prefabs: Option<&PrefabRegistry>,
     ) -> Result<SceneSpawnResult, String> {
         let mut entity_map = HashMap::new();
+        let entity_name_lookup = self.build_entity_name_lookup();
 
         for entity in &self.entities {
             entity_map.insert(entity.id, world.ecs.spawn(()));
@@ -295,7 +378,13 @@ impl Scene {
                 .copied()
                 .ok_or_else(|| format!("Scene entity '{}' was not pre-spawned", entity.name))?;
 
-            let resolved_components = self.resolve_entity_components(entity, prefabs)?;
+            let mut resolved_components = self.resolve_entity_components(entity, prefabs)?;
+            self.apply_entity_references(
+                entity,
+                &mut resolved_components,
+                &entity_map,
+                &entity_name_lookup,
+            )?;
             let ignored =
                 insert_bound_components(&resolved_components, &mut world.ecs, spawned_entity)?;
             ignored_components.extend(
@@ -338,6 +427,103 @@ impl Scene {
         }
 
         Ok(components)
+    }
+
+    fn build_entity_name_lookup(&self) -> HashMap<String, Vec<Uuid>> {
+        let mut lookup = HashMap::<String, Vec<Uuid>>::new();
+        for entity in &self.entities {
+            lookup
+                .entry(entity.name.clone())
+                .or_default()
+                .push(entity.id);
+        }
+        lookup
+    }
+
+    fn apply_entity_references(
+        &self,
+        entity: &EntityInstance,
+        components: &mut HashMap<String, PrefabComponent>,
+        entity_map: &HashMap<Uuid, Entity>,
+        entity_name_lookup: &HashMap<String, Vec<Uuid>>,
+    ) -> Result<(), String> {
+        for reference in &entity.entity_references {
+            let target = self.resolve_entity_reference_target(
+                entity,
+                reference,
+                entity_map,
+                entity_name_lookup,
+            )?;
+            let component = components.get_mut(&reference.component).ok_or_else(|| {
+                format!(
+                    "Entity reference '{}.{}' on '{}' requires component '{}'",
+                    reference.component, reference.path, entity.name, reference.component
+                )
+            })?;
+            let path: Vec<&str> = reference
+                .path
+                .split('.')
+                .filter(|segment| !segment.is_empty())
+                .collect();
+            if path.is_empty() {
+                return Err(format!(
+                    "Entity reference on '{}' for component '{}' must specify a non-empty property path",
+                    entity.name, reference.component
+                ));
+            }
+
+            set_component_path_value(component, &path, &serde_json::json!(target.id() as u64))
+                .map_err(|err| {
+                    format!(
+                        "Failed to resolve entity reference '{}.{}' on '{}' in scene '{}': {}",
+                        reference.component, reference.path, entity.name, self.metadata.name, err
+                    )
+                })?;
+        }
+
+        Ok(())
+    }
+
+    fn resolve_entity_reference_target(
+        &self,
+        entity: &EntityInstance,
+        reference: &EntityReferenceBinding,
+        entity_map: &HashMap<Uuid, Entity>,
+        entity_name_lookup: &HashMap<String, Vec<Uuid>>,
+    ) -> Result<Entity, String> {
+        let target_scene_id = match &reference.target {
+            EntityReferenceTarget::ById { id } => *id,
+            EntityReferenceTarget::ByName { name } => {
+                let matches = entity_name_lookup.get(name).ok_or_else(|| {
+                    format!(
+                        "Entity reference '{}.{}' on '{}' points to missing {}",
+                        reference.component,
+                        reference.path,
+                        entity.name,
+                        reference.target.describe()
+                    )
+                })?;
+
+                if matches.len() != 1 {
+                    return Err(format!(
+                        "Entity reference '{}.{}' on '{}' is ambiguous for {}",
+                        reference.component,
+                        reference.path,
+                        entity.name,
+                        reference.target.describe()
+                    ));
+                }
+
+                matches[0]
+            }
+        };
+
+        entity_map.get(&target_scene_id).copied().ok_or_else(|| {
+            format!(
+                "Entity reference '{}.{}' on '{}' points to unresolved scene entity {}",
+                reference.component, reference.path, entity.name, target_scene_id
+            )
+        })
     }
 
     fn apply_parent_graph(
@@ -531,7 +717,10 @@ fn chrono_format_date() -> String {
 mod tests {
     use super::*;
     use glam::Vec3;
-    use pod_core::{Label, Material, Mesh, Parent3D, Sprite, Team, Transform, Transform3D};
+    use pod_core::{
+        Camera3D, FollowCameraController, Label, Material, Mesh, Parent3D, Sprite, Team, Transform,
+        Transform3D,
+    };
 
     use crate::prefab::Prefab;
 
@@ -760,5 +949,136 @@ mod tests {
         assert_eq!(actor_sprite.texture, "actor_sprite");
         assert_eq!(actor_label.name, "ActorBase");
         assert_eq!(actor_label.team, Team::Team(2));
+    }
+
+    #[test]
+    fn test_scene_instantiation_resolves_entity_references_by_id() {
+        let mut scene = Scene::new("EntityRefScene");
+
+        let mut player = EntityInstance::new("Player");
+        player
+            .add_native_component(&Transform3D {
+                position: Vec3::new(4.0, 0.0, 2.0),
+                ..Default::default()
+            })
+            .unwrap();
+        let player_id = scene.add_entity(player);
+
+        let mut camera = EntityInstance::new("Camera");
+        camera.add_native_component(&Camera3D::default()).unwrap();
+        camera
+            .add_native_component(&FollowCameraController::default())
+            .unwrap();
+        camera.add_entity_reference_by_id("FollowCameraController", "target", player_id);
+        let camera_id = scene.add_entity(camera);
+
+        let mut world = World::new(5);
+        let result = scene.instantiate(&mut world).unwrap();
+
+        let player_entity = result
+            .entity_for(player_id)
+            .expect("player should be spawned");
+        let camera_entity = result
+            .entity_for(camera_id)
+            .expect("camera should be spawned");
+        let controller = world
+            .ecs
+            .get::<&FollowCameraController>(camera_entity)
+            .expect("camera should keep follow controller");
+        assert_eq!(controller.target, player_entity.id() as u64);
+    }
+
+    #[test]
+    fn test_scene_instantiation_resolves_entity_references_by_name_for_prefabs() {
+        let mut registry = PrefabRegistry::new();
+        let mut camera_prefab = Prefab::new("CameraRig");
+        camera_prefab
+            .add_native_component(&Camera3D::default())
+            .unwrap();
+        camera_prefab
+            .add_native_component(&FollowCameraController::default())
+            .unwrap();
+        registry.register("CameraRig", camera_prefab);
+
+        let mut scene = Scene::new("PrefabRefScene");
+
+        let mut player = EntityInstance::new("Player");
+        player
+            .add_native_component(&Transform3D {
+                position: Vec3::new(-2.0, 1.0, 8.0),
+                ..Default::default()
+            })
+            .unwrap();
+        let player_id = scene.add_entity(player);
+
+        let mut camera = EntityInstance::new("Camera").with_prefab("CameraRig");
+        camera.add_entity_reference_by_name("FollowCameraController", "target", "Player");
+        let camera_id = scene.add_entity(camera);
+
+        let mut world = World::new(6);
+        let result = scene
+            .instantiate_with_prefabs(&mut world, Some(&registry))
+            .unwrap();
+
+        let player_entity = result
+            .entity_for(player_id)
+            .expect("player should be spawned");
+        let camera_entity = result
+            .entity_for(camera_id)
+            .expect("camera should be spawned");
+        let controller = world
+            .ecs
+            .get::<&FollowCameraController>(camera_entity)
+            .expect("prefab-backed camera should keep follow controller");
+        assert_eq!(controller.target, player_entity.id() as u64);
+    }
+
+    #[test]
+    fn test_scene_instantiation_rejects_missing_entity_reference_target() {
+        let mut scene = Scene::new("MissingEntityRefScene");
+        let mut camera = EntityInstance::new("Camera");
+        camera.add_native_component(&Camera3D::default()).unwrap();
+        camera
+            .add_native_component(&FollowCameraController::default())
+            .unwrap();
+        camera.add_entity_reference_by_name("FollowCameraController", "target", "Missing");
+        scene.add_entity(camera);
+
+        let mut world = World::new(7);
+        let err = scene.instantiate(&mut world).expect_err(
+            "scene instantiation should fail when a named entity reference is unresolved",
+        );
+        assert!(err.contains("missing scene entity name 'Missing'"));
+    }
+
+    #[test]
+    fn test_scene_instantiation_rejects_ambiguous_entity_reference_name() {
+        let mut scene = Scene::new("AmbiguousEntityRefScene");
+
+        let mut first_player = EntityInstance::new("Player");
+        first_player
+            .add_native_component(&Transform3D::default())
+            .unwrap();
+        scene.add_entity(first_player);
+
+        let mut second_player = EntityInstance::new("Player");
+        second_player
+            .add_native_component(&Transform3D::default())
+            .unwrap();
+        scene.add_entity(second_player);
+
+        let mut camera = EntityInstance::new("Camera");
+        camera.add_native_component(&Camera3D::default()).unwrap();
+        camera
+            .add_native_component(&FollowCameraController::default())
+            .unwrap();
+        camera.add_entity_reference_by_name("FollowCameraController", "target", "Player");
+        scene.add_entity(camera);
+
+        let mut world = World::new(8);
+        let err = scene.instantiate(&mut world).expect_err(
+            "scene instantiation should fail when a named entity reference is ambiguous",
+        );
+        assert!(err.contains("ambiguous"));
     }
 }


### PR DESCRIPTION
## Summary
- add authored scene entity reference bindings with selectors by scene entity UUID or unique scene entity name
- resolve those bindings during scene instantiation so native component fields can target the correct runtime `hecs` entity ids
- reuse the prefab component-path mutation logic for both prefab overrides and scene reference application

## Why
- scene entities could spawn deterministically, but authored content still had no stable way to point one spawned entity at another
- camera follow rigs and similar world-authored relationships need a stable bridge from scene auth ids to runtime entity ids

## Validation
```bash
cargo check -p pod-scene
cargo test -p pod-scene --lib
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Scene entities can now reference other entities by UUID or unique name for stable cross-entity relationships.
  * Entity references are automatically resolved during scene instantiation with deterministic ID assignment.

* **Documentation**
  * Updated implementation plan tracking for current development phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->