### PR TITLE
Add phase-aware Three.js WebGPU batches

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -323,5 +323,14 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cargo test -p pod-render --lib`
   - `cargo check -p pod-render --target wasm32-unknown-unknown`
 
-**Last updated**: Iteration 42
+### Iteration 43 — Three.js WebGPU Phase-Aware Material Batching
+
+- [x] Extended `pod-render`'s 3D draw contract to preserve material-surface state (`tint`, `roughness`, `metallic`, `emissive`, `double_sided`) instead of dropping it during render extraction.
+- [x] Updated the Three.js/WebGPU browser bridge to classify 3D mesh and sprite batches as opaque or transparent, expose depth-write guidance, and keep incompatible material variants out of the same instanced batch.
+- [x] Added deterministic tests covering material metadata preservation, opaque vs transparent batch splitting, and the resulting WebGPU phase hints.
+- [x] Validated touched targets:
+  - `cargo test -p pod-render --lib`
+  - `cargo check -p pod-render --target wasm32-unknown-unknown`
+
+**Last updated**: Iteration 43
 **Current focus**: Phase 8 shipping parity and Phase 9 hardening backlog

--- a/crates/pod-render/src/renderer.rs
+++ b/crates/pod-render/src/renderer.rs
@@ -2,8 +2,8 @@
 
 use glam::{Vec2, Vec3};
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
 use std::cmp::Ordering;
+use std::collections::{HashMap, HashSet};
 
 /// Type of drawable entity.
 ///
@@ -37,6 +37,11 @@ pub enum DrawType {
     Mesh3D {
         mesh: String,
         material: String,
+        tint: [f32; 4],
+        roughness: f32,
+        metallic: f32,
+        emissive: [f32; 3],
+        double_sided: bool,
         transform: RenderTransform3D,
         cast_shadows: bool,
         receive_shadows: bool,
@@ -83,9 +88,7 @@ pub struct RenderState {
 impl RenderState {
     /// Create a new empty render state
     pub fn new() -> Self {
-        Self {
-            items: Vec::new(),
-        }
+        Self { items: Vec::new() }
     }
 
     /// Add a render item
@@ -106,7 +109,9 @@ impl RenderState {
                     // Secondary sort:
                     // 2D items use y as depth proxy,
                     // 3D items use world z for depth ordering.
-                    a.sort_key().partial_cmp(&b.sort_key()).unwrap_or(Ordering::Equal)
+                    a.sort_key()
+                        .partial_cmp(&b.sort_key())
+                        .unwrap_or(Ordering::Equal)
                 }
                 other => other,
             }
@@ -126,9 +131,7 @@ impl RenderItem {
 
 /// Extract render state from hecs ECS world
 pub fn extract_render_state(world: &hecs::World) -> RenderState {
-    use pod_core::{
-        ColorRect, Material, Mesh, Parent3D, Sprite, Transform, Transform3D,
-    };
+    use pod_core::{ColorRect, Material, Mesh, Parent3D, Sprite, Transform, Transform3D};
 
     let mut state = RenderState::new();
     let mut transform_graph = HashMap::<u32, pod_core::Transform3D>::new();
@@ -149,10 +152,7 @@ pub fn extract_render_state(world: &hecs::World) -> RenderState {
     let mut transform_color_rects = HashSet::new();
 
     // Query all entities with Transform + Sprite
-    for (entity, (transform, sprite)) in world
-        .query::<(&Transform, &Sprite)>()
-        .iter()
-    {
+    for (entity, (transform, sprite)) in world.query::<(&Transform, &Sprite)>().iter() {
         if !sprite.visible {
             continue;
         }
@@ -173,10 +173,7 @@ pub fn extract_render_state(world: &hecs::World) -> RenderState {
         state.add_item(item);
     }
 
-    for (entity, (transform, color_rect)) in world
-        .query::<(&Transform, &ColorRect)>()
-        .iter()
-    {
+    for (entity, (transform, color_rect)) in world.query::<(&Transform, &ColorRect)>().iter() {
         transform_color_rects.insert(entity.id());
         let item = RenderItem {
             position: transform.position,
@@ -215,9 +212,8 @@ pub fn extract_render_state(world: &hecs::World) -> RenderState {
         state.add_item(item);
     }
 
-    for (entity, (_transform3d, mesh, material)) in world
-        .query::<(&Transform3D, &Mesh, &Material)>()
-        .iter()
+    for (entity, (_transform3d, mesh, material)) in
+        world.query::<(&Transform3D, &Mesh, &Material)>().iter()
     {
         if !mesh.visible || !material.visible {
             continue;
@@ -238,6 +234,11 @@ pub fn extract_render_state(world: &hecs::World) -> RenderState {
             draw_type: DrawType::Mesh3D {
                 mesh: mesh.asset_id.clone(),
                 material: material.asset_id.clone(),
+                tint: material.tint,
+                roughness: material.roughness,
+                metallic: material.metallic,
+                emissive: material.emissive,
+                double_sided: material.double_sided,
                 transform: world_transform,
                 cast_shadows: mesh.cast_shadows,
                 receive_shadows: mesh.receive_shadows,
@@ -248,10 +249,7 @@ pub fn extract_render_state(world: &hecs::World) -> RenderState {
     }
 
     // Query entities with Transform3D + Sprite for 2.5D pseudo-depth rendering
-    for (entity, (_transform3d, sprite)) in world
-        .query::<(&Transform3D, &Sprite)>()
-        .iter()
-    {
+    for (entity, (_transform3d, sprite)) in world.query::<(&Transform3D, &Sprite)>().iter() {
         if !sprite.visible {
             continue;
         }
@@ -424,7 +422,9 @@ mod tests {
         let root_item = items
             .iter()
             .find_map(|item| match &item.draw_type {
-                DrawType::Mesh3D { mesh, transform, .. } if mesh == "root" => Some(transform.clone()),
+                DrawType::Mesh3D {
+                    mesh, transform, ..
+                } if mesh == "root" => Some(transform.clone()),
                 _ => None,
             })
             .expect("root mesh should be extracted");
@@ -432,7 +432,9 @@ mod tests {
         let child_item = items
             .iter()
             .find_map(|item| match &item.draw_type {
-                DrawType::Mesh3D { mesh, transform, .. } if mesh == "child" => Some(transform.clone()),
+                DrawType::Mesh3D {
+                    mesh, transform, ..
+                } if mesh == "child" => Some(transform.clone()),
                 _ => None,
             })
             .expect("child mesh should be extracted");
@@ -515,9 +517,7 @@ mod tests {
             },
         ));
 
-        world.spawn((
-            ColorRect::new(16.0, 9.0, [0.1, 0.1, 0.1, 1.0]),
-        ));
+        world.spawn((ColorRect::new(16.0, 9.0, [0.1, 0.1, 0.1, 1.0]),));
 
         let state = extract_render_state(&world);
         assert_eq!(
@@ -597,6 +597,70 @@ mod tests {
     }
 
     #[test]
+    fn extract_render_state_preserves_mesh_material_surface_metadata() {
+        let mut world = hecs::World::new();
+
+        world.spawn((
+            Transform3D {
+                position: Vec3::new(0.0, 1.0, 2.0),
+                ..Default::default()
+            },
+            Mesh {
+                asset_id: "surface_mesh".to_string(),
+                cast_shadows: false,
+                receive_shadows: true,
+                ..Default::default()
+            },
+            Material {
+                asset_id: "surface_mat".to_string(),
+                tint: [0.25, 0.5, 0.75, 0.6],
+                roughness: 0.9,
+                metallic: 0.2,
+                emissive: [0.1, 0.2, 0.3],
+                double_sided: true,
+                ..Default::default()
+            },
+        ));
+
+        let state = extract_render_state(&world);
+        let mesh = state
+            .items
+            .iter()
+            .find_map(|item| match &item.draw_type {
+                DrawType::Mesh3D {
+                    mesh,
+                    material,
+                    tint,
+                    roughness,
+                    metallic,
+                    emissive,
+                    double_sided,
+                    cast_shadows,
+                    receive_shadows,
+                    ..
+                } if mesh == "surface_mesh" && material == "surface_mat" => Some((
+                    *tint,
+                    *roughness,
+                    *metallic,
+                    *emissive,
+                    *double_sided,
+                    *cast_shadows,
+                    *receive_shadows,
+                )),
+                _ => None,
+            })
+            .expect("surface mesh should be extracted");
+
+        assert_eq!(mesh.0, [0.25, 0.5, 0.75, 0.6]);
+        assert!((mesh.1 - 0.9).abs() < 1e-6);
+        assert!((mesh.2 - 0.2).abs() < 1e-6);
+        assert_eq!(mesh.3, [0.1, 0.2, 0.3]);
+        assert!(mesh.4);
+        assert!(!mesh.5);
+        assert!(mesh.6);
+    }
+
+    #[test]
     fn extract_render_state_2d_and_3d_items_same_layer_sort_by_mode_depth_key() {
         let mut world = hecs::World::new();
 
@@ -665,12 +729,15 @@ mod tests {
             .collect();
 
         assert_eq!(ordered.len(), 4);
-        assert_eq!(ordered, vec![
-            "ui_near".to_string(),
-            "sprite3d:sprite3d_near".to_string(),
-            "mesh_far".to_string(),
-            "ui_far".to_string(),
-        ]);
+        assert_eq!(
+            ordered,
+            vec![
+                "ui_near".to_string(),
+                "sprite3d:sprite3d_near".to_string(),
+                "mesh_far".to_string(),
+                "ui_far".to_string(),
+            ]
+        );
     }
 
     #[test]
@@ -732,7 +799,11 @@ mod tests {
         ));
 
         let state = extract_render_state(&world);
-        assert_eq!(state.items.len(), 3, "root color rect + mesh + sprite3d should be extracted");
+        assert_eq!(
+            state.items.len(),
+            3,
+            "root color rect + mesh + sprite3d should be extracted"
+        );
 
         let mesh_transform = state
             .items
@@ -881,9 +952,7 @@ mod tests {
 
         let extract = state.items.iter().find_map(|item| match &item.draw_type {
             DrawType::Sprite3D {
-                transform,
-                texture,
-                ..
+                transform, texture, ..
             } if texture == "orphan_sprite3d" => Some(*transform),
             _ => None,
         });
@@ -938,23 +1007,32 @@ mod tests {
             },
         ));
 
-        world.insert_one(
-            entity_a,
-            Parent3D {
-                parent: entity_b.id() as u64,
-            },
-        )
-        .expect("update loop entity A parent to B");
+        world
+            .insert_one(
+                entity_a,
+                Parent3D {
+                    parent: entity_b.id() as u64,
+                },
+            )
+            .expect("update loop entity A parent to B");
 
         let state = extract_render_state(&world);
-        assert_eq!(state.items.len(), 2, "cycle meshes should be extracted without recursion failure");
+        assert_eq!(
+            state.items.len(),
+            2,
+            "cycle meshes should be extracted without recursion failure"
+        );
 
         let mut cycle_positions = state
             .items
             .iter()
             .filter_map(|item| match &item.draw_type {
-                DrawType::Mesh3D { mesh, transform, .. } if mesh == "cycle_a" => Some(transform.position[0]),
-                DrawType::Mesh3D { mesh, transform, .. } if mesh == "cycle_b" => Some(transform.position[0]),
+                DrawType::Mesh3D {
+                    mesh, transform, ..
+                } if mesh == "cycle_a" => Some(transform.position[0]),
+                DrawType::Mesh3D {
+                    mesh, transform, ..
+                } if mesh == "cycle_b" => Some(transform.position[0]),
                 _ => None,
             })
             .collect::<Vec<_>>();
@@ -976,9 +1054,7 @@ mod tests {
                 texture: "cycle_a".to_string(),
                 ..Default::default()
             },
-            Parent3D {
-                parent: 1,
-            },
+            Parent3D { parent: 1 },
         ));
 
         let entity_b = world.spawn((
@@ -995,13 +1071,14 @@ mod tests {
             },
         ));
 
-        world.insert_one(
-            entity_a,
-            Parent3D {
-                parent: entity_b.id() as u64,
-            },
-        )
-        .expect("update loop entity A parent to B");
+        world
+            .insert_one(
+                entity_a,
+                Parent3D {
+                    parent: entity_b.id() as u64,
+                },
+            )
+            .expect("update loop entity A parent to B");
 
         let state = extract_render_state(&world);
         assert_eq!(
@@ -1014,12 +1091,12 @@ mod tests {
             .items
             .iter()
             .filter_map(|item| match &item.draw_type {
-                DrawType::Sprite3D { texture, transform, .. } if texture == "cycle_a" => {
-                    Some(transform.position[0])
-                }
-                DrawType::Sprite3D { texture, transform, .. } if texture == "cycle_b" => {
-                    Some(transform.position[0])
-                }
+                DrawType::Sprite3D {
+                    texture, transform, ..
+                } if texture == "cycle_a" => Some(transform.position[0]),
+                DrawType::Sprite3D {
+                    texture, transform, ..
+                } if texture == "cycle_b" => Some(transform.position[0]),
                 _ => None,
             })
             .collect::<Vec<_>>();
@@ -1033,7 +1110,10 @@ mod tests {
                 sprite3d_count += 1;
             }
         }
-        assert_eq!(sprite3d_count, 2, "all sprite3d cycle entries should be extracted");
+        assert_eq!(
+            sprite3d_count, 2,
+            "all sprite3d cycle entries should be extracted"
+        );
     }
 
     #[test]

--- a/crates/pod-render/src/web.rs
+++ b/crates/pod-render/src/web.rs
@@ -42,6 +42,16 @@ pub struct RenderCommand {
     pub cast_shadows: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub receive_shadows: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transparent: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub double_sided: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub roughness: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metallic: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub emissive: Option<[f32; 3]>,
     pub layer: i32,
     pub visible: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -100,8 +110,17 @@ pub struct ThreeJsMeshBatch {
     pub mesh: String,
     pub material: String,
     pub layer: i32,
+    pub phase: ThreeJsRenderPhase,
+    pub transparent: bool,
+    pub double_sided: bool,
     pub cast_shadows: bool,
     pub receive_shadows: bool,
+    pub tint: [f32; 4],
+    pub roughness: f32,
+    pub metallic: f32,
+    pub emissive: [f32; 3],
+    pub depth_write: bool,
+    pub depth_test: bool,
     pub instances: Vec<ThreeJsInstance>,
 }
 
@@ -113,7 +132,19 @@ pub struct ThreeJsSpriteBatch {
     pub frame: u32,
     pub layer: i32,
     pub billboard: bool,
+    pub phase: ThreeJsRenderPhase,
+    pub transparent: bool,
+    pub depth_write: bool,
+    pub depth_test: bool,
     pub instances: Vec<ThreeJsInstance>,
+}
+
+/// Render phase guidance for Three.js/WebGPU consumers.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum ThreeJsRenderPhase {
+    Opaque,
+    Transparent,
 }
 
 /// Runtime hints for a Three.js WebGPU consumer.
@@ -126,6 +157,9 @@ pub struct ThreeJsWebGpuHints {
     pub use_instancing: bool,
     pub sort_opaque_front_to_back: bool,
     pub preserve_instance_order: bool,
+    pub sort_transparent_back_to_front: bool,
+    pub opaque_depth_write: bool,
+    pub transparent_depth_write: bool,
     pub max_pixel_ratio: f32,
 }
 
@@ -146,6 +180,12 @@ struct MeshBatchKey {
     layer: i32,
     mesh: String,
     material: String,
+    tint_bits: [u32; 4],
+    roughness_bits: u32,
+    metallic_bits: u32,
+    emissive_bits: [u32; 3],
+    double_sided: bool,
+    transparent: bool,
     cast_shadows: bool,
     receive_shadows: bool,
 }
@@ -156,6 +196,7 @@ struct SpriteBatchKey {
     texture: String,
     frame: u32,
     billboard: bool,
+    transparent: bool,
 }
 
 /// Web-specific renderer bridge.
@@ -237,14 +278,26 @@ impl WebRenderBridge {
                 DrawType::Mesh3D {
                     mesh,
                     material,
+                    tint,
+                    roughness,
+                    metallic,
+                    emissive,
+                    double_sided,
                     transform,
                     cast_shadows,
                     receive_shadows,
                 } => {
+                    let transparent = Self::is_transparent(*tint);
                     let key = MeshBatchKey {
                         layer: item.layer,
                         mesh: mesh.clone(),
                         material: material.clone(),
+                        tint_bits: Self::float4_bits(*tint),
+                        roughness_bits: roughness.to_bits(),
+                        metallic_bits: metallic.to_bits(),
+                        emissive_bits: Self::float3_bits(*emissive),
+                        double_sided: *double_sided,
+                        transparent,
                         cast_shadows: *cast_shadows,
                         receive_shadows: *receive_shadows,
                     };
@@ -264,11 +317,13 @@ impl WebRenderBridge {
                     transform,
                     billboard,
                 } => {
+                    let transparent = Self::is_transparent(*tint);
                     let key = SpriteBatchKey {
                         layer: item.layer,
                         texture: texture.clone(),
                         frame: *frame,
                         billboard: *billboard,
+                        transparent,
                     };
                     sprite_batches
                         .entry(key)
@@ -292,8 +347,17 @@ impl WebRenderBridge {
                     mesh: key.mesh,
                     material: key.material,
                     layer: key.layer,
+                    phase: Self::phase_from_transparency(key.transparent),
+                    transparent: key.transparent,
+                    double_sided: key.double_sided,
                     cast_shadows: key.cast_shadows,
                     receive_shadows: key.receive_shadows,
+                    tint: Self::bits_to_float4(key.tint_bits),
+                    roughness: f32::from_bits(key.roughness_bits),
+                    metallic: f32::from_bits(key.metallic_bits),
+                    emissive: Self::bits_to_float3(key.emissive_bits),
+                    depth_write: !key.transparent,
+                    depth_test: true,
                     instances,
                 })
                 .collect(),
@@ -304,6 +368,10 @@ impl WebRenderBridge {
                     frame: key.frame,
                     layer: key.layer,
                     billboard: key.billboard,
+                    phase: Self::phase_from_transparency(key.transparent),
+                    transparent: key.transparent,
+                    depth_write: !key.transparent,
+                    depth_test: true,
                     instances,
                 })
                 .collect(),
@@ -314,6 +382,9 @@ impl WebRenderBridge {
                 use_instancing: true,
                 sort_opaque_front_to_back: true,
                 preserve_instance_order: true,
+                sort_transparent_back_to_front: true,
+                opaque_depth_write: true,
+                transparent_depth_write: false,
                 max_pixel_ratio: 2.0,
             },
         }
@@ -394,6 +465,11 @@ impl WebRenderBridge {
                 billboard: None,
                 cast_shadows: None,
                 receive_shadows: None,
+                transparent: Some(Self::is_transparent(*color)),
+                double_sided: None,
+                roughness: None,
+                metallic: None,
+                emissive: None,
                 layer: item.layer,
                 visible: item.visible,
                 source_entity: item.source_entity,
@@ -422,6 +498,11 @@ impl WebRenderBridge {
                 billboard: None,
                 cast_shadows: None,
                 receive_shadows: None,
+                transparent: Some(Self::is_transparent(*tint)),
+                double_sided: None,
+                roughness: None,
+                metallic: None,
+                emissive: None,
                 layer: item.layer,
                 visible: item.visible,
                 source_entity: item.source_entity,
@@ -429,6 +510,11 @@ impl WebRenderBridge {
             DrawType::Mesh3D {
                 mesh,
                 material,
+                tint,
+                roughness,
+                metallic,
+                emissive,
+                double_sided,
                 transform,
                 cast_shadows,
                 receive_shadows,
@@ -441,8 +527,8 @@ impl WebRenderBridge {
                 rotation: 0.0,
                 scale_x: transform.scale[0],
                 scale_y: transform.scale[1],
-                color: [1.0, 1.0, 1.0, 1.0],
-                alpha: 1.0,
+                color: *tint,
+                alpha: tint[3],
                 texture: None,
                 frame: None,
                 mesh: Some(mesh.clone()),
@@ -452,6 +538,11 @@ impl WebRenderBridge {
                 billboard: None,
                 cast_shadows: Some(*cast_shadows),
                 receive_shadows: Some(*receive_shadows),
+                transparent: Some(Self::is_transparent(*tint)),
+                double_sided: Some(*double_sided),
+                roughness: Some(*roughness),
+                metallic: Some(*metallic),
+                emissive: Some(*emissive),
                 layer: item.layer,
                 visible: item.visible,
                 source_entity: item.source_entity,
@@ -482,6 +573,11 @@ impl WebRenderBridge {
                 billboard: Some(*billboard),
                 cast_shadows: None,
                 receive_shadows: None,
+                transparent: Some(Self::is_transparent(*tint)),
+                double_sided: None,
+                roughness: None,
+                metallic: None,
+                emissive: None,
                 layer: item.layer,
                 visible: item.visible,
                 source_entity: item.source_entity,
@@ -501,6 +597,52 @@ impl WebRenderBridge {
             color,
             source_entity,
         }
+    }
+
+    fn phase_from_transparency(transparent: bool) -> ThreeJsRenderPhase {
+        if transparent {
+            ThreeJsRenderPhase::Transparent
+        } else {
+            ThreeJsRenderPhase::Opaque
+        }
+    }
+
+    fn is_transparent(color: [f32; 4]) -> bool {
+        color[3] < 0.999
+    }
+
+    fn float3_bits(values: [f32; 3]) -> [u32; 3] {
+        [
+            values[0].to_bits(),
+            values[1].to_bits(),
+            values[2].to_bits(),
+        ]
+    }
+
+    fn bits_to_float3(values: [u32; 3]) -> [f32; 3] {
+        [
+            f32::from_bits(values[0]),
+            f32::from_bits(values[1]),
+            f32::from_bits(values[2]),
+        ]
+    }
+
+    fn float4_bits(values: [f32; 4]) -> [u32; 4] {
+        [
+            values[0].to_bits(),
+            values[1].to_bits(),
+            values[2].to_bits(),
+            values[3].to_bits(),
+        ]
+    }
+
+    fn bits_to_float4(values: [u32; 4]) -> [f32; 4] {
+        [
+            f32::from_bits(values[0]),
+            f32::from_bits(values[1]),
+            f32::from_bits(values[2]),
+            f32::from_bits(values[3]),
+        ]
     }
 
     /// Post data to JavaScript side.
@@ -661,6 +803,11 @@ mod tests {
                 draw_type: DrawType::Mesh3D {
                     mesh: "tree".to_string(),
                     material: "forest".to_string(),
+                    tint: [1.0, 1.0, 1.0, 1.0],
+                    roughness: 0.8,
+                    metallic: 0.1,
+                    emissive: [0.0, 0.0, 0.0],
+                    double_sided: false,
                     transform: RenderTransform3D {
                         position: [x, 0.0, 8.0 - x],
                         rotation: [0.0, 0.0, 0.0, 1.0],
@@ -681,6 +828,11 @@ mod tests {
             draw_type: DrawType::Mesh3D {
                 mesh: "rock".to_string(),
                 material: "stone".to_string(),
+                tint: [0.5, 0.5, 0.5, 0.4],
+                roughness: 1.0,
+                metallic: 0.0,
+                emissive: [0.1, 0.0, 0.0],
+                double_sided: true,
                 transform: RenderTransform3D {
                     position: [10.0, 0.0, 2.0],
                     rotation: [0.0, 0.0, 0.0, 1.0],
@@ -706,10 +858,26 @@ mod tests {
             .find(|batch| batch.mesh == "tree")
             .expect("tree batch should exist");
         assert_eq!(tree_batch.instances.len(), 2);
+        assert_eq!(tree_batch.phase, ThreeJsRenderPhase::Opaque);
+        assert!(!tree_batch.transparent);
+        assert!(tree_batch.depth_write);
+        assert_eq!(tree_batch.tint, [1.0, 1.0, 1.0, 1.0]);
         assert_eq!(tree_batch.instances[0].source_entity, Some(401));
         assert_eq!(tree_batch.instances[1].source_entity, Some(402));
+        let rock_batch = frame
+            .mesh_batches
+            .iter()
+            .find(|batch| batch.mesh == "rock")
+            .expect("rock batch should exist");
+        assert_eq!(rock_batch.phase, ThreeJsRenderPhase::Transparent);
+        assert!(rock_batch.transparent);
+        assert!(!rock_batch.depth_write);
+        assert!(rock_batch.double_sided);
+        assert_eq!(rock_batch.emissive, [0.1, 0.0, 0.0]);
         assert_eq!(frame.hints.renderer, "three/webgpu");
         assert!(frame.hints.use_instancing);
+        assert!(frame.hints.sort_transparent_back_to_front);
+        assert!(!frame.hints.transparent_depth_write);
     }
 
     #[test]
@@ -779,15 +947,34 @@ mod tests {
             [0.0, 0.0, 0.0, 1.0],
         );
 
-        assert_eq!(frame.sprite_batches.len(), 2);
-        let npc_batch = frame
+        assert_eq!(frame.sprite_batches.len(), 3);
+        let opaque_npc_batch = frame
             .sprite_batches
             .iter()
-            .find(|batch| batch.texture == "npc.png" && batch.frame == 2)
-            .expect("frame-2 sprite batch should exist");
-        assert_eq!(npc_batch.instances.len(), 2);
-        assert_eq!(npc_batch.instances[0].color, Some([1.0, 0.5, 0.5, 1.0]));
-        assert_eq!(npc_batch.instances[1].source_entity, Some(502));
+            .find(|batch| {
+                batch.texture == "npc.png"
+                    && batch.frame == 2
+                    && batch.phase == ThreeJsRenderPhase::Opaque
+            })
+            .expect("opaque frame-2 sprite batch should exist");
+        assert_eq!(opaque_npc_batch.instances.len(), 1);
+        assert!(opaque_npc_batch.depth_write);
+        assert_eq!(
+            opaque_npc_batch.instances[0].color,
+            Some([1.0, 0.5, 0.5, 1.0])
+        );
+        let transparent_npc_batch = frame
+            .sprite_batches
+            .iter()
+            .find(|batch| {
+                batch.texture == "npc.png"
+                    && batch.frame == 2
+                    && batch.phase == ThreeJsRenderPhase::Transparent
+            })
+            .expect("transparent frame-2 sprite batch should exist");
+        assert_eq!(transparent_npc_batch.instances.len(), 1);
+        assert!(!transparent_npc_batch.depth_write);
+        assert_eq!(transparent_npc_batch.instances[0].source_entity, Some(502));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- preserve mesh material surface metadata through `pod-render`
- classify Three.js/WebGPU batches as opaque vs transparent with depth-write guidance
- keep incompatible material variants out of shared instanced batches

## Validation
- cargo test -p pod-render --lib
- cargo check -p pod-render --target wasm32-unknown-unknown
- git diff --check