### PR TITLE
[codex] add pod-scene prefab override tracking

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -236,5 +236,16 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cargo check -p pod-scene`
   - `cargo test -p pod-scene --lib`
 
-**Last updated**: Iteration 33
+### Iteration 34 — Prefab Override Tracking Pass
+
+- [x] Added structured prefab override reporting in `pod-scene` so prefab resolution now returns applied and ignored override records with previous values for editor/debug inspection.
+- [x] Added authored `prefab_overrides` on scene entities, applied during prefab-backed scene instantiation before full local component replacement semantics.
+- [x] Surfaced per-entity prefab override reports in `SceneSpawnResult`, and rejected invalid authoring cases such as prefab overrides on entities with no prefab source.
+- [x] Hardened override path mutation to reject incompatible JSON shape rewrites instead of silently corrupting typed component payloads.
+- [x] Added deterministic tests covering prefab-level override reports, scene-level prefab override application/reporting, local component precedence, and invalid prefab-override usage.
+- [x] Validated touched crate:
+  - `cargo check -p pod-scene`
+  - `cargo test -p pod-scene --lib`
+
+**Last updated**: Iteration 34
 **Current focus**: Phase 7.5 scene-system parity and Phase 9 hardening backlog

--- a/crates/pod-scene/src/lib.rs
+++ b/crates/pod-scene/src/lib.rs
@@ -18,7 +18,11 @@ pub mod state;
 
 pub use asset::{AssetHandle, AssetLoader, AssetManager, AssetState, AssetStore};
 pub use binding::{NativeComponent, NativeComponentBinding};
-pub use prefab::{Prefab, PrefabComponent, PrefabDiff, PrefabMetadataDiff, PrefabRegistry};
+pub use prefab::{
+    AppliedPropertyOverride, IgnoredPropertyOverride, Prefab, PrefabComponent, PrefabDiff,
+    PrefabMetadataDiff, PrefabRegistry, PropertyOverride, PropertyOverrideReport,
+    ResolvedPrefabComponents,
+};
 pub use save::{SaveData, SaveManager};
 pub use scene::{
     EntityInstance, EntityReferenceBinding, EntityReferenceTarget, Scene, SceneGraph, SceneManager,

--- a/crates/pod-scene/src/prefab.rs
+++ b/crates/pod-scene/src/prefab.rs
@@ -164,6 +164,39 @@ impl PropertyOverride {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AppliedPropertyOverride {
+    pub path: String,
+    pub previous_value: Option<serde_json::Value>,
+    pub value: serde_json::Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IgnoredPropertyOverride {
+    pub path: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct PropertyOverrideReport {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub applied: Vec<AppliedPropertyOverride>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub ignored: Vec<IgnoredPropertyOverride>,
+}
+
+impl PropertyOverrideReport {
+    pub fn is_empty(&self) -> bool {
+        self.applied.is_empty() && self.ignored.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedPrefabComponents {
+    pub components: HashMap<String, PrefabComponent>,
+    pub override_report: PropertyOverrideReport,
+}
+
 /// Serializable entity template with components
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Prefab {
@@ -276,21 +309,53 @@ impl Prefab {
         &self,
         overrides: &[PropertyOverride],
     ) -> HashMap<String, PrefabComponent> {
+        self.resolved_components_with_report(overrides).components
+    }
+
+    pub fn resolved_components_with_report(
+        &self,
+        overrides: &[PropertyOverride],
+    ) -> ResolvedPrefabComponents {
         let mut components = self.components.clone();
+        let mut override_report = PropertyOverrideReport::default();
 
         for override_ in overrides {
             let parts: Vec<&str> = override_.path.split('.').collect();
             if parts.len() < 2 {
+                override_report.ignored.push(IgnoredPropertyOverride {
+                    path: override_.path.clone(),
+                    reason: "override path must include a component name and property path"
+                        .to_string(),
+                });
                 continue;
             }
 
             let component_name = parts[0];
             if let Some(component) = components.get_mut(component_name) {
-                apply_property_override(component, &parts[1..], &override_.value);
+                let previous_value = get_component_path_value(component, &parts[1..]).cloned();
+                match set_component_path_value(component, &parts[1..], &override_.value) {
+                    Ok(()) => override_report.applied.push(AppliedPropertyOverride {
+                        path: override_.path.clone(),
+                        previous_value,
+                        value: override_.value.clone(),
+                    }),
+                    Err(reason) => override_report.ignored.push(IgnoredPropertyOverride {
+                        path: override_.path.clone(),
+                        reason,
+                    }),
+                }
+            } else {
+                override_report.ignored.push(IgnoredPropertyOverride {
+                    path: override_.path.clone(),
+                    reason: format!("component '{}' is not present on prefab", component_name),
+                });
             }
         }
 
-        components
+        ResolvedPrefabComponents {
+            components,
+            override_report,
+        }
     }
 
     pub fn diff_against(&self, base: &Prefab) -> PrefabDiff {
@@ -407,7 +472,7 @@ impl Prefab {
         world: &mut World,
         overrides: &[PropertyOverride],
     ) -> Result<hecs::Entity, String> {
-        let components = self.resolved_components(overrides);
+        let components = self.resolved_components_with_report(overrides).components;
         let entity = world.ecs.spawn(());
         let ignored = insert_bound_components(&components, &mut world.ecs, entity)?;
         for component_name in ignored {
@@ -419,15 +484,6 @@ impl Prefab {
         }
         Ok(entity)
     }
-}
-
-/// Helper to apply nested property overrides
-fn apply_property_override(
-    component: &mut PrefabComponent,
-    path: &[&str],
-    value: &serde_json::Value,
-) {
-    let _ = set_component_path_value(component, path, value);
 }
 
 pub(crate) fn set_component_path_value(
@@ -460,13 +516,38 @@ fn set_json_path_value(
     }
 
     let next_key = path[1];
-    let child = get_or_create_json_child(current, key, next_key).ok_or_else(|| {
-        format!(
-            "cannot descend through '{}' on non-container JSON value",
-            key
-        )
-    })?;
+    let child = get_or_create_json_child(current, key, next_key)?;
     set_json_path_value(child, &path[1..], value)
+}
+
+fn get_component_path_value<'a>(
+    component: &'a PrefabComponent,
+    path: &[&str],
+) -> Option<&'a serde_json::Value> {
+    match component {
+        PrefabComponent::Json(json) => get_json_path_value(json, path),
+    }
+}
+
+fn get_json_path_value<'a>(
+    current: &'a serde_json::Value,
+    path: &[&str],
+) -> Option<&'a serde_json::Value> {
+    if path.is_empty() {
+        return Some(current);
+    }
+
+    let key = path[0];
+    let next = match current {
+        serde_json::Value::Object(object) => object.get(key)?,
+        serde_json::Value::Array(array) => {
+            let index = key_to_index(key)?;
+            array.get(index)?
+        }
+        _ => return None,
+    };
+
+    get_json_path_value(next, &path[1..])
 }
 
 fn set_json_child(
@@ -497,26 +578,42 @@ fn get_or_create_json_child<'a>(
     target: &'a mut serde_json::Value,
     key: &str,
     next_key: &str,
-) -> Option<&'a mut serde_json::Value> {
+) -> Result<&'a mut serde_json::Value, String> {
     match target {
         serde_json::Value::Object(object) => {
             let entry = object
                 .entry(key.to_string())
                 .or_insert_with(|| empty_container_for(next_key));
-            if !matches_container(entry, next_key) {
+            if entry.is_null() {
                 *entry = empty_container_for(next_key);
+            } else if !matches_container(entry, next_key) {
+                return Err(format!(
+                    "cannot descend through '{}' because the existing value has incompatible shape",
+                    key
+                ));
             }
-            Some(entry)
+            Ok(entry)
         }
         serde_json::Value::Array(array) => {
-            let index = key_to_index(key)?;
+            let index = key_to_index(key)
+                .ok_or_else(|| format!("array path segment '{}' is not addressable", key))?;
             ensure_array_len(array, index + 1);
-            if !matches_container(&array[index], next_key) {
+            if array[index].is_null() {
                 array[index] = empty_container_for(next_key);
+            } else if !matches_container(&array[index], next_key) {
+                return Err(format!(
+                    "cannot descend through '{}' because the existing array element has incompatible shape",
+                    key
+                ));
             }
-            array.get_mut(index)
+            array
+                .get_mut(index)
+                .ok_or_else(|| format!("array path segment '{}' is out of bounds", key))
         }
-        _ => None,
+        _ => Err(format!(
+            "cannot descend through '{}' on non-container JSON value",
+            key
+        )),
     }
 }
 
@@ -767,6 +864,48 @@ mod tests {
     fn test_property_override() {
         let override_ = PropertyOverride::new("Transform.position.x", serde_json::json!(42.0));
         assert_eq!(override_.path, "Transform.position.x");
+    }
+
+    #[test]
+    fn test_resolved_components_with_report_tracks_applied_and_ignored_overrides() {
+        let mut prefab = Prefab::new("OverrideReportPrefab");
+        prefab
+            .add_native_component(&Transform::at(1.0, 2.0))
+            .unwrap();
+
+        let resolved = prefab.resolved_components_with_report(&[
+            PropertyOverride::new("Transform.position.x", serde_json::json!(42.0)),
+            PropertyOverride::new("Sprite.layer", serde_json::json!(3)),
+            PropertyOverride::new("Transform.position.foo", serde_json::json!(9.0)),
+        ]);
+
+        let transform = resolved.components["Transform"]
+            .get_native::<Transform>()
+            .expect("resolved transform should deserialize");
+        assert_eq!(transform.position, Vec2::new(42.0, 2.0));
+
+        assert_eq!(resolved.override_report.applied.len(), 1);
+        assert_eq!(resolved.override_report.ignored.len(), 2);
+        assert_eq!(
+            resolved.override_report.applied[0].previous_value,
+            Some(serde_json::json!(1.0))
+        );
+        let ignored_reasons = resolved
+            .override_report
+            .ignored
+            .iter()
+            .map(|entry| entry.reason.as_str())
+            .collect::<Vec<_>>()
+            .join(" | ");
+        assert!(
+            ignored_reasons.contains("component 'Sprite' is not present on prefab"),
+            "unexpected ignored override reasons: {ignored_reasons}"
+        );
+        assert!(
+            ignored_reasons.contains("incompatible shape")
+                || ignored_reasons.contains("cannot assign"),
+            "unexpected ignored override reasons: {ignored_reasons}"
+        );
     }
 
     #[test]

--- a/crates/pod-scene/src/scene.rs
+++ b/crates/pod-scene/src/scene.rs
@@ -5,7 +5,10 @@ use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
 
 use crate::binding::{insert_bound_components, NativeComponentBinding};
-use crate::prefab::{set_component_path_value, PrefabComponent, PrefabRegistry};
+use crate::prefab::{
+    set_component_path_value, PrefabComponent, PrefabRegistry, PropertyOverride,
+    PropertyOverrideReport,
+};
 
 /// Represents a spawn point in a scene
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -275,6 +278,8 @@ pub struct EntityInstance {
     pub prefab_ref: Option<String>, // Reference to a prefab, if this entity was created from one
     pub components: HashMap<String, PrefabComponent>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub prefab_overrides: Vec<PropertyOverride>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub entity_references: Vec<EntityReferenceBinding>,
 }
 
@@ -285,6 +290,7 @@ impl EntityInstance {
             name: name.into(),
             prefab_ref: None,
             components: HashMap::new(),
+            prefab_overrides: Vec::new(),
             entity_references: Vec::new(),
         }
     }
@@ -332,6 +338,10 @@ impl EntityInstance {
         self.components.remove(name)
     }
 
+    pub fn add_prefab_override(&mut self, override_: PropertyOverride) {
+        self.prefab_overrides.push(override_);
+    }
+
     pub fn add_entity_reference(&mut self, reference: EntityReferenceBinding) {
         self.entity_references.push(reference);
     }
@@ -359,11 +369,19 @@ impl EntityInstance {
 pub struct SceneSpawnResult {
     pub entity_map: HashMap<Uuid, Entity>,
     pub ignored_components: Vec<String>,
+    pub prefab_override_reports: HashMap<Uuid, PropertyOverrideReport>,
 }
 
 impl SceneSpawnResult {
     pub fn entity_for(&self, scene_entity_id: Uuid) -> Option<Entity> {
         self.entity_map.get(&scene_entity_id).copied()
+    }
+
+    pub fn prefab_override_report_for(
+        &self,
+        scene_entity_id: Uuid,
+    ) -> Option<&PropertyOverrideReport> {
+        self.prefab_override_reports.get(&scene_entity_id)
     }
 }
 
@@ -546,6 +564,7 @@ impl Scene {
     ) -> Result<SceneSpawnResult, String> {
         let mut entity_map = HashMap::new();
         let entity_name_lookup = self.build_entity_name_lookup();
+        let mut prefab_override_reports = HashMap::new();
 
         let scene_entities: Vec<&EntityInstance> = self
             .entities
@@ -569,13 +588,17 @@ impl Scene {
                 .copied()
                 .ok_or_else(|| format!("Scene entity '{}' was not pre-spawned", entity.name))?;
 
-            let mut resolved_components = self.resolve_entity_components(entity, prefabs)?;
+            let (mut resolved_components, override_report) =
+                self.resolve_entity_components(entity, prefabs)?;
             self.apply_entity_references(
                 entity,
                 &mut resolved_components,
                 &entity_map,
                 &entity_name_lookup,
             )?;
+            if !override_report.is_empty() {
+                prefab_override_reports.insert(entity.id, override_report);
+            }
             let ignored =
                 insert_bound_components(&resolved_components, &mut world.ecs, spawned_entity)?;
             ignored_components.extend(
@@ -592,6 +615,7 @@ impl Scene {
         Ok(SceneSpawnResult {
             entity_map,
             ignored_components,
+            prefab_override_reports,
         })
     }
 
@@ -599,8 +623,8 @@ impl Scene {
         &self,
         entity: &EntityInstance,
         prefabs: Option<&PrefabRegistry>,
-    ) -> Result<HashMap<String, PrefabComponent>, String> {
-        let mut components = match entity.prefab_ref.as_deref() {
+    ) -> Result<(HashMap<String, PrefabComponent>, PropertyOverrideReport), String> {
+        let (mut components, override_report) = match entity.prefab_ref.as_deref() {
             Some(prefab_name) => {
                 let registry = prefabs.ok_or_else(|| {
                     format!(
@@ -608,16 +632,26 @@ impl Scene {
                         self.metadata.name, prefab_name
                     )
                 })?;
-                registry.resolve_prefab(prefab_name)?.components.clone()
+                let prefab = registry.resolve_prefab(prefab_name)?;
+                let resolved = prefab.resolved_components_with_report(&entity.prefab_overrides);
+                (resolved.components, resolved.override_report)
             }
-            None => HashMap::new(),
+            None => {
+                if !entity.prefab_overrides.is_empty() {
+                    return Err(format!(
+                        "Scene entity '{}' defines prefab overrides but has no prefab reference",
+                        entity.name
+                    ));
+                }
+                (HashMap::new(), PropertyOverrideReport::default())
+            }
         };
 
         for (name, component) in &entity.components {
             components.insert(name.clone(), component.clone());
         }
 
-        Ok(components)
+        Ok((components, override_report))
     }
 
     fn build_entity_name_lookup(&self) -> HashMap<String, Vec<Uuid>> {
@@ -990,7 +1024,7 @@ mod tests {
         Transform3D,
     };
 
-    use crate::prefab::Prefab;
+    use crate::prefab::{Prefab, PropertyOverride};
 
     #[test]
     fn test_scene_graph_parent_child() {
@@ -1348,6 +1382,105 @@ mod tests {
             "scene instantiation should fail when a named entity reference is ambiguous",
         );
         assert!(err.contains("ambiguous"));
+    }
+
+    #[test]
+    fn test_scene_instantiation_applies_prefab_overrides_and_reports_them() {
+        let mut registry = PrefabRegistry::new();
+        let mut actor_prefab = Prefab::new("Actor");
+        actor_prefab
+            .add_native_component(&Sprite {
+                texture: "hero".to_string(),
+                layer: 2,
+                ..Default::default()
+            })
+            .unwrap();
+        registry.register("Actor", actor_prefab);
+
+        let mut scene = Scene::new("PrefabOverrideScene");
+        let mut actor = EntityInstance::new("ActorInstance").with_prefab("Actor");
+        actor.add_prefab_override(PropertyOverride::new("Sprite.layer", serde_json::json!(9)));
+        let actor_id = scene.add_entity(actor);
+
+        let mut world = World::new(12);
+        let result = scene
+            .instantiate_with_prefabs(&mut world, Some(&registry))
+            .unwrap();
+
+        let actor_entity = result.entity_for(actor_id).expect("actor should spawn");
+        let sprite = world
+            .ecs
+            .get::<&Sprite>(actor_entity)
+            .expect("actor should keep sprite");
+        assert_eq!(sprite.layer, 9);
+
+        let report = result
+            .prefab_override_report_for(actor_id)
+            .expect("override report should be stored");
+        assert_eq!(report.applied.len(), 1);
+        assert!(report.ignored.is_empty());
+        assert_eq!(report.applied[0].path, "Sprite.layer");
+        assert_eq!(report.applied[0].previous_value, Some(serde_json::json!(2)));
+        assert_eq!(report.applied[0].value, serde_json::json!(9));
+    }
+
+    #[test]
+    fn test_scene_instantiation_prefab_override_report_coexists_with_local_component_override() {
+        let mut registry = PrefabRegistry::new();
+        let mut actor_prefab = Prefab::new("Actor");
+        actor_prefab
+            .add_native_component(&Sprite {
+                texture: "hero".to_string(),
+                layer: 2,
+                ..Default::default()
+            })
+            .unwrap();
+        registry.register("Actor", actor_prefab);
+
+        let mut scene = Scene::new("PrefabOverridePriorityScene");
+        let mut actor = EntityInstance::new("ActorInstance").with_prefab("Actor");
+        actor.add_prefab_override(PropertyOverride::new("Sprite.layer", serde_json::json!(9)));
+        actor
+            .add_native_component(&Sprite {
+                texture: "hero_local".to_string(),
+                layer: 14,
+                ..Default::default()
+            })
+            .unwrap();
+        let actor_id = scene.add_entity(actor);
+
+        let mut world = World::new(13);
+        let result = scene
+            .instantiate_with_prefabs(&mut world, Some(&registry))
+            .unwrap();
+
+        let actor_entity = result.entity_for(actor_id).expect("actor should spawn");
+        let sprite = world
+            .ecs
+            .get::<&Sprite>(actor_entity)
+            .expect("local component override should still insert sprite");
+        assert_eq!(sprite.texture, "hero_local");
+        assert_eq!(sprite.layer, 14);
+
+        let report = result
+            .prefab_override_report_for(actor_id)
+            .expect("override report should still be stored");
+        assert_eq!(report.applied.len(), 1);
+        assert_eq!(report.applied[0].value, serde_json::json!(9));
+    }
+
+    #[test]
+    fn test_scene_instantiation_rejects_prefab_overrides_without_prefab() {
+        let mut scene = Scene::new("InvalidPrefabOverrideScene");
+        let mut entity = EntityInstance::new("LooseEntity");
+        entity.add_prefab_override(PropertyOverride::new("Sprite.layer", serde_json::json!(7)));
+        scene.add_entity(entity);
+
+        let mut world = World::new(14);
+        let err = scene
+            .instantiate(&mut world)
+            .expect_err("prefab overrides should require a prefab reference");
+        assert!(err.contains("defines prefab overrides but has no prefab reference"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add structured prefab override reporting with applied and ignored override records plus previous values
- add authored `prefab_overrides` on scene entities and surface per-entity override reports in `SceneSpawnResult`
- harden override path mutation so invalid shape rewrites fail instead of corrupting typed component payloads

## Why
- prefab overrides existed only as raw runtime mutation input, with no authored scene instance support and no editor/debug provenance
- override reporting is required for practical prefab authoring workflows and for understanding why an instantiated scene entity differs from its source prefab

## Validation
```bash
cargo check -p pod-scene
cargo test -p pod-scene --lib
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added property override reporting for prefabs, tracking which overrides are applied versus ignored
  * Override reports include previous values for applied overrides and detailed reasons for ignored overrides
  * Scene spawn results now provide per-entity override reports for validation
  * Prefabs can now be overridden at the entity level with automatic error checking for incompatible configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->