### PR TITLE
[codex] add pod-scene provenance reporting

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -247,5 +247,15 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cargo check -p pod-scene`
   - `cargo test -p pod-scene --lib`
 
-**Last updated**: Iteration 34
+### Iteration 35 — Scene/Prefab Provenance Reporting Pass
+
+- [x] Added component provenance layers in `pod-scene` so resolved prefab components can explain which prefab definitions, property overrides, scene-authored components, and entity-reference bindings contributed to final runtime state.
+- [x] Extended prefab inheritance resolution with provenance-aware component assembly, preserving full source chains across base/derived prefab merges before overrides are applied.
+- [x] Surfaced per-entity component provenance maps in `SceneSpawnResult`, giving editor/debug tooling stable insight into final component origin across prefab inheritance, scene overrides, and entity-reference resolution.
+- [x] Added deterministic tests covering inherited prefab provenance, scene-local override provenance precedence, and entity-reference provenance tracking.
+- [x] Validated touched crate:
+  - `cargo check -p pod-scene`
+  - `cargo test -p pod-scene --lib`
+
+**Last updated**: Iteration 35
 **Current focus**: Phase 7.5 scene-system parity and Phase 9 hardening backlog

--- a/crates/pod-scene/src/lib.rs
+++ b/crates/pod-scene/src/lib.rs
@@ -19,9 +19,10 @@ pub mod state;
 pub use asset::{AssetHandle, AssetLoader, AssetManager, AssetState, AssetStore};
 pub use binding::{NativeComponent, NativeComponentBinding};
 pub use prefab::{
-    AppliedPropertyOverride, IgnoredPropertyOverride, Prefab, PrefabComponent, PrefabDiff,
-    PrefabMetadataDiff, PrefabRegistry, PropertyOverride, PropertyOverrideReport,
-    ResolvedPrefabComponents,
+    AppliedPropertyOverride, ComponentProvenance, ComponentProvenanceLayer,
+    IgnoredPropertyOverride, Prefab, PrefabComponent, PrefabDiff, PrefabMetadataDiff,
+    PrefabRegistry, PropertyOverride, PropertyOverrideReport, ResolvedPrefabComponents,
+    ResolvedPrefabComponentsWithProvenance,
 };
 pub use save::{SaveData, SaveManager};
 pub use scene::{

--- a/crates/pod-scene/src/prefab.rs
+++ b/crates/pod-scene/src/prefab.rs
@@ -197,6 +197,67 @@ pub struct ResolvedPrefabComponents {
     pub override_report: PropertyOverrideReport,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ComponentProvenanceLayer {
+    PrefabDefinition {
+        prefab: String,
+    },
+    PropertyOverride {
+        path: String,
+    },
+    SceneComponent {
+        entity_id: Uuid,
+        entity_name: String,
+    },
+    EntityReference {
+        path: String,
+        target: String,
+    },
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ComponentProvenance {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub layers: Vec<ComponentProvenanceLayer>,
+}
+
+impl ComponentProvenance {
+    pub fn from_layer(layer: ComponentProvenanceLayer) -> Self {
+        Self {
+            layers: vec![layer],
+        }
+    }
+
+    pub fn push(&mut self, layer: ComponentProvenanceLayer) {
+        self.layers.push(layer);
+    }
+
+    pub fn current(&self) -> Option<&ComponentProvenanceLayer> {
+        self.layers.last()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.layers.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedPrefabComponentsWithProvenance {
+    pub components: HashMap<String, PrefabComponent>,
+    pub override_report: PropertyOverrideReport,
+    pub component_provenance: HashMap<String, ComponentProvenance>,
+}
+
+impl From<ResolvedPrefabComponentsWithProvenance> for ResolvedPrefabComponents {
+    fn from(value: ResolvedPrefabComponentsWithProvenance) -> Self {
+        Self {
+            components: value.components,
+            override_report: value.override_report,
+        }
+    }
+}
+
 /// Serializable entity template with components
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Prefab {
@@ -316,45 +377,23 @@ impl Prefab {
         &self,
         overrides: &[PropertyOverride],
     ) -> ResolvedPrefabComponents {
+        self.resolved_components_with_provenance(overrides).into()
+    }
+
+    pub fn resolved_components_with_provenance(
+        &self,
+        overrides: &[PropertyOverride],
+    ) -> ResolvedPrefabComponentsWithProvenance {
         let mut components = self.components.clone();
-        let mut override_report = PropertyOverrideReport::default();
+        let mut component_provenance =
+            build_prefab_definition_provenance(self.components.keys(), &self.metadata.name);
+        let override_report =
+            apply_property_overrides(&mut components, overrides, &mut component_provenance);
 
-        for override_ in overrides {
-            let parts: Vec<&str> = override_.path.split('.').collect();
-            if parts.len() < 2 {
-                override_report.ignored.push(IgnoredPropertyOverride {
-                    path: override_.path.clone(),
-                    reason: "override path must include a component name and property path"
-                        .to_string(),
-                });
-                continue;
-            }
-
-            let component_name = parts[0];
-            if let Some(component) = components.get_mut(component_name) {
-                let previous_value = get_component_path_value(component, &parts[1..]).cloned();
-                match set_component_path_value(component, &parts[1..], &override_.value) {
-                    Ok(()) => override_report.applied.push(AppliedPropertyOverride {
-                        path: override_.path.clone(),
-                        previous_value,
-                        value: override_.value.clone(),
-                    }),
-                    Err(reason) => override_report.ignored.push(IgnoredPropertyOverride {
-                        path: override_.path.clone(),
-                        reason,
-                    }),
-                }
-            } else {
-                override_report.ignored.push(IgnoredPropertyOverride {
-                    path: override_.path.clone(),
-                    reason: format!("component '{}' is not present on prefab", component_name),
-                });
-            }
-        }
-
-        ResolvedPrefabComponents {
+        ResolvedPrefabComponentsWithProvenance {
             components,
             override_report,
+            component_provenance,
         }
     }
 
@@ -472,7 +511,9 @@ impl Prefab {
         world: &mut World,
         overrides: &[PropertyOverride],
     ) -> Result<hecs::Entity, String> {
-        let components = self.resolved_components_with_report(overrides).components;
+        let components = self
+            .resolved_components_with_provenance(overrides)
+            .components;
         let entity = world.ecs.spawn(());
         let ignored = insert_bound_components(&components, &mut world.ecs, entity)?;
         for component_name in ignored {
@@ -649,6 +690,72 @@ fn ensure_array_len(array: &mut Vec<serde_json::Value>, len: usize) {
     }
 }
 
+fn build_prefab_definition_provenance<'a>(
+    component_names: impl Iterator<Item = &'a String>,
+    prefab_name: &str,
+) -> HashMap<String, ComponentProvenance> {
+    component_names
+        .map(|component_name| {
+            (
+                component_name.clone(),
+                ComponentProvenance::from_layer(ComponentProvenanceLayer::PrefabDefinition {
+                    prefab: prefab_name.to_string(),
+                }),
+            )
+        })
+        .collect()
+}
+
+fn apply_property_overrides(
+    components: &mut HashMap<String, PrefabComponent>,
+    overrides: &[PropertyOverride],
+    component_provenance: &mut HashMap<String, ComponentProvenance>,
+) -> PropertyOverrideReport {
+    let mut override_report = PropertyOverrideReport::default();
+
+    for override_ in overrides {
+        let parts: Vec<&str> = override_.path.split('.').collect();
+        if parts.len() < 2 {
+            override_report.ignored.push(IgnoredPropertyOverride {
+                path: override_.path.clone(),
+                reason: "override path must include a component name and property path".to_string(),
+            });
+            continue;
+        }
+
+        let component_name = parts[0];
+        if let Some(component) = components.get_mut(component_name) {
+            let previous_value = get_component_path_value(component, &parts[1..]).cloned();
+            match set_component_path_value(component, &parts[1..], &override_.value) {
+                Ok(()) => {
+                    override_report.applied.push(AppliedPropertyOverride {
+                        path: override_.path.clone(),
+                        previous_value,
+                        value: override_.value.clone(),
+                    });
+                    component_provenance
+                        .entry(component_name.to_string())
+                        .or_default()
+                        .push(ComponentProvenanceLayer::PropertyOverride {
+                            path: override_.path.clone(),
+                        });
+                }
+                Err(reason) => override_report.ignored.push(IgnoredPropertyOverride {
+                    path: override_.path.clone(),
+                    reason,
+                }),
+            }
+        } else {
+            override_report.ignored.push(IgnoredPropertyOverride {
+                path: override_.path.clone(),
+                reason: format!("component '{}' is not present on prefab", component_name),
+            });
+        }
+    }
+
+    override_report
+}
+
 /// Global registry of named prefabs
 pub struct PrefabRegistry {
     prefabs: HashMap<String, Prefab>,
@@ -697,6 +804,25 @@ impl PrefabRegistry {
         self.resolve_prefab_internal(name, &mut visiting)
     }
 
+    pub fn resolve_components_with_provenance(
+        &self,
+        name: &str,
+        overrides: &[PropertyOverride],
+    ) -> Result<ResolvedPrefabComponentsWithProvenance, String> {
+        let mut visiting = Vec::new();
+        let (prefab, mut component_provenance) =
+            self.resolve_prefab_internal_with_provenance(name, &mut visiting)?;
+        let mut components = prefab.components.clone();
+        let override_report =
+            apply_property_overrides(&mut components, overrides, &mut component_provenance);
+
+        Ok(ResolvedPrefabComponentsWithProvenance {
+            components,
+            override_report,
+            component_provenance,
+        })
+    }
+
     fn resolve_prefab_internal(
         &self,
         name: &str,
@@ -743,6 +869,65 @@ impl PrefabRegistry {
         resolved.base_prefab = prefab.base_prefab.clone();
         resolved.id = prefab.id;
         Ok(resolved)
+    }
+
+    fn resolve_prefab_internal_with_provenance(
+        &self,
+        name: &str,
+        visiting: &mut Vec<String>,
+    ) -> Result<(Prefab, HashMap<String, ComponentProvenance>), String> {
+        if visiting.iter().any(|current| current == name) {
+            visiting.push(name.to_string());
+            return Err(format!(
+                "Prefab inheritance cycle detected: {}",
+                visiting.join(" -> ")
+            ));
+        }
+
+        let prefab = self
+            .prefabs
+            .get(name)
+            .ok_or_else(|| format!("Prefab '{}' not found", name))?;
+
+        visiting.push(name.to_string());
+
+        let (mut resolved, component_provenance) = if let Some(base_name) = &prefab.base_prefab {
+            let (mut base_prefab, mut base_provenance) =
+                self.resolve_prefab_internal_with_provenance(base_name, visiting)?;
+            base_prefab.metadata = prefab.metadata.clone();
+            base_prefab.base_prefab = prefab.base_prefab.clone();
+
+            for (component_name, component) in &prefab.components {
+                base_prefab
+                    .components
+                    .insert(component_name.clone(), component.clone());
+                base_provenance
+                    .entry(component_name.clone())
+                    .or_default()
+                    .push(ComponentProvenanceLayer::PrefabDefinition {
+                        prefab: name.to_string(),
+                    });
+            }
+            for nested in &prefab.nested_prefabs {
+                if !base_prefab.nested_prefabs.contains(nested) {
+                    base_prefab.nested_prefabs.push(nested.clone());
+                }
+            }
+
+            (base_prefab, base_provenance)
+        } else {
+            (
+                prefab.clone(),
+                build_prefab_definition_provenance(prefab.components.keys(), name),
+            )
+        };
+
+        visiting.pop();
+
+        resolved.metadata = prefab.metadata.clone();
+        resolved.base_prefab = prefab.base_prefab.clone();
+        resolved.id = prefab.id;
+        Ok((resolved, component_provenance))
     }
 
     /// Get a mutable reference to a prefab
@@ -1112,6 +1297,72 @@ mod tests {
 
         assert_eq!(transform.position, Vec3::new(6.0, 7.0, 8.0));
         assert_eq!(mesh.asset_id, "tower");
+    }
+
+    #[test]
+    fn test_prefab_registry_tracks_component_provenance_across_inheritance_and_overrides() {
+        let mut registry = PrefabRegistry::new();
+
+        let mut base = Prefab::new("BaseActor");
+        base.add_native_component(&Transform::at(1.0, 2.0)).unwrap();
+        base.add_native_component(&Sprite {
+            texture: "base".to_string(),
+            layer: 1,
+            ..Default::default()
+        })
+        .unwrap();
+        registry.register("BaseActor", base);
+
+        let mut derived = Prefab::new("MageActor").with_base_prefab("BaseActor");
+        derived
+            .add_native_component(&Sprite {
+                texture: "mage".to_string(),
+                layer: 4,
+                ..Default::default()
+            })
+            .unwrap();
+        derived
+            .add_native_component(&Mesh {
+                asset_id: "staff".to_string(),
+                layer: 7,
+                ..Default::default()
+            })
+            .unwrap();
+        registry.register("MageActor", derived);
+
+        let resolved = registry
+            .resolve_components_with_provenance(
+                "MageActor",
+                &[PropertyOverride::new("Sprite.layer", serde_json::json!(9))],
+            )
+            .expect("resolved prefab components should be available");
+
+        assert_eq!(
+            resolved.component_provenance["Transform"].layers,
+            vec![ComponentProvenanceLayer::PrefabDefinition {
+                prefab: "BaseActor".to_string()
+            }]
+        );
+        assert_eq!(
+            resolved.component_provenance["Sprite"].layers,
+            vec![
+                ComponentProvenanceLayer::PrefabDefinition {
+                    prefab: "BaseActor".to_string()
+                },
+                ComponentProvenanceLayer::PrefabDefinition {
+                    prefab: "MageActor".to_string()
+                },
+                ComponentProvenanceLayer::PropertyOverride {
+                    path: "Sprite.layer".to_string()
+                },
+            ]
+        );
+        assert_eq!(
+            resolved.component_provenance["Mesh"].layers,
+            vec![ComponentProvenanceLayer::PrefabDefinition {
+                prefab: "MageActor".to_string()
+            }]
+        );
     }
 
     #[test]

--- a/crates/pod-scene/src/scene.rs
+++ b/crates/pod-scene/src/scene.rs
@@ -6,8 +6,8 @@ use uuid::Uuid;
 
 use crate::binding::{insert_bound_components, NativeComponentBinding};
 use crate::prefab::{
-    set_component_path_value, PrefabComponent, PrefabRegistry, PropertyOverride,
-    PropertyOverrideReport,
+    set_component_path_value, ComponentProvenance, ComponentProvenanceLayer, PrefabComponent,
+    PrefabRegistry, PropertyOverride, PropertyOverrideReport,
 };
 
 /// Represents a spawn point in a scene
@@ -370,6 +370,7 @@ pub struct SceneSpawnResult {
     pub entity_map: HashMap<Uuid, Entity>,
     pub ignored_components: Vec<String>,
     pub prefab_override_reports: HashMap<Uuid, PropertyOverrideReport>,
+    pub component_provenance: HashMap<Uuid, HashMap<String, ComponentProvenance>>,
 }
 
 impl SceneSpawnResult {
@@ -383,6 +384,20 @@ impl SceneSpawnResult {
     ) -> Option<&PropertyOverrideReport> {
         self.prefab_override_reports.get(&scene_entity_id)
     }
+
+    pub fn component_provenance_for(
+        &self,
+        scene_entity_id: Uuid,
+    ) -> Option<&HashMap<String, ComponentProvenance>> {
+        self.component_provenance.get(&scene_entity_id)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ResolvedEntityComponents {
+    components: HashMap<String, PrefabComponent>,
+    override_report: PropertyOverrideReport,
+    component_provenance: HashMap<String, ComponentProvenance>,
 }
 
 /// Complete scene representation
@@ -565,6 +580,7 @@ impl Scene {
         let mut entity_map = HashMap::new();
         let entity_name_lookup = self.build_entity_name_lookup();
         let mut prefab_override_reports = HashMap::new();
+        let mut component_provenance = HashMap::new();
 
         let scene_entities: Vec<&EntityInstance> = self
             .entities
@@ -588,19 +604,22 @@ impl Scene {
                 .copied()
                 .ok_or_else(|| format!("Scene entity '{}' was not pre-spawned", entity.name))?;
 
-            let (mut resolved_components, override_report) =
-                self.resolve_entity_components(entity, prefabs)?;
+            let mut resolved = self.resolve_entity_components(entity, prefabs)?;
             self.apply_entity_references(
                 entity,
-                &mut resolved_components,
+                &mut resolved.components,
+                &mut resolved.component_provenance,
                 &entity_map,
                 &entity_name_lookup,
             )?;
-            if !override_report.is_empty() {
-                prefab_override_reports.insert(entity.id, override_report);
+            if !resolved.override_report.is_empty() {
+                prefab_override_reports.insert(entity.id, resolved.override_report.clone());
+            }
+            if !resolved.component_provenance.is_empty() {
+                component_provenance.insert(entity.id, resolved.component_provenance.clone());
             }
             let ignored =
-                insert_bound_components(&resolved_components, &mut world.ecs, spawned_entity)?;
+                insert_bound_components(&resolved.components, &mut world.ecs, spawned_entity)?;
             ignored_components.extend(
                 ignored
                     .into_iter()
@@ -616,6 +635,7 @@ impl Scene {
             entity_map,
             ignored_components,
             prefab_override_reports,
+            component_provenance,
         })
     }
 
@@ -623,8 +643,8 @@ impl Scene {
         &self,
         entity: &EntityInstance,
         prefabs: Option<&PrefabRegistry>,
-    ) -> Result<(HashMap<String, PrefabComponent>, PropertyOverrideReport), String> {
-        let (mut components, override_report) = match entity.prefab_ref.as_deref() {
+    ) -> Result<ResolvedEntityComponents, String> {
+        let mut resolved = match entity.prefab_ref.as_deref() {
             Some(prefab_name) => {
                 let registry = prefabs.ok_or_else(|| {
                     format!(
@@ -632,9 +652,13 @@ impl Scene {
                         self.metadata.name, prefab_name
                     )
                 })?;
-                let prefab = registry.resolve_prefab(prefab_name)?;
-                let resolved = prefab.resolved_components_with_report(&entity.prefab_overrides);
-                (resolved.components, resolved.override_report)
+                let resolved = registry
+                    .resolve_components_with_provenance(prefab_name, &entity.prefab_overrides)?;
+                ResolvedEntityComponents {
+                    components: resolved.components,
+                    override_report: resolved.override_report,
+                    component_provenance: resolved.component_provenance,
+                }
             }
             None => {
                 if !entity.prefab_overrides.is_empty() {
@@ -643,15 +667,27 @@ impl Scene {
                         entity.name
                     ));
                 }
-                (HashMap::new(), PropertyOverrideReport::default())
+                ResolvedEntityComponents {
+                    components: HashMap::new(),
+                    override_report: PropertyOverrideReport::default(),
+                    component_provenance: HashMap::new(),
+                }
             }
         };
 
         for (name, component) in &entity.components {
-            components.insert(name.clone(), component.clone());
+            resolved.components.insert(name.clone(), component.clone());
+            resolved
+                .component_provenance
+                .entry(name.clone())
+                .or_default()
+                .push(ComponentProvenanceLayer::SceneComponent {
+                    entity_id: entity.id,
+                    entity_name: entity.name.clone(),
+                });
         }
 
-        Ok((components, override_report))
+        Ok(resolved)
     }
 
     fn build_entity_name_lookup(&self) -> HashMap<String, Vec<Uuid>> {
@@ -746,6 +782,7 @@ impl Scene {
         &self,
         entity: &EntityInstance,
         components: &mut HashMap<String, PrefabComponent>,
+        component_provenance: &mut HashMap<String, ComponentProvenance>,
         entity_map: &HashMap<Uuid, Entity>,
         entity_name_lookup: &HashMap<String, Vec<Uuid>>,
     ) -> Result<(), String> {
@@ -781,6 +818,13 @@ impl Scene {
                         reference.component, reference.path, entity.name, self.metadata.name, err
                     )
                 })?;
+            component_provenance
+                .entry(reference.component.clone())
+                .or_default()
+                .push(ComponentProvenanceLayer::EntityReference {
+                    path: format!("{}.{}", reference.component, reference.path),
+                    target: reference.target.describe(),
+                });
         }
 
         Ok(())
@@ -1467,6 +1511,118 @@ mod tests {
             .expect("override report should still be stored");
         assert_eq!(report.applied.len(), 1);
         assert_eq!(report.applied[0].value, serde_json::json!(9));
+    }
+
+    #[test]
+    fn test_scene_instantiation_tracks_component_provenance_across_prefab_and_scene_layers() {
+        let mut registry = PrefabRegistry::new();
+
+        let mut base = Prefab::new("BaseActor");
+        base.add_native_component(&Transform::at(1.0, 2.0)).unwrap();
+        base.add_native_component(&Sprite {
+            texture: "base".to_string(),
+            layer: 2,
+            ..Default::default()
+        })
+        .unwrap();
+        registry.register("BaseActor", base);
+
+        let mut derived = Prefab::new("DerivedActor").with_base_prefab("BaseActor");
+        derived
+            .add_native_component(&Sprite {
+                texture: "derived".to_string(),
+                layer: 4,
+                ..Default::default()
+            })
+            .unwrap();
+        registry.register("DerivedActor", derived);
+
+        let mut scene = Scene::new("ProvenanceScene");
+        let mut actor = EntityInstance::new("ActorInstance").with_prefab("DerivedActor");
+        actor.add_prefab_override(PropertyOverride::new("Sprite.layer", serde_json::json!(9)));
+        actor
+            .add_native_component(&Sprite {
+                texture: "scene_local".to_string(),
+                layer: 14,
+                ..Default::default()
+            })
+            .unwrap();
+        let actor_id = scene.add_entity(actor);
+
+        let mut world = World::new(15);
+        let result = scene
+            .instantiate_with_prefabs(&mut world, Some(&registry))
+            .unwrap();
+
+        let provenance = result
+            .component_provenance_for(actor_id)
+            .expect("component provenance should be stored");
+        assert_eq!(
+            provenance["Transform"].layers,
+            vec![ComponentProvenanceLayer::PrefabDefinition {
+                prefab: "BaseActor".to_string()
+            }]
+        );
+        assert_eq!(
+            provenance["Sprite"].layers,
+            vec![
+                ComponentProvenanceLayer::PrefabDefinition {
+                    prefab: "BaseActor".to_string()
+                },
+                ComponentProvenanceLayer::PrefabDefinition {
+                    prefab: "DerivedActor".to_string()
+                },
+                ComponentProvenanceLayer::PropertyOverride {
+                    path: "Sprite.layer".to_string()
+                },
+                ComponentProvenanceLayer::SceneComponent {
+                    entity_id: actor_id,
+                    entity_name: "ActorInstance".to_string()
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_scene_instantiation_tracks_entity_reference_provenance() {
+        let mut scene = Scene::new("EntityReferenceProvenanceScene");
+
+        let mut player = EntityInstance::new("Player");
+        player
+            .add_native_component(&Transform3D {
+                position: Vec3::new(4.0, 0.0, 2.0),
+                ..Default::default()
+            })
+            .unwrap();
+        let player_id = scene.add_entity(player);
+
+        let mut camera = EntityInstance::new("Camera");
+        camera.add_native_component(&Camera3D::default()).unwrap();
+        camera
+            .add_native_component(&FollowCameraController::default())
+            .unwrap();
+        camera.add_entity_reference_by_id("FollowCameraController", "target", player_id);
+        let camera_id = scene.add_entity(camera);
+
+        let mut world = World::new(16);
+        let result = scene.instantiate(&mut world).unwrap();
+
+        let provenance = result
+            .component_provenance_for(camera_id)
+            .expect("camera provenance should be recorded");
+        assert_eq!(
+            provenance["FollowCameraController"].layers,
+            vec![
+                ComponentProvenanceLayer::SceneComponent {
+                    entity_id: camera_id,
+                    entity_name: "Camera".to_string()
+                },
+                ComponentProvenanceLayer::EntityReference {
+                    path: "FollowCameraController.target".to_string(),
+                    target: format!("scene entity id {}", player_id),
+                },
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add provenance-aware prefab component resolution across inheritance and property overrides
- surface per-entity component provenance in scene spawn results, including scene-local overrides and entity-reference bindings
- add deterministic prefab and scene tests for provenance reporting and update the implementation plan

## Validation
- cargo check -p pod-scene
- cargo test -p pod-scene --lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added component provenance tracking that records the origin of each component through prefabs, overrides, and scene components.
  * Scene spawn results now include component provenance data per entity, with accessor methods for querying provenance information.

* **Tests**
  * Added tests validating component provenance across prefab inheritance and scene instantiation layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->