### PR TITLE
[codex] add public platform docs

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -146,7 +146,7 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
 - [x] 7.13 Finalize mixed-mode API contract (`RenderItem`, `DrawType`, depth key rules) and add docs
 - [x] 7.14 Add scene-level transform provenance metadata for editor debugging
 - [x] 7.15 Add browser render compatibility checks in CI (headless wgpu + feature checks)
-- [ ] 7.16 Draft public platform docs: architecture, plugin model, agent integration contract
+- [x] 7.16 Draft public platform docs: architecture, plugin model, agent integration contract
 
 ## Phase 8: Shipping Parity
 - [ ] 8.1 Create importers and authoring workflows for major Unity/Godot style assets
@@ -267,5 +267,14 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cargo test -p pod-render --lib`
   - `cargo check -p pod-render --target wasm32-unknown-unknown`
 
-**Last updated**: Iteration 36
-**Current focus**: Phase 7.16 platform docs and Phase 9 hardening backlog
+### Iteration 37 — Public Platform Docs Draft
+
+- [x] Added a public `README.md` that explains the project, workspace layout, and entry-point documentation for external readers.
+- [x] Added `docs/architecture.md` describing the current crate boundaries, data flow, runtime authority model, and subsystem responsibilities.
+- [x] Added `docs/plugin-model.md` documenting the extension surfaces that exist today and clearly separating them from the still-unfinished formal plugin lifecycle work.
+- [x] Added `docs/agent-integration-contract.md` defining the shared agent pipeline, trait contract, transport invariants, and integration rules for human and AI controllers.
+- [x] Validated touched files:
+  - `git diff --check`
+
+**Last updated**: Iteration 37
+**Current focus**: Phase 8 shipping parity and Phase 9 hardening backlog

--- a/README.md
+++ b/README.md
@@ -1,0 +1,57 @@
+# Prompt or Die
+
+Prompt or Die is an open-source game platform for building games where autonomous AI agents and human players are first-class participants in the same world. The runtime is written in Rust, uses a deterministic ECS core, supports native and browser clients, and is being extended toward a full 2D, 2.5D, and 3D authoring stack.
+
+## What exists today
+
+- Deterministic ECS runtime in `pod-core` with a shared agent pipeline: Observe -> Decide -> Validate -> Execute -> Broadcast
+- Native and browser rendering surfaces in `pod-render`, including mixed 2D/2.5D/3D frame extraction
+- Scene, prefab, save/load, and state-stack authoring in `pod-scene`
+- Dedicated editor shell in `pod-editor`
+- Direct-connect networking plus SpacetimeDB integration in `pod-net` and `pod-stdb`
+- Asset processing, animation, scripting, spatial queries, and physics support across the workspace
+
+## Quick start
+
+```bash
+cargo build --workspace
+cargo run --bin prompt-or-die
+cargo run --bin pod-server
+cargo test --workspace
+cargo check --workspace
+```
+
+## Workspace map
+
+```text
+crates/
+  pod-core       Deterministic ECS world, tick loop, agent contract, actions, observations, events
+  pod-render     Native wgpu renderer and browser bridge
+  pod-scene      Scenes, prefabs, save/load, typed bindings, streaming
+  pod-net        QUIC/WebSocket transport and SpacetimeDB-aware clients
+  pod-stdb       SpacetimeDB tables, reducers, events, and client wrapper
+  pod-agents     LLM, neural, scripted, and hybrid agent implementations
+  pod-editor     Visual editor shell and authoring panels
+  pod-assets     Asset import, processing, caching, and procedural generation
+  pod-animation  Keyframes, tweening, blending, and state machines
+  pod-physics    Physics integration
+  pod-spatial    Pathfinding, raycasts, and spatial queries
+  pod-scripting  Lua scripting API and sandbox
+apps/
+  pod-desktop    Desktop runtime and local simulation entry point
+  pod-server     Dedicated authoritative server
+specs/
+  Product and subsystem requirements
+docs/
+  Public architecture and integration guides
+```
+
+## Platform docs
+
+- [Architecture Overview](docs/architecture.md)
+- [Plugin Model](docs/plugin-model.md)
+- [Agent Integration Contract](docs/agent-integration-contract.md)
+
+## Current status
+
+The project has completed its deterministic core, networking, rendering baseline, editor scaffold, and scene-system foundations. The next major layers are public platform hardening, import/shipping workflows, and a formal plugin lifecycle.

--- a/docs/agent-integration-contract.md
+++ b/docs/agent-integration-contract.md
@@ -1,0 +1,181 @@
+# Agent Integration Contract
+
+This document defines how an agent integrates with Prompt or Die. It is the main contract for human control, scripted NPCs, LLM agents, neural policies, and system automation.
+
+## Core invariant
+
+Every agent type goes through the same authoritative pipeline:
+
+```text
+Observe -> Decide -> Validate -> Execute -> Broadcast
+```
+
+No agent type gets privileged access to world mutation. Agents do not directly change the world. They emit `Action` values, and the runtime decides what is valid.
+
+## Runtime contract
+
+The core trait lives in `pod-core`:
+
+```rust
+pub trait Agent: Send {
+    fn id(&self) -> AgentId;
+    fn agent_type(&self) -> AgentType;
+    fn observe(&mut self, observation: Observation);
+    fn decide(&mut self) -> Vec<Action>;
+    fn constraints(&self) -> &AgentConstraints;
+    fn constraints_mut(&mut self) -> &mut AgentConstraints;
+
+    fn on_join(&mut self) {}
+    fn on_leave(&mut self) {}
+    fn on_death(&mut self) {}
+    fn on_respawn(&mut self) {}
+    fn on_spawn(&mut self, _entity_id: EntityId) {}
+    fn on_damage(&mut self, _amount: f32, _source: Option<AgentId>) {}
+    fn on_interact(&mut self, _target: EntityId) {}
+    fn introspect(&self) -> AgentIntrospection { /* ... */ }
+}
+```
+
+The minimum implementation surface is:
+
+- accept an `Observation`
+- choose zero or more `Action` values
+- expose constraint settings
+
+Everything else is optional lifecycle and debugging support.
+
+## What an agent receives
+
+Each tick, the runtime builds an `Observation` from authoritative world state. That observation may include:
+
+- self state
+- visible entities
+- heard events or recent world events
+- combat and cooldown state
+- messages and objectives
+
+The observation is already filtered by perception, range, and other gameplay rules before it reaches the agent.
+
+## What an agent may emit
+
+Agents return `Vec<Action>`. Examples include:
+
+- `Move`
+- `Stop`
+- `Rotate`
+- `LookAt`
+- `Attack`
+- `AttackTarget`
+- `Interact`
+- `Speak`
+- `Signal`
+- `UseAbility`
+- `Spawn`
+- `Idle`
+
+These are requests, not guarantees. The runtime validates them against:
+
+- action budget
+- cooldowns
+- reaction gates
+- target availability
+- range and world-state legality
+
+## Tick semantics
+
+The runtime executes this order every tick:
+
+1. Build observations.
+2. Call `observe()` on each connected agent.
+3. Call `decide()` and collect actions.
+4. Validate actions against `AgentConstraints`.
+5. Execute valid actions.
+6. Advance movement/controllers and flush events.
+
+This means:
+
+- `decide()` should be side-effect free with respect to world mutation.
+- Returning no actions is valid.
+- Returning stale actions is tolerated for async agents, but validation still applies.
+
+## Agent categories
+
+### Human agents
+
+Humans integrate through a `HumanAgent` adapter that buffers input and emits standard `Action` values. The runtime treats this exactly like any other agent implementation.
+
+### Scripted agents
+
+Scripted agents are the simplest deterministic integration path. They use observations plus local state to emit actions directly.
+
+### LLM agents
+
+LLM agents should translate observations into prompts and translate model outputs back into `Action` values. They must still obey the same runtime constraints and may return delayed decisions if the model response is asynchronous.
+
+### Neural agents
+
+Neural agents should treat observations as the authoritative sensor input and map them to standard actions or action scores.
+
+### System agents
+
+System agents are allowed as orchestration participants, but they still go through the same validation pipeline if they act through the normal agent path.
+
+## Networking contract
+
+Prompt or Die supports both local and remote agent operation:
+
+- local in-process agents inside the game or server runtime
+- direct-connect transport via `pod-net`
+- SpacetimeDB-backed remote integration via `pod-stdb`
+
+Regardless of transport, the gameplay contract does not change:
+
+- the agent receives an observation-like payload
+- the agent emits standard actions
+- the authoritative runtime validates and applies them
+
+## Determinism and safety rules
+
+Agent authors should follow these rules:
+
+- Do not mutate the ECS world directly from agent code.
+- Do not assume every emitted action will execute.
+- Keep nondeterminism inside the agent implementation, not the world authority path.
+- Treat `Observation` as complete for the current tick; do not rely on hidden state.
+- Use `introspect()` for debugging instead of side-channel state leaks.
+
+If an agent needs memory, planning, prompt templates, model calls, or policy inference, that belongs inside the agent implementation, not in the world execution layer.
+
+## Minimal example
+
+```rust
+use pod_core::{Action, Agent, AgentConstraints, AgentId, AgentType, Observation};
+
+struct SimpleAgent {
+    id: AgentId,
+    constraints: AgentConstraints,
+    last_observation: Option<Observation>,
+}
+
+impl Agent for SimpleAgent {
+    fn id(&self) -> AgentId { self.id }
+    fn agent_type(&self) -> AgentType { AgentType::ScriptedNpc }
+    fn observe(&mut self, observation: Observation) {
+        self.last_observation = Some(observation);
+    }
+    fn decide(&mut self) -> Vec<Action> {
+        vec![Action::Idle]
+    }
+    fn constraints(&self) -> &AgentConstraints { &self.constraints }
+    fn constraints_mut(&mut self) -> &mut AgentConstraints { &mut self.constraints }
+}
+```
+
+## Integration checklist
+
+- Implement `Agent`.
+- Emit only standard `Action` values.
+- Keep world mutation out of agent code.
+- Respect constraint-driven execution.
+- Add tests for observation handling and chosen actions.
+- Use the same path whether the controller is human, scripted, LLM, neural, or remote.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,144 @@
+# Architecture Overview
+
+This document describes the current Prompt or Die platform architecture as it exists in the workspace today. It is intentionally grounded in the current crate layout and runtime behavior rather than the full long-term roadmap.
+
+## Design goals
+
+- One runtime for humans and AI agents
+- Deterministic simulation first
+- Native and browser clients from the same core world model
+- Authoring surfaces for 2D, 2.5D, and 3D games
+- Server-authoritative multiplayer with a path to SpacetimeDB-native worlds
+
+## System map
+
+```mermaid
+flowchart LR
+    A["Game Authoring"] --> B["pod-editor"]
+    A --> C["pod-assets"]
+    A --> D["pod-scene"]
+    D --> E["pod-core World"]
+    B --> E
+    C --> D
+    E --> F["pod-render"]
+    E --> G["pod-net"]
+    E --> H["pod-stdb"]
+    E --> I["pod-scripting"]
+    E --> J["pod-animation / pod-physics / pod-spatial"]
+    F --> K["Native Client"]
+    F --> L["Browser Client"]
+    G --> K
+    G --> L
+    H --> M["SpacetimeDB Runtime"]
+```
+
+## Core runtime
+
+`pod-core` is the authoritative simulation kernel. It defines:
+
+- ECS components and entity state
+- The shared `Agent` trait and agent slots
+- Action validation and constraint enforcement
+- Observation building
+- The tick loop and event bus
+- Deterministic timing constants
+
+The simulation executes in a fixed order every tick:
+
+1. Build observations for connected agents.
+2. Deliver observations and collect decisions.
+3. Validate and execute actions.
+4. Advance movement and controller systems.
+5. Flush events for the next frame or tick.
+
+The key platform invariant is that every agent type uses the same gameplay pipeline. Human, LLM, neural, scripted, and system agents all emit the same `Action` values and are constrained by the same validation path.
+
+## Authoring and world building
+
+`pod-scene` is the authoring-side bridge between serialized game content and the runtime world. It provides:
+
+- Scenes and prefab definitions
+- Native component bindings
+- Prefab inheritance and property overrides
+- Scene-level entity references
+- Region-based scene streaming
+- Save/load and state-stack support
+
+This is the current foundation for world creation across 2D, 2.5D, and 3D content. Scene and prefab data can now instantiate directly into `pod-core::World`, which is the main runtime bridge used by the editor and future asset/import workflows.
+
+`pod-assets` complements this by handling import, caching, and generated content pipelines for textures, meshes, and other runtime assets.
+
+## Rendering
+
+`pod-render` is split into two runtime surfaces:
+
+- Native: `wgpu` + `winit`
+- Browser: Rust frame extraction plus a JavaScript bridge
+
+The renderer supports mixed-mode output:
+
+- 2D primitives and sprites
+- 2.5D sprite-in-3D presentation
+- 3D mesh draw data
+
+The render layer is downstream of the ECS world. It does not own gameplay state. Instead, it extracts render items from world components and serializes them into backend-specific draw data.
+
+## Networking and persistence
+
+Prompt or Die currently supports two multiplayer authority modes:
+
+- Direct-connect transport in `pod-net`
+  - QUIC on native
+  - WebSocket on web
+  - Server-authoritative snapshots and deltas
+- SpacetimeDB integration in `pod-stdb`
+  - Table-backed world state
+  - Reducer-driven game logic
+  - Event tables for transient data
+  - Native client wrapper for subscriptions and reducers
+
+This split allows local or LAN-style play without SpacetimeDB while keeping the platform aligned with large-world, persistent, database-native operation.
+
+## Tooling and editor surfaces
+
+`pod-editor` is the current authoring shell. It already includes the main panel categories needed for an integrated game maker workflow:
+
+- Viewport
+- Hierarchy
+- Inspector
+- Console
+- Asset browser
+- Behavior tree and FSM panels
+- LLM agent configuration
+- SpacetimeDB dashboard
+
+`pod-scripting` extends the platform with a sandboxed Lua surface for content logic and scripted runtime hooks.
+
+## Architectural boundaries
+
+The intended responsibilities are:
+
+- `pod-core`: simulation truth
+- `pod-scene`: world composition and authored content translation
+- `pod-render`: visual extraction and backend bridge
+- `pod-net` / `pod-stdb`: transport and persistent authority
+- `pod-editor`: authoring UX
+- `pod-assets`: import and generation pipeline
+
+New features should extend the nearest existing boundary instead of bypassing it. For example:
+
+- New authored gameplay content should land in scene/prefab bindings, not ad-hoc boot code.
+- New renderable types should translate through `RenderState`, not mutate world logic.
+- New agent types should implement `Agent`, not create a separate decision path.
+
+## What is not complete yet
+
+This architecture is real, but not final. The following platform layers remain explicitly in progress:
+
+- Formal plugin and app lifecycle hooks
+- Full schedule-driven ECS world graph
+- Final import/shipping parity
+- UI runtime parity
+- Public SDK stabilization
+
+Those roadmap items are tracked in `IMPLEMENTATION_PLAN.md`.

--- a/docs/plugin-model.md
+++ b/docs/plugin-model.md
@@ -1,0 +1,118 @@
+# Plugin Model
+
+Prompt or Die does not yet ship a formal Bevy-style `App` / `Plugin` lifecycle. That work is still tracked in the Phase 8 and Phase 9 roadmap. This document defines the plugin model that exists today so integrators can extend the platform without inventing incompatible patterns.
+
+## Current status
+
+Today, "plugin" means extending the platform through stable subsystem seams, not through a single runtime registration API.
+
+The practical extension surfaces are:
+
+- New crates inside the workspace
+- New components and systems in `pod-core`
+- New scene/prefab bindings in `pod-scene`
+- New asset import or processing stages in `pod-assets`
+- New agent implementations in `pod-agents`
+- New scripting functions in `pod-scripting`
+- New editor panels or authoring flows in `pod-editor`
+- New transport or persistence adapters in `pod-net` / `pod-stdb`
+
+## Stability tiers
+
+| Tier | Surface | Guidance |
+| --- | --- | --- |
+| Current platform contract | `Agent` trait, action/observation flow, `pod-scene` bindings, `RenderState`, transport message types | Safe place to integrate against now |
+| Draft contract | Public docs in this directory, scene streaming model, prefab provenance and override reporting | Good integration targets, but still moving |
+| Internal / not yet stabilized | Formal plugin lifecycle, schedule graph, app startup hooks, versioned extension SDK | Do not build hard dependencies on these yet |
+
+## How to extend the platform today
+
+### 1. Gameplay or simulation feature
+
+Use this path when adding a new game mechanic, system, or authored component:
+
+1. Add components or supporting types in the closest runtime crate.
+2. Wire deterministic behavior into the simulation tick or authoritative reducer path.
+3. Add scene/prefab bindings if designers need to author the data.
+4. Add editor inspection support if it must be editable visually.
+5. Add tests at the crate boundary that owns the behavior.
+
+This keeps gameplay state in the world model instead of splitting logic across ad-hoc boot code.
+
+### 2. Rendering extension
+
+Use this path when introducing a new visual representation:
+
+1. Extend world-side render extraction inputs.
+2. Extend `pod-render::renderer::DrawType` or the extraction rules where appropriate.
+3. Ensure both native and browser surfaces degrade or serialize cleanly.
+4. Add tests for the extracted render representation.
+
+The render layer should consume world state, not become a second gameplay state container.
+
+### 3. Authoring extension
+
+Use this path when adding a new designer-facing concept:
+
+1. Define the authored schema in `pod-scene`.
+2. Bind it to native component data.
+3. Support prefab overrides and provenance when the concept is editable.
+4. Expose it in `pod-editor`.
+
+### 4. Agent extension
+
+Use this path when adding a new agent runtime or control surface:
+
+1. Implement the `Agent` trait.
+2. Emit standard `Action` values.
+3. Respect runtime constraints and observation semantics.
+4. Integrate through the same tick path as every other agent type.
+
+This is the most important plugin rule in the repo: no agent type gets special gameplay privileges.
+
+## Recommended crate pattern
+
+For new platform subsystems, prefer a dedicated crate that depends on the existing runtime boundaries rather than modifying many crates at once.
+
+Typical shape:
+
+```text
+crates/pod-your-feature
+  src/lib.rs
+  src/types.rs
+  src/runtime.rs
+  src/tests.rs
+```
+
+The feature crate should then integrate with:
+
+- `pod-core` for runtime data and system hooks
+- `pod-scene` for authored content
+- `pod-editor` for tooling
+- `pod-net` or `pod-stdb` if the feature crosses the network boundary
+
+## What the formal plugin system will add later
+
+The roadmap items for plugin parity still matter. The future formal model is expected to add:
+
+- Startup and shutdown hooks
+- Ordered plugin registration
+- Schedule phase hooks
+- Resource and system registration
+- Versioned extension API boundaries
+
+Those items are already tracked in:
+
+- `8.4 Add plugin/extension ecosystem and versioned SDK API surface`
+- `9.1 Implement plugin and app lifecycle system equivalent to Bevy App/Plugin hooks`
+- `9.2 Implement full schedule-driven ECS world graph`
+
+## Rules for extension authors
+
+- Treat `pod-core` as the simulation authority.
+- Treat `pod-scene` as the authored-content authority.
+- Keep new behavior deterministic unless the boundary explicitly allows otherwise.
+- Do not create agent-specific gameplay bypasses.
+- Prefer additive crate-level integrations over large cross-cutting edits.
+
+Following those rules now will make the eventual formal plugin API easier to adopt when it lands.


### PR DESCRIPTION
## Summary
This PR closes the public documentation task in Phase 7 by adding a real entry point for external readers and documenting the platform shape that already exists in the repo.

Until now, the repo had strong internal guidance in `CLAUDE.md`, specs, and crate-level comments, but it did not have a public-facing architecture guide, plugin model explanation, or explicit agent integration contract. That made the project harder to approach from the outside and also risked future integrations assuming a formal plugin lifecycle that does not exist yet.

The fix adds a root `README.md` plus three public docs: architecture, plugin model, and agent integration contract. The docs are grounded in the current crate boundaries and runtime behavior, and the plugin document explicitly separates current extension seams from the still-unfinished formal plugin/app lifecycle work tracked later in the plan.

## Validation
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive project README with quick start guide and component overview.
  * Added Architecture documentation detailing system design and subsystem boundaries.
  * Added Agent Integration Contract guide with interaction patterns and validation rules.
  * Added Plugin Model guide describing current extension surfaces and future capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->