### PR TITLE
[codex] add browser render compatibility checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,24 @@ jobs:
 
       - name: Cargo clippy
         run: cargo clippy --workspace -- -D warnings
+
+  browser-render:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Pod Render browser bridge tests
+        run: cargo test -p pod-render --lib
+
+      - name: Pod Render wasm compatibility check
+        run: cargo check -p pod-render --target wasm32-unknown-unknown

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1783,10 +1783,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3742,6 +3744,8 @@ name = "pod-core"
 version = "0.1.0"
 dependencies = [
  "bincode",
+ "getrandom 0.2.17",
+ "getrandom 0.4.1",
  "glam",
  "hecs",
  "log",
@@ -3819,6 +3823,7 @@ dependencies = [
  "glam",
  "gltf",
  "hecs",
+ "js-sys",
  "log",
  "pod-core",
  "pollster",
@@ -3841,6 +3846,7 @@ dependencies = [
  "pod-core",
  "serde",
  "serde_json",
+ "tempfile",
  "uuid",
 ]
 
@@ -5489,7 +5495,17 @@ dependencies = [
  "getrandom 0.4.1",
  "js-sys",
  "serde_core",
+ "uuid-rng-internal",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "uuid-rng-internal"
+version = "1.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b76dc0e3c64be846ad2fd1378656e7de2120530d1e83d8f20ca6a0cdba01de"
+dependencies = [
+ "getrandom 0.4.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ serde_json = "1.0"
 bincode = "1.3"
 rand = "0.8"
 rand_chacha = "0.3"
+getrandom = { version = "0.2", features = ["js"] }
 
 # Physics
 rapier2d = { version = "0.22", features = ["simd-stable"] }
@@ -50,7 +51,7 @@ sha2 = "0.10"
 tokio = { version = "1", features = ["full"] }
 
 # IDs
-uuid = { version = "1", features = ["v4", "serde"] }
+uuid = { version = "1", features = ["v4", "serde", "rng-getrandom"] }
 
 # Scripting
 mlua = { version = "0.10", features = ["lua54", "vendored", "serialize"] }

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -145,7 +145,7 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
 - [x] 7.12 Resolve 2.5D edge-case matrix (cycle-safe parenting, mixed-layer ordering, parented projection fallback)
 - [x] 7.13 Finalize mixed-mode API contract (`RenderItem`, `DrawType`, depth key rules) and add docs
 - [x] 7.14 Add scene-level transform provenance metadata for editor debugging
-- [ ] 7.15 Add browser render compatibility checks in CI (headless wgpu + feature checks)
+- [x] 7.15 Add browser render compatibility checks in CI (headless wgpu + feature checks)
 - [ ] 7.16 Draft public platform docs: architecture, plugin model, agent integration contract
 
 ## Phase 8: Shipping Parity
@@ -257,5 +257,15 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cargo check -p pod-scene`
   - `cargo test -p pod-scene --lib`
 
-**Last updated**: Iteration 35
-**Current focus**: Phase 7.5 scene-system parity and Phase 9 hardening backlog
+### Iteration 36 — Browser Render Compatibility CI Pass
+
+- [x] Added a dedicated GitHub Actions browser-render job that installs `wasm32-unknown-unknown`, runs `pod-render` library tests, and checks `pod-render` against the wasm target.
+- [x] Added a headless `wgpu` adapter/device smoke test so CI exercises a real native render backend path without needing a window server.
+- [x] Fixed wasm browser compatibility in the render dependency graph by enabling `getrandom`'s JS path for `pod-core` on `wasm32`, unblocking `rand`/`rand_chacha` usage during browser builds.
+- [x] Exposed the web render bridge during native test builds and added mixed-mode bridge tests so browser serialization for 2D, 2.5D, and 3D render items is exercised in CI.
+- [x] Validated touched targets:
+  - `cargo test -p pod-render --lib`
+  - `cargo check -p pod-render --target wasm32-unknown-unknown`
+
+**Last updated**: Iteration 36
+**Current focus**: Phase 7.16 platform docs and Phase 9 hardening backlog

--- a/crates/pod-core/Cargo.toml
+++ b/crates/pod-core/Cargo.toml
@@ -16,3 +16,7 @@ rand.workspace = true
 rand_chacha.workspace = true
 log.workspace = true
 uuid.workspace = true
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom.workspace = true
+getrandom_04 = { package = "getrandom", version = "0.4", features = ["wasm_js"] }

--- a/crates/pod-render/Cargo.toml
+++ b/crates/pod-render/Cargo.toml
@@ -20,7 +20,8 @@ pollster = "0.3"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"
-web-sys = "0.3"
+js-sys = "0.3"
+web-sys = { version = "0.3", features = ["Window"] }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/pod-render/src/lib.rs
+++ b/crates/pod-render/src/lib.rs
@@ -9,20 +9,20 @@
 #![allow(clippy::should_implement_trait)]
 #![allow(clippy::unnecessary_cast)]
 
-pub mod renderer;
 pub mod camera;
 pub mod color;
 pub mod gltf_import;
+pub mod renderer;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub mod native;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(any(target_arch = "wasm32", test))]
 pub mod web;
 
 pub use camera::Camera;
 pub use color::Color;
-pub use renderer::{RenderState, RenderItem, DrawType};
+pub use renderer::{DrawType, RenderItem, RenderState};
 
 /// Configuration for window creation
 #[derive(Debug, Clone)]

--- a/crates/pod-render/src/native.rs
+++ b/crates/pod-render/src/native.rs
@@ -1129,3 +1129,38 @@ impl ApplicationHandler for RenderApp {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn headless_wgpu_device_is_available_for_ci() {
+        pollster::block_on(async {
+            let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+                backends: wgpu::Backends::all(),
+                ..Default::default()
+            });
+
+            let adapter = instance
+                .request_adapter(&wgpu::RequestAdapterOptions {
+                    power_preference: wgpu::PowerPreference::LowPower,
+                    compatible_surface: None,
+                    force_fallback_adapter: false,
+                })
+                .await
+                .expect("headless CI should expose a wgpu adapter");
+
+            let info = adapter.get_info();
+            let (device, queue) = adapter
+                .request_device(&wgpu::DeviceDescriptor::default(), None)
+                .await
+                .expect("headless adapter should create a wgpu device");
+
+            assert!(
+                !info.name.trim().is_empty(),
+                "wgpu adapter should report a backend name"
+            );
+            drop(queue);
+            drop(device);
+        });
+    }
+}

--- a/crates/pod-render/src/web.rs
+++ b/crates/pod-render/src/web.rs
@@ -1,8 +1,8 @@
 //! Web renderer bridge for browser platforms
 //! Serializes render state to JSON for PixiJS consumption on JS side
 
-use crate::renderer::{RenderState, DrawType};
 use crate::camera::Camera;
+use crate::renderer::{DrawType, RenderState};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
@@ -102,6 +102,9 @@ impl WebRenderBridge {
                     alpha: color[3],
                     texture: None,
                     frame: None,
+                    mesh: None,
+                    material: None,
+                    z: None,
                     layer: item.layer,
                     visible: item.visible,
                     source_entity: item.source_entity,
@@ -343,11 +346,7 @@ impl WebRenderBridge {
     }
 
     /// Render a frame (posts to JavaScript)
-    pub fn render(
-        state: &RenderState,
-        camera: &Camera,
-        background_color: [f32; 4],
-    ) {
+    pub fn render(state: &RenderState, camera: &Camera, background_color: [f32; 4]) {
         let json_str = Self::to_render_json(state, camera, background_color);
         Self::post_to_js("render", &json_str);
     }
@@ -356,9 +355,10 @@ impl WebRenderBridge {
     fn post_to_js(method: &str, data: &str) {
         #[cfg(target_arch = "wasm32")]
         {
+            use js_sys::eval;
             use web_sys::window;
-            if let Some(window) = window() {
-                let _ = window.eval(&format!(
+            if window().is_some() {
+                let _ = eval(&format!(
                     "if (window.podRender) {{ window.podRender.{}('{}'); }}",
                     method,
                     data.replace("'", "\\'")
@@ -398,7 +398,7 @@ pub mod js_bridge {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::renderer::{RenderItem, DrawType};
+    use crate::renderer::{DrawType, RenderItem, RenderTransform3D};
     use glam::Vec2;
 
     #[test]
@@ -421,7 +421,7 @@ mod tests {
         let camera = Camera::new(Vec2::ZERO, 1280.0, 720.0);
         let json = WebRenderBridge::to_render_json(&state, &camera, [0.1, 0.1, 0.1, 1.0]);
 
-        assert!(json.contains("\"type\":\"rect\""));
+        assert!(json.contains("\"item_type\":\"rect\""));
         assert!(json.contains("\"x\":100"));
         assert!(json.contains("\"y\":200"));
         assert!(json.contains("\"source_entity\":101"));
@@ -483,5 +483,75 @@ mod tests {
         assert_eq!(value["commands"][0]["texture"], "npc_sprite");
         assert!(value["commands"][0]["visible"].as_bool().unwrap_or(false));
         assert_eq!(value["commands"][0]["source_entity"], 303);
+    }
+
+    #[test]
+    fn test_render_frame_tracks_mixed_mode_items_for_browser_bridge() {
+        let mut state = RenderState::new();
+        state.add_item(RenderItem {
+            position: Vec2::new(8.0, 16.0),
+            rotation: 0.25,
+            scale: Vec2::new(1.0, 2.0),
+            layer: 1,
+            draw_type: DrawType::Sprite {
+                texture: "hero".to_string(),
+                frame: 2,
+                tint: [1.0, 1.0, 1.0, 0.9],
+            },
+            visible: true,
+            source_entity: Some(11),
+        });
+        state.add_item(RenderItem {
+            position: Vec2::ZERO,
+            rotation: 0.0,
+            scale: Vec2::ONE,
+            layer: 2,
+            draw_type: DrawType::Sprite3D {
+                texture: "tree_card".to_string(),
+                frame: 0,
+                tint: [0.3, 0.8, 0.2, 1.0],
+                transform: RenderTransform3D {
+                    position: [1.0, 2.0, 5.0],
+                    rotation: [0.0, 0.0, 0.0, 1.0],
+                    scale: [1.5, 2.5, 1.0],
+                },
+                billboard: true,
+            },
+            visible: true,
+            source_entity: Some(22),
+        });
+        state.add_item(RenderItem {
+            position: Vec2::ZERO,
+            rotation: 0.0,
+            scale: Vec2::ONE,
+            layer: 3,
+            draw_type: DrawType::Mesh3D {
+                mesh: "tower".to_string(),
+                material: "stone".to_string(),
+                transform: RenderTransform3D {
+                    position: [4.0, 0.5, 9.0],
+                    rotation: [0.0, 0.0, 0.0, 1.0],
+                    scale: [2.0, 3.0, 2.0],
+                },
+                cast_shadows: true,
+                receive_shadows: true,
+            },
+            visible: true,
+            source_entity: Some(33),
+        });
+
+        let camera = Camera::new(Vec2::new(32.0, 48.0), 1920.0, 1080.0);
+        let value = WebRenderBridge::to_render_value(&state, &camera, [0.1, 0.2, 0.3, 1.0]);
+
+        assert_eq!(value["camera"]["viewportWidth"], 1920.0);
+        assert_eq!(value["commands"][0]["type"], "sprite");
+        assert_eq!(value["commands"][0]["source_entity"], 11);
+        assert_eq!(value["commands"][1]["type"], "sprite3d");
+        assert_eq!(value["commands"][1]["z"], 5.0);
+        assert_eq!(value["commands"][1]["source_entity"], 22);
+        assert_eq!(value["commands"][2]["type"], "mesh3d");
+        assert_eq!(value["commands"][2]["mesh"], "tower");
+        assert_eq!(value["commands"][2]["material"], "stone");
+        assert_eq!(value["commands"][2]["source_entity"], 33);
     }
 }


### PR DESCRIPTION
## Summary
This PR closes the Phase 7 immediate browser-render CI gap by adding a dedicated GitHub Actions job for `pod-render`, hardening the dependency graph for wasm browser builds, and extending render-side coverage so both the browser bridge and a headless native `wgpu` path are exercised in CI.

Before this change, `pod-render` could serialize mixed 2D/2.5D/3D render state locally, but the workspace did not continuously verify that code against a browser target. The wasm target failed because the RNG path used by `rand` and `uuid` was not configured for JS-backed entropy, and the web bridge code contained compile-time drift that native unit tests never compiled. That left a real regression window for browser-facing game projects.

The fix adds a `browser-render` CI job that installs `wasm32-unknown-unknown`, runs `cargo test -p pod-render --lib`, and checks `pod-render` for the wasm target. On the code side, it enables the wasm-safe `getrandom`/`uuid` configuration required by `pod-core`, exposes the web bridge during native test builds, fixes stale web bridge serialization assumptions, and adds coverage for mixed-mode browser output plus a headless `wgpu` adapter/device smoke test.

## Validation
- `cargo test -p pod-render --lib`
- `cargo check -p pod-render --target wasm32-unknown-unknown`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended render commands with optional mesh, material, and z-position fields for richer 3D content serialization.
  * Improved browser rendering with WASM compatibility and targeted runtime checks.

* **Tests**
  * Added comprehensive CI pipeline for browser rendering validation and headless GPU testing.
  * Expanded browser rendering tests to cover mixed-item types and 3D content.

* **Chores**
  * Updated dependencies (getrandom, uuid, web-sys) to support WASM browser environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->