### PR TITLE
Add pod-web Three.js WebGPU client

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -341,5 +341,16 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cargo test -p pod-render --lib`
   - `cargo check -p pod-render --target wasm32-unknown-unknown`
 
-**Last updated**: Iteration 44
+### Iteration 45 — Browser Three.js Client Baseline
+
+- [x] Added `apps/pod-web`, a real browser-side Three.js client that consumes `pod-render` frame payloads instead of leaving the WebGPU contract as a Rust-only abstraction.
+- [x] Implemented `three/webgpu` initialization with automatic WebGL2 fallback, instanced 3D mesh batching, billboard sprite batching, and a 2D overlay pass for legacy `RenderFrame` content.
+- [x] Added deterministic TypeScript tests for camera rig mapping, transparent sprite tint splitting, and batch ordering preservation, plus a runnable demo bridge exposed through `window.podRender`.
+- [x] Documented the new browser client in the root README, architecture docs, and app-level README.
+- [x] Validated touched targets:
+  - `cd apps/pod-web && bun run typecheck`
+  - `cd apps/pod-web && bun test`
+  - `cd apps/pod-web && bun run build`
+
+**Last updated**: Iteration 45
 **Current focus**: Phase 8 shipping parity and Phase 9 hardening backlog

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Prompt or Die is an open-source game platform for building games where autonomou
 
 - Deterministic ECS runtime in `pod-core` with a shared agent pipeline: Observe -> Decide -> Validate -> Execute -> Broadcast
 - Native and browser rendering surfaces in `pod-render`, including mixed 2D/2.5D/3D frame extraction
+- A real browser-side Three.js client in `apps/pod-web` that consumes the WebGPU frame contract
 - Scene, prefab, save/load, and state-stack authoring in `pod-scene`
 - Dedicated editor shell in `pod-editor`
 - Direct-connect networking plus SpacetimeDB integration in `pod-net` and `pod-stdb`
@@ -19,6 +20,10 @@ cargo run --bin prompt-or-die
 cargo run --bin pod-server
 cargo test --workspace
 cargo check --workspace
+
+cd apps/pod-web
+bun install
+bun run dev
 ```
 
 ## Workspace map
@@ -39,6 +44,7 @@ crates/
   pod-scripting  Lua scripting API and sandbox
 apps/
   pod-desktop    Desktop runtime and local simulation entry point
+  pod-web        Browser-side Three.js/WebGPU client and bridge demo
   pod-server     Dedicated authoritative server
 specs/
   Product and subsystem requirements
@@ -54,4 +60,4 @@ docs/
 
 ## Current status
 
-The project has completed its deterministic core, networking, rendering baseline, editor scaffold, and scene-system foundations. The next major layers are public platform hardening, import/shipping workflows, and a formal plugin lifecycle.
+The project has completed its deterministic core, networking, rendering baseline, editor scaffold, scene-system foundations, and the first real browser-side Three.js/WebGPU client. The next major layers are public platform hardening, import/shipping workflows, and a formal plugin lifecycle.

--- a/apps/pod-web/.gitignore
+++ b/apps/pod-web/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/apps/pod-web/README.md
+++ b/apps/pod-web/README.md
@@ -1,0 +1,37 @@
+# pod-web
+
+`pod-web` is the browser-side Three.js client for Prompt or Die.
+
+It consumes the `pod-render` browser frame contract and provides:
+
+- `three/webgpu` rendering with automatic WebGL2 fallback
+- instanced mesh batches for 3D authored content
+- billboard sprite batches with transparent depth-order preservation
+- a 2D overlay scene for the legacy `RenderFrame` contract
+- a demo bridge via `window.podRender.*` so the app is useful before the Rust wasm entrypoint is wired in
+
+## Run
+
+```bash
+cd apps/pod-web
+bun install
+bun run dev
+```
+
+## Validate
+
+```bash
+cd apps/pod-web
+bun run typecheck
+bun test
+bun run build
+```
+
+## Bridge surface
+
+- `window.podRender.render(json)`
+  - accepts the legacy `RenderFrame` JSON from `pod-render`
+- `window.podRender.renderThreeJsWebGpuFrame(json)`
+  - accepts the batched `ThreeJsWebGpuFrame` JSON from `pod-render`
+- `window.podRender.resetDemo()`
+  - returns the app to its built-in demo scene

--- a/apps/pod-web/bun.lock
+++ b/apps/pod-web/bun.lock
@@ -1,0 +1,171 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@prompt-or-die/pod-web",
+      "dependencies": {
+        "three": "^0.182.0",
+      },
+      "devDependencies": {
+        "@types/three": "^0.182.0",
+        "bun-types": "^1.3.10",
+        "typescript": "^5.9.2",
+        "vite": "^7.1.5",
+      },
+    },
+  },
+  "packages": {
+    "@dimforge/rapier3d-compat": ["@dimforge/rapier3d-compat@0.12.0", "", {}, "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.3", "", { "os": "android", "cpu": "arm" }, "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.3", "", { "os": "android", "cpu": "arm64" }, "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.3", "", { "os": "android", "cpu": "x64" }, "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.3", "", { "os": "linux", "cpu": "arm" }, "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.3", "", { "os": "linux", "cpu": "ia32" }, "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.3", "", { "os": "none", "cpu": "x64" }, "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.3", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.3", "", { "os": "openbsd", "cpu": "x64" }, "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.3", "", { "os": "sunos", "cpu": "x64" }, "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.59.0", "", { "os": "android", "cpu": "arm" }, "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.59.0", "", { "os": "android", "cpu": "arm64" }, "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.59.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.59.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.59.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.59.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.59.0", "", { "os": "linux", "cpu": "arm" }, "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.59.0", "", { "os": "linux", "cpu": "arm" }, "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.59.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.59.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.59.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.59.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.59.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.59.0", "", { "os": "linux", "cpu": "x64" }, "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.59.0", "", { "os": "linux", "cpu": "x64" }, "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.59.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.59.0", "", { "os": "none", "cpu": "arm64" }, "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.59.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.59.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA=="],
+
+    "@tweenjs/tween.js": ["@tweenjs/tween.js@23.1.3", "", {}, "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/node": ["@types/node@25.3.5", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA=="],
+
+    "@types/stats.js": ["@types/stats.js@0.17.4", "", {}, "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA=="],
+
+    "@types/three": ["@types/three@0.182.0", "", { "dependencies": { "@dimforge/rapier3d-compat": "~0.12.0", "@tweenjs/tween.js": "~23.1.3", "@types/stats.js": "*", "@types/webxr": ">=0.5.17", "@webgpu/types": "*", "fflate": "~0.8.2", "meshoptimizer": "~0.22.0" } }, "sha512-WByN9V3Sbwbe2OkWuSGyoqQO8Du6yhYaXtXLoA5FkKTUJorZ+yOHBZ35zUUPQXlAKABZmbYp5oAqpA4RBjtJ/Q=="],
+
+    "@types/webxr": ["@types/webxr@0.5.24", "", {}, "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg=="],
+
+    "@webgpu/types": ["@webgpu/types@0.1.69", "", {}, "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ=="],
+
+    "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+
+    "esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fflate": ["fflate@0.8.2", "", {}, "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "meshoptimizer": ["meshoptimizer@0.22.0", "", {}, "sha512-IebiK79sqIy+E4EgOr+CAw+Ke8hAspXKzBd0JdgEmPHiAwmvEj2S4h1rfvo+o/BnfEYd/jAOg5IeeIjzlzSnDg=="],
+
+    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
+    "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
+
+    "rollup": ["rollup@4.59.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.59.0", "@rollup/rollup-android-arm64": "4.59.0", "@rollup/rollup-darwin-arm64": "4.59.0", "@rollup/rollup-darwin-x64": "4.59.0", "@rollup/rollup-freebsd-arm64": "4.59.0", "@rollup/rollup-freebsd-x64": "4.59.0", "@rollup/rollup-linux-arm-gnueabihf": "4.59.0", "@rollup/rollup-linux-arm-musleabihf": "4.59.0", "@rollup/rollup-linux-arm64-gnu": "4.59.0", "@rollup/rollup-linux-arm64-musl": "4.59.0", "@rollup/rollup-linux-loong64-gnu": "4.59.0", "@rollup/rollup-linux-loong64-musl": "4.59.0", "@rollup/rollup-linux-ppc64-gnu": "4.59.0", "@rollup/rollup-linux-ppc64-musl": "4.59.0", "@rollup/rollup-linux-riscv64-gnu": "4.59.0", "@rollup/rollup-linux-riscv64-musl": "4.59.0", "@rollup/rollup-linux-s390x-gnu": "4.59.0", "@rollup/rollup-linux-x64-gnu": "4.59.0", "@rollup/rollup-linux-x64-musl": "4.59.0", "@rollup/rollup-openbsd-x64": "4.59.0", "@rollup/rollup-openharmony-arm64": "4.59.0", "@rollup/rollup-win32-arm64-msvc": "4.59.0", "@rollup/rollup-win32-ia32-msvc": "4.59.0", "@rollup/rollup-win32-x64-gnu": "4.59.0", "@rollup/rollup-win32-x64-msvc": "4.59.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "three": ["three@0.182.0", "", {}, "sha512-GbHabT+Irv+ihI1/f5kIIsZ+Ef9Sl5A1Y7imvS5RQjWgtTPfPnZ43JmlYI7NtCRDK9zir20lQpfg8/9Yd02OvQ=="],
+
+    "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
+  }
+}

--- a/apps/pod-web/index.html
+++ b/apps/pod-web/index.html
@@ -1,0 +1,114 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Prompt or Die WebGPU Client</title>
+    <link
+      rel="icon"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='16' fill='%2308101b'/%3E%3Cpath d='M18 46V18h14c8.4 0 14 4.9 14 13.5S40.4 46 32 46H18zm8-6h5.3c4.6 0 7.8-2.6 7.8-8.5 0-5.6-3.2-7.5-7.8-7.5H26V40z' fill='%238af5cf'/%3E%3C/svg%3E"
+    />
+    <style>
+      :root {
+        color-scheme: dark;
+        --panel-bg: rgba(10, 16, 26, 0.76);
+        --panel-border: rgba(130, 170, 255, 0.24);
+        --panel-accent: #8af5cf;
+        --page-bg: radial-gradient(circle at top, #19304d 0%, #08101b 48%, #03060c 100%);
+        --copy: #f2f4f7;
+        --muted: #9ca6b6;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        overflow: hidden;
+        background: var(--page-bg);
+        color: var(--copy);
+        font-family: "IBM Plex Sans", "Avenir Next", sans-serif;
+      }
+
+      #app {
+        position: relative;
+        width: 100vw;
+        height: 100vh;
+      }
+
+      #pod-web-canvas {
+        display: block;
+        width: 100%;
+        height: 100%;
+      }
+
+      .hud {
+        position: absolute;
+        inset: 20px auto auto 20px;
+        width: min(360px, calc(100vw - 40px));
+        padding: 16px 18px;
+        border: 1px solid var(--panel-border);
+        border-radius: 18px;
+        background: var(--panel-bg);
+        backdrop-filter: blur(18px);
+        box-shadow: 0 30px 80px rgba(0, 0, 0, 0.28);
+      }
+
+      .hud h1 {
+        margin: 0 0 8px;
+        font-size: 1.1rem;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+      }
+
+      .hud p {
+        margin: 0;
+        color: var(--muted);
+        line-height: 1.45;
+      }
+
+      .hud strong {
+        color: var(--panel-accent);
+      }
+
+      .hud dl {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: 8px 12px;
+        margin: 14px 0 0;
+      }
+
+      .hud dt {
+        color: var(--muted);
+      }
+
+      .hud dd {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app">
+      <canvas id="pod-web-canvas"></canvas>
+      <section class="hud">
+        <h1>Prompt or Die Browser Client</h1>
+        <p>
+          Real <strong>Three.js</strong> scene consumption for the
+          <strong>pod-render</strong> WebGPU frame contract, with instanced 3D
+          batches, billboards, and a 2D overlay pass.
+        </p>
+        <dl>
+          <dt>Backend</dt>
+          <dd id="backend-label">starting…</dd>
+          <dt>Source</dt>
+          <dd id="frame-source">demo frame</dd>
+          <dt>Bridge</dt>
+          <dd><code>window.podRender.renderThreeJsWebGpuFrame(...)</code></dd>
+        </dl>
+      </section>
+    </div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/apps/pod-web/package.json
+++ b/apps/pod-web/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@prompt-or-die/pod-web",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "three": "^0.182.0"
+  },
+  "devDependencies": {
+    "@types/three": "^0.182.0",
+    "bun-types": "^1.3.10",
+    "typescript": "^5.9.2",
+    "vite": "^7.1.5"
+  }
+}

--- a/apps/pod-web/src/assets.ts
+++ b/apps/pod-web/src/assets.ts
@@ -1,0 +1,170 @@
+import {
+  BoxGeometry,
+  ConeGeometry,
+  Color,
+  CylinderGeometry,
+  DataTexture,
+  DodecahedronGeometry,
+  FrontSide,
+  MeshBasicMaterial,
+  MeshStandardMaterial,
+  PlaneGeometry,
+  RepeatWrapping,
+  SRGBColorSpace,
+  Texture
+} from "three";
+import type { BufferGeometry, Material, Side } from "three";
+
+import type { RgbaTuple, ThreeJsMeshBatch, ThreeJsSpriteBatch } from "./contracts";
+
+export interface ResolvedSpriteTexture {
+  texture: Texture;
+  repeat?: [number, number];
+  offset?: [number, number];
+}
+
+export interface PodThreeAssetRegistry {
+  resolveGeometry(batch: ThreeJsMeshBatch): BufferGeometry | Promise<BufferGeometry>;
+  resolveMeshMaterial?(batch: ThreeJsMeshBatch): Material | Promise<Material>;
+  resolveSpriteTexture(
+    batch: Pick<ThreeJsSpriteBatch, "texture" | "frame">
+  ): ResolvedSpriteTexture | Promise<ResolvedSpriteTexture>;
+}
+
+export class DefaultPodThreeAssetRegistry implements PodThreeAssetRegistry {
+  private geometryCache = new Map<string, BufferGeometry>();
+  private textureCache = new Map<string, Texture>();
+
+  resolveGeometry(batch: ThreeJsMeshBatch): BufferGeometry {
+    const cached = this.geometryCache.get(batch.mesh);
+    if (cached) {
+      return cached;
+    }
+
+    const meshName = batch.mesh.toLowerCase();
+    let geometry: BufferGeometry;
+
+    if (meshName.includes("spire") || meshName.includes("obelisk") || meshName.includes("spike")) {
+      geometry = new ConeGeometry(1.2, 4.8, 6);
+    } else if (meshName.includes("rock") || meshName.includes("boulder")) {
+      geometry = new DodecahedronGeometry(1.35, 0);
+    } else if (
+      meshName.includes("column") ||
+      meshName.includes("tower") ||
+      meshName.includes("pillar")
+    ) {
+      geometry = new CylinderGeometry(0.65, 0.9, 5.2, 12);
+    } else if (meshName.includes("tree") || meshName.includes("pine")) {
+      geometry = new ConeGeometry(1.4, 3.4, 10);
+    } else {
+      geometry = new BoxGeometry(2, 2, 2);
+    }
+
+    this.geometryCache.set(batch.mesh, geometry);
+    return geometry;
+  }
+
+  resolveSpriteTexture(batch: Pick<ThreeJsSpriteBatch, "texture" | "frame">): ResolvedSpriteTexture {
+    const key = `${batch.texture}:${batch.frame}`;
+    const cached = this.textureCache.get(key);
+    if (cached) {
+      return { texture: cached };
+    }
+
+    const texture = createRadialTexture(hashColor(batch.texture));
+    this.textureCache.set(key, texture);
+    return { texture };
+  }
+}
+
+export function createMeshMaterial(batch: ThreeJsMeshBatch): MeshStandardMaterial {
+  const material = new MeshStandardMaterial({
+    color: new Color(batch.tint[0], batch.tint[1], batch.tint[2]),
+    transparent: batch.transparent,
+    opacity: batch.tint[3],
+    roughness: batch.roughness,
+    metalness: batch.metallic,
+    emissive: new Color(batch.emissive[0], batch.emissive[1], batch.emissive[2]),
+    depthWrite: batch.depthWrite,
+    depthTest: batch.depthTest,
+    side: batch.doubleSided ? 2 : FrontSide
+  });
+  material.name = `pod-mesh:${batch.mesh}:${batch.material}`;
+  return material;
+}
+
+export function createSpriteMaterial(
+  resolved: ResolvedSpriteTexture,
+  tint: RgbaTuple,
+  transparent: boolean,
+  depthWrite: boolean,
+  depthTest: boolean,
+  side: Side = FrontSide
+): MeshBasicMaterial {
+  const material = new MeshBasicMaterial({
+    map: resolved.texture,
+    color: new Color(tint[0], tint[1], tint[2]),
+    transparent: transparent || tint[3] < 0.999,
+    opacity: tint[3],
+    depthWrite,
+    depthTest,
+    side
+  });
+
+  if (resolved.repeat || resolved.offset) {
+    material.map?.matrix.identity();
+    material.map?.repeat.set(resolved.repeat?.[0] ?? 1, resolved.repeat?.[1] ?? 1);
+    material.map?.offset.set(resolved.offset?.[0] ?? 0, resolved.offset?.[1] ?? 0);
+    if (material.map) {
+      material.map.matrixAutoUpdate = false;
+      material.map.updateMatrix();
+    }
+  }
+
+  return material;
+}
+
+export const OVERLAY_PLANE_GEOMETRY = new PlaneGeometry(1, 1);
+export const SPRITE_PLANE_GEOMETRY = new PlaneGeometry(1, 1);
+
+function createRadialTexture(color: [number, number, number]): Texture {
+  const size = 32;
+  const pixels = new Uint8Array(size * size * 4);
+
+  for (let y = 0; y < size; y += 1) {
+    for (let x = 0; x < size; x += 1) {
+      const index = (y * size + x) * 4;
+      const dx = (x / (size - 1)) * 2 - 1;
+      const dy = (y / (size - 1)) * 2 - 1;
+      const distance = Math.sqrt(dx * dx + dy * dy);
+      const alpha = Math.max(0, Math.min(1, 1 - distance));
+
+      pixels[index] = color[0];
+      pixels[index + 1] = color[1];
+      pixels[index + 2] = color[2];
+      pixels[index + 3] = Math.round(alpha * 255);
+    }
+  }
+
+  const texture = new DataTexture(pixels, size, size);
+  texture.needsUpdate = true;
+  texture.colorSpace = SRGBColorSpace;
+  texture.wrapS = RepeatWrapping;
+  texture.wrapT = RepeatWrapping;
+  texture.name = "pod-fallback-sprite";
+  return texture;
+}
+
+function hashColor(input: string): [number, number, number] {
+  let hash = 2166136261;
+  for (let index = 0; index < input.length; index += 1) {
+    hash ^= input.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+
+  return [
+    96 + (hash & 0x7f),
+    96 + ((hash >> 8) & 0x7f),
+    96 + ((hash >> 16) & 0x7f)
+  ];
+}

--- a/apps/pod-web/src/contracts.ts
+++ b/apps/pod-web/src/contracts.ts
@@ -1,0 +1,156 @@
+export type Vec3Tuple = [number, number, number];
+export type Vec4Tuple = [number, number, number, number];
+export type RgbaTuple = [number, number, number, number];
+
+export interface CameraState {
+  x: number;
+  y: number;
+  zoom: number;
+  rotation: number;
+  viewportWidth: number;
+  viewportHeight: number;
+}
+
+export interface RenderCommand {
+  type: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  rotation: number;
+  scaleX: number;
+  scaleY: number;
+  color: RgbaTuple;
+  alpha: number;
+  texture?: string;
+  frame?: number;
+  mesh?: string;
+  material?: string;
+  z?: number;
+  transform3d?: {
+    position: Vec3Tuple;
+    rotation: Vec4Tuple;
+    scale: Vec3Tuple;
+  };
+  billboard?: boolean;
+  castShadows?: boolean;
+  receiveShadows?: boolean;
+  transparent?: boolean;
+  doubleSided?: boolean;
+  roughness?: number;
+  metallic?: number;
+  emissive?: Vec3Tuple;
+  layer: number;
+  visible: boolean;
+  sourceEntity?: number;
+}
+
+export interface RenderFrame {
+  camera: CameraState;
+  commands: RenderCommand[];
+  backgroundColor: RgbaTuple;
+}
+
+export interface ThreeJsInstance {
+  position: Vec3Tuple;
+  rotation: Vec4Tuple;
+  scale: Vec3Tuple;
+  color?: RgbaTuple;
+  sourceEntity?: number;
+}
+
+export type ThreeJsRenderPhase = "opaque" | "transparent";
+
+export interface ThreeJsMeshBatch {
+  mesh: string;
+  material: string;
+  layer: number;
+  phase: ThreeJsRenderPhase;
+  sortDepth: number;
+  renderOrder: number;
+  transparent: boolean;
+  doubleSided: boolean;
+  castShadows: boolean;
+  receiveShadows: boolean;
+  tint: RgbaTuple;
+  roughness: number;
+  metallic: number;
+  emissive: Vec3Tuple;
+  depthWrite: boolean;
+  depthTest: boolean;
+  instances: ThreeJsInstance[];
+}
+
+export interface ThreeJsSpriteBatch {
+  texture: string;
+  frame: number;
+  layer: number;
+  billboard: boolean;
+  phase: ThreeJsRenderPhase;
+  sortDepth: number;
+  renderOrder: number;
+  transparent: boolean;
+  depthWrite: boolean;
+  depthTest: boolean;
+  instances: ThreeJsInstance[];
+}
+
+export interface ThreeJsWebGpuHints {
+  renderer: string;
+  preferredBackend: string;
+  fallbackBackend: string;
+  useInstancing: boolean;
+  sortMetric: string;
+  sortOpaqueFrontToBack: boolean;
+  preserveInstanceOrder: boolean;
+  sortTransparentBackToFront: boolean;
+  transparentInstancingStrategy: string;
+  opaqueDepthWrite: boolean;
+  transparentDepthWrite: boolean;
+  maxPixelRatio: number;
+}
+
+export interface ThreeJsWebGpuFrame {
+  camera: CameraState;
+  backgroundColor: RgbaTuple;
+  overlayCommands: RenderCommand[];
+  meshBatches: ThreeJsMeshBatch[];
+  spriteBatches: ThreeJsSpriteBatch[];
+  hints: ThreeJsWebGpuHints;
+}
+
+export function parseThreeJsWebGpuFrame(
+  frame: string | ThreeJsWebGpuFrame
+): ThreeJsWebGpuFrame {
+  return typeof frame === "string"
+    ? (JSON.parse(frame) as ThreeJsWebGpuFrame)
+    : frame;
+}
+
+export function parseRenderFrame(frame: string | RenderFrame): RenderFrame {
+  return typeof frame === "string" ? (JSON.parse(frame) as RenderFrame) : frame;
+}
+
+export function legacyFrameToThreeJsFrame(frame: RenderFrame): ThreeJsWebGpuFrame {
+  return {
+    camera: frame.camera,
+    backgroundColor: frame.backgroundColor,
+    overlayCommands: frame.commands.filter((command) => command.visible),
+    meshBatches: [],
+    spriteBatches: [],
+    hints: {
+      renderer: "three/webgpu",
+      preferredBackend: "webgpu",
+      fallbackBackend: "webgl2",
+      useInstancing: true,
+      sortMetric: "world-z",
+      sortOpaqueFrontToBack: true,
+      preserveInstanceOrder: true,
+      sortTransparentBackToFront: true,
+      transparentInstancingStrategy: "shared-sort-depth",
+      opaqueDepthWrite: true,
+      transparentDepthWrite: false,
+      maxPixelRatio: 2
+    }
+  };
+}

--- a/apps/pod-web/src/frame-plan.test.ts
+++ b/apps/pod-web/src/frame-plan.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ThreeJsWebGpuFrame } from "./contracts";
+import { buildCameraPose, buildFramePlan, splitSpriteBatchesByTint } from "./frame-plan";
+
+describe("buildCameraPose", () => {
+  test("maps 2D camera target and zoom into a perspective rig", () => {
+    const pose = buildCameraPose({
+      x: 24,
+      y: -10,
+      zoom: 2,
+      rotation: Math.PI / 2,
+      viewportWidth: 1280,
+      viewportHeight: 720
+    });
+
+    expect(pose.target).toEqual([24, 0, -10]);
+    expect(pose.position[0]).toBeGreaterThan(24);
+    expect(pose.position[2]).toBeCloseTo(-10, 5);
+    expect(pose.position[1]).toBeGreaterThan(0);
+  });
+});
+
+describe("splitSpriteBatchesByTint", () => {
+  test("keeps per-instance alpha by splitting tint groups", () => {
+    const [batch] = splitSpriteBatchesByTint([
+      {
+        texture: "mist",
+        frame: 0,
+        layer: 2,
+        billboard: true,
+        phase: "transparent",
+        sortDepth: 14,
+        renderOrder: 6,
+        transparent: true,
+        depthWrite: false,
+        depthTest: true,
+        instances: [
+          {
+            position: [0, 0, 14],
+            rotation: [0, 0, 0, 1],
+            scale: [2, 2, 1],
+            color: [1, 1, 1, 0.25]
+          },
+          {
+            position: [4, 0, 14],
+            rotation: [0, 0, 0, 1],
+            scale: [2, 2, 1],
+            color: [0.5, 1, 0.75, 0.4]
+          }
+        ]
+      }
+    ]);
+
+    const groups = splitSpriteBatchesByTint([
+      {
+        texture: "mist",
+        frame: 0,
+        layer: 2,
+        billboard: true,
+        phase: "transparent",
+        sortDepth: 14,
+        renderOrder: 6,
+        transparent: true,
+        depthWrite: false,
+        depthTest: true,
+        instances: [
+          {
+            position: [0, 0, 14],
+            rotation: [0, 0, 0, 1],
+            scale: [2, 2, 1],
+            color: [1, 1, 1, 0.25]
+          },
+          {
+            position: [4, 0, 14],
+            rotation: [0, 0, 0, 1],
+            scale: [2, 2, 1],
+            color: [0.5, 1, 0.75, 0.4]
+          }
+        ]
+      }
+    ]);
+
+    expect(groups).toHaveLength(2);
+    expect(batch.batch.renderOrder).toBe(6);
+    expect(groups[0]?.tint[3]).toBeGreaterThan(0);
+    expect(groups[1]?.tint[3]).toBeGreaterThan(groups[0]?.tint[3] ?? 0);
+  });
+});
+
+describe("buildFramePlan", () => {
+  test("preserves transparent render ordering from the Rust bridge", () => {
+    const frame: ThreeJsWebGpuFrame = {
+      camera: {
+        x: 0,
+        y: 0,
+        zoom: 1,
+        rotation: 0,
+        viewportWidth: 1280,
+        viewportHeight: 720
+      },
+      backgroundColor: [0, 0, 0, 1],
+      overlayCommands: [],
+      meshBatches: [
+        {
+          mesh: "glass",
+          material: "aether",
+          layer: 1,
+          phase: "transparent",
+          sortDepth: 24,
+          renderOrder: 0,
+          transparent: true,
+          doubleSided: true,
+          castShadows: false,
+          receiveShadows: true,
+          tint: [0.5, 0.7, 1, 0.35],
+          roughness: 0.2,
+          metallic: 0.1,
+          emissive: [0.1, 0.2, 0.3],
+          depthWrite: false,
+          depthTest: true,
+          instances: [
+            {
+              position: [0, 0, 24],
+              rotation: [0, 0, 0, 1],
+              scale: [1, 1, 1]
+            }
+          ]
+        }
+      ],
+      spriteBatches: [
+        {
+          texture: "mist",
+          frame: 0,
+          layer: 2,
+          billboard: true,
+          phase: "transparent",
+          sortDepth: 18,
+          renderOrder: 1,
+          transparent: true,
+          depthWrite: false,
+          depthTest: true,
+          instances: [
+            {
+              position: [0, 0, 18],
+              rotation: [0, 0, 0, 1],
+              scale: [2, 2, 1],
+              color: [1, 1, 1, 0.25]
+            }
+          ]
+        }
+      ],
+      hints: {
+        renderer: "three/webgpu",
+        preferredBackend: "webgpu",
+        fallbackBackend: "webgl2",
+        useInstancing: true,
+        sortMetric: "world-z",
+        sortOpaqueFrontToBack: true,
+        preserveInstanceOrder: true,
+        sortTransparentBackToFront: true,
+        transparentInstancingStrategy: "shared-sort-depth",
+        opaqueDepthWrite: true,
+        transparentDepthWrite: false,
+        maxPixelRatio: 2
+      }
+    };
+
+    const plan = buildFramePlan(frame);
+    expect(plan.meshBatches).toHaveLength(1);
+    expect(plan.spriteBatches).toHaveLength(1);
+    expect(plan.meshBatches[0]?.batch.renderOrder).toBe(0);
+    expect(plan.spriteBatches[0]?.batch.renderOrder).toBe(1);
+    expect(plan.spriteBatches[0]?.matrices).toHaveLength(1);
+  });
+});

--- a/apps/pod-web/src/frame-plan.ts
+++ b/apps/pod-web/src/frame-plan.ts
@@ -1,0 +1,206 @@
+import { Matrix4, Quaternion, Vector3 } from "three";
+
+import type {
+  CameraState,
+  RgbaTuple,
+  ThreeJsInstance,
+  ThreeJsMeshBatch,
+  ThreeJsSpriteBatch,
+  ThreeJsWebGpuFrame
+} from "./contracts";
+
+const DEFAULT_UP = new Vector3(0, 1, 0);
+
+export interface PodThreeCameraRigOptions {
+  pitch?: number;
+  height?: number;
+  baseDistance?: number;
+  minDistance?: number;
+  maxDistance?: number;
+  fov?: number;
+  near?: number;
+  far?: number;
+}
+
+export interface PlannedCameraPose {
+  position: [number, number, number];
+  target: [number, number, number];
+  quaternion: Quaternion;
+  fov: number;
+  near: number;
+  far: number;
+}
+
+export interface PlannedMeshBatch {
+  key: string;
+  batch: ThreeJsMeshBatch;
+  matrices: Matrix4[];
+}
+
+export interface PlannedSpriteBatch {
+  key: string;
+  batch: Omit<ThreeJsSpriteBatch, "instances">;
+  tint: RgbaTuple;
+  instances: ThreeJsInstance[];
+  matrices: Matrix4[];
+}
+
+export interface PlannedFrame {
+  camera: PlannedCameraPose;
+  meshBatches: PlannedMeshBatch[];
+  spriteBatches: PlannedSpriteBatch[];
+}
+
+export function buildCameraPose(
+  camera: CameraState,
+  options: PodThreeCameraRigOptions = {}
+): PlannedCameraPose {
+  const pitch = options.pitch ?? Math.PI / 5;
+  const baseDistance = options.baseDistance ?? 54;
+  const minDistance = options.minDistance ?? 12;
+  const maxDistance = options.maxDistance ?? 180;
+  const distance = clamp(baseDistance / Math.max(camera.zoom, 0.15), minDistance, maxDistance);
+  const heightOffset = options.height ?? 12;
+  const target = new Vector3(camera.x, 0, camera.y);
+  const azimuth = camera.rotation;
+  const horizontalDistance = Math.cos(pitch) * distance;
+  const position = new Vector3(
+    target.x + Math.sin(azimuth) * horizontalDistance,
+    target.y + Math.sin(pitch) * distance + heightOffset,
+    target.z + Math.cos(azimuth) * horizontalDistance
+  );
+  const quaternion = new Quaternion().setFromRotationMatrix(
+    new Matrix4().lookAt(position, target, DEFAULT_UP)
+  );
+
+  return {
+    position: position.toArray(),
+    target: target.toArray(),
+    quaternion,
+    fov: options.fov ?? 55,
+    near: options.near ?? 0.1,
+    far: options.far ?? 1024
+  };
+}
+
+export function buildFramePlan(
+  frame: ThreeJsWebGpuFrame,
+  options: PodThreeCameraRigOptions = {}
+): PlannedFrame {
+  const camera = buildCameraPose(frame.camera, options);
+
+  return {
+    camera,
+    meshBatches: frame.meshBatches.map((batch) => ({
+      key: createMeshBatchKey(batch),
+      batch,
+      matrices: batch.instances.map((instance) => composeInstanceMatrix(instance))
+    })),
+    spriteBatches: splitSpriteBatchesByTint(frame.spriteBatches).map((batch) => ({
+      ...batch,
+      matrices: batch.instances.map((instance) =>
+        composeInstanceMatrix(
+          instance,
+          batch.batch.billboard ? camera.quaternion : undefined
+        )
+      )
+    }))
+  };
+}
+
+export function splitSpriteBatchesByTint(
+  batches: ThreeJsSpriteBatch[]
+): Array<Omit<PlannedSpriteBatch, "matrices">> {
+  const planned = new Array<Omit<PlannedSpriteBatch, "matrices">>();
+
+  for (const batch of batches) {
+    const groups = new Map<string, { tint: RgbaTuple; instances: ThreeJsInstance[] }>();
+
+    for (const instance of batch.instances) {
+      const tint = instance.color ?? [1, 1, 1, 1];
+      const key = tint.map((channel) => channel.toFixed(4)).join(":");
+      const group = groups.get(key);
+
+      if (group) {
+        group.instances.push(instance);
+      } else {
+        groups.set(key, { tint, instances: [instance] });
+      }
+    }
+
+    let tintIndex = 0;
+    for (const { tint, instances } of groups.values()) {
+      planned.push({
+        key: `${createSpriteBatchKey(batch)}:tint:${tintIndex}:${tint
+          .map((channel) => channel.toFixed(4))
+          .join("-")}`,
+        batch: {
+          texture: batch.texture,
+          frame: batch.frame,
+          layer: batch.layer,
+          billboard: batch.billboard,
+          phase: batch.phase,
+          sortDepth: batch.sortDepth,
+          renderOrder: batch.renderOrder,
+          transparent: batch.transparent || tint[3] < 0.999,
+          depthWrite: batch.transparent || tint[3] < 0.999 ? false : batch.depthWrite,
+          depthTest: batch.depthTest
+        },
+        tint,
+        instances
+      });
+      tintIndex += 1;
+    }
+  }
+
+  planned.sort((left, right) => {
+    if (left.batch.renderOrder !== right.batch.renderOrder) {
+      return left.batch.renderOrder - right.batch.renderOrder;
+    }
+
+    return left.key.localeCompare(right.key);
+  });
+
+  return planned;
+}
+
+export function composeInstanceMatrix(
+  instance: ThreeJsInstance,
+  rotationOverride?: Quaternion
+): Matrix4 {
+  const matrix = new Matrix4();
+  matrix.compose(
+    new Vector3(...instance.position),
+    rotationOverride ?? new Quaternion(...instance.rotation),
+    new Vector3(...instance.scale)
+  );
+  return matrix;
+}
+
+function createMeshBatchKey(batch: ThreeJsMeshBatch): string {
+  return [
+    "mesh",
+    batch.mesh,
+    batch.material,
+    batch.layer,
+    batch.renderOrder,
+    batch.phase,
+    batch.transparent ? "transparent" : "opaque"
+  ].join(":");
+}
+
+function createSpriteBatchKey(batch: ThreeJsSpriteBatch): string {
+  return [
+    "sprite",
+    batch.texture,
+    batch.frame,
+    batch.layer,
+    batch.renderOrder,
+    batch.phase,
+    batch.billboard ? "billboard" : "flat"
+  ].join(":");
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}

--- a/apps/pod-web/src/main.ts
+++ b/apps/pod-web/src/main.ts
@@ -1,0 +1,67 @@
+import { parseRenderFrame, parseThreeJsWebGpuFrame } from "./contracts";
+import { PodThreeWorldRenderer } from "./renderer";
+import { createDemoFrame } from "./sample-frame";
+
+declare global {
+  interface Window {
+    podRender: {
+      render: (frame: string) => void;
+      renderThreeJsWebGpuFrame: (frame: string) => void;
+      resetDemo: () => void;
+      getBackend: () => string;
+    };
+  }
+}
+
+const canvas = document.querySelector<HTMLCanvasElement>("#pod-web-canvas");
+const backendLabel = document.querySelector<HTMLElement>("#backend-label");
+const frameSourceLabel = document.querySelector<HTMLElement>("#frame-source");
+
+if (!canvas || !backendLabel || !frameSourceLabel) {
+  throw new Error("pod-web bootstrap failed: required DOM nodes are missing");
+}
+
+const renderer = await PodThreeWorldRenderer.create(canvas);
+backendLabel.textContent = renderer.backend;
+
+let liveFrameSource: "demo" | "legacy" | "threejs" = "demo";
+let latestFrameJson: string | null = null;
+
+window.podRender = {
+  render(frame: string) {
+    latestFrameJson = frame;
+    liveFrameSource = "legacy";
+    frameSourceLabel.textContent = "legacy pod-render frame";
+  },
+  renderThreeJsWebGpuFrame(frame: string) {
+    latestFrameJson = frame;
+    liveFrameSource = "threejs";
+    frameSourceLabel.textContent = "Three.js WebGPU frame";
+  },
+  resetDemo() {
+    latestFrameJson = null;
+    liveFrameSource = "demo";
+    frameSourceLabel.textContent = "demo frame";
+  },
+  getBackend() {
+    return renderer.backend;
+  }
+};
+
+async function tick(timestamp: number): Promise<void> {
+  if (latestFrameJson) {
+    if (liveFrameSource === "threejs") {
+      await renderer.applyFrame(parseThreeJsWebGpuFrame(latestFrameJson));
+    } else {
+      await renderer.applyLegacyFrame(parseRenderFrame(latestFrameJson));
+    }
+  } else {
+    await renderer.applyFrame(createDemoFrame(timestamp / 1000));
+  }
+
+  requestAnimationFrame((nextTimestamp) => {
+    void tick(nextTimestamp);
+  });
+}
+
+void tick(performance.now());

--- a/apps/pod-web/src/renderer.ts
+++ b/apps/pod-web/src/renderer.ts
@@ -1,0 +1,468 @@
+import * as THREE from "three";
+
+import {
+  createMeshMaterial,
+  createSpriteMaterial,
+  DefaultPodThreeAssetRegistry,
+  OVERLAY_PLANE_GEOMETRY,
+  SPRITE_PLANE_GEOMETRY,
+  type PodThreeAssetRegistry
+} from "./assets";
+import {
+  buildCameraPose,
+  buildFramePlan,
+  type PodThreeCameraRigOptions,
+  type PlannedMeshBatch,
+  type PlannedSpriteBatch
+} from "./frame-plan";
+import {
+  legacyFrameToThreeJsFrame,
+  type RenderCommand,
+  type RenderFrame,
+  type ThreeJsWebGpuFrame
+} from "./contracts";
+
+type RuntimeRenderer = THREE.WebGLRenderer & {
+  init?: () => Promise<void>;
+  backend?: { isWebGPUBackend?: boolean };
+  renderAsync?: (scene: THREE.Scene, camera: THREE.Camera) => Promise<void>;
+};
+
+interface InstancedEntry {
+  capacity: number;
+  mesh: THREE.InstancedMesh;
+  material: THREE.Material;
+}
+
+export interface PodThreeWorldRendererOptions {
+  assetRegistry?: PodThreeAssetRegistry;
+  cameraRig?: PodThreeCameraRigOptions;
+  clearColor?: number;
+  enableShadows?: boolean;
+  showGrid?: boolean;
+  maxPixelRatio?: number;
+}
+
+export class PodThreeWorldRenderer {
+  static async create(
+    canvas: HTMLCanvasElement,
+    options: PodThreeWorldRendererOptions = {}
+  ): Promise<PodThreeWorldRenderer> {
+    const { renderer, backend } = await createRenderer(canvas, options);
+    return new PodThreeWorldRenderer(canvas, renderer, backend, options);
+  }
+
+  readonly scene = new THREE.Scene();
+  readonly overlayScene = new THREE.Scene();
+  readonly camera = new THREE.PerspectiveCamera(55, 1, 0.1, 1024);
+  readonly overlayCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, -10, 10);
+  readonly assetRegistry: PodThreeAssetRegistry;
+  readonly backend: "webgpu" | "webgl2";
+
+  private readonly meshEntries = new Map<string, InstancedEntry>();
+  private readonly spriteEntries = new Map<string, InstancedEntry>();
+  private readonly overlayObjects = new Array<THREE.Object3D>();
+  private readonly resizeObserver: ResizeObserver;
+  private readonly options: Required<Pick<PodThreeWorldRendererOptions, "showGrid" | "enableShadows">> &
+    Omit<PodThreeWorldRendererOptions, "showGrid" | "enableShadows">;
+
+  constructor(
+    private readonly canvas: HTMLCanvasElement,
+    private readonly renderer: RuntimeRenderer,
+    backend: "webgpu" | "webgl2",
+    options: PodThreeWorldRendererOptions
+  ) {
+    this.backend = backend;
+    this.assetRegistry = options.assetRegistry ?? new DefaultPodThreeAssetRegistry();
+    this.options = {
+      ...options,
+      showGrid: options.showGrid ?? true,
+      enableShadows: options.enableShadows ?? true
+    };
+
+    this.bootstrapScenes();
+    this.resizeObserver = new ResizeObserver(() => this.resize());
+    this.resizeObserver.observe(canvas);
+    this.resize();
+  }
+
+  async applyFrame(frame: ThreeJsWebGpuFrame): Promise<void> {
+    this.scene.background = new THREE.Color(...frame.backgroundColor.slice(0, 3));
+
+    const planned = buildFramePlan(frame, this.options.cameraRig);
+    this.applyCamera(planned.camera, frame.camera);
+    await this.syncMeshBatches(planned.meshBatches);
+    await this.syncSpriteBatches(planned.spriteBatches);
+    await this.syncOverlay(frame.overlayCommands);
+    await this.renderFrame();
+  }
+
+  async applyLegacyFrame(frame: RenderFrame): Promise<void> {
+    await this.applyFrame(legacyFrameToThreeJsFrame(frame));
+  }
+
+  dispose(): void {
+    this.resizeObserver.disconnect();
+
+    for (const entry of this.meshEntries.values()) {
+      disposeInstancedEntry(entry);
+    }
+    for (const entry of this.spriteEntries.values()) {
+      disposeInstancedEntry(entry);
+    }
+
+    this.clearOverlay();
+    this.renderer.dispose();
+  }
+
+  private bootstrapScenes(): void {
+    this.scene.fog = new THREE.Fog(0x09111b, 28, 180);
+
+    const hemisphere = new THREE.HemisphereLight(0xa8d1ff, 0x14263f, 1.2);
+    this.scene.add(hemisphere);
+
+    const sun = new THREE.DirectionalLight(0xfff0cf, 2.6);
+    sun.position.set(24, 42, 18);
+    sun.castShadow = this.options.enableShadows;
+    sun.shadow.mapSize.set(2048, 2048);
+    sun.shadow.camera.near = 1;
+    sun.shadow.camera.far = 160;
+    sun.shadow.camera.left = -60;
+    sun.shadow.camera.right = 60;
+    sun.shadow.camera.top = 60;
+    sun.shadow.camera.bottom = -60;
+    this.scene.add(sun);
+
+    const fill = new THREE.DirectionalLight(0x6cbcff, 0.7);
+    fill.position.set(-18, 14, -10);
+    this.scene.add(fill);
+
+    const ground = new THREE.Mesh(
+      new THREE.CircleGeometry(140, 64),
+      new THREE.MeshStandardMaterial({
+        color: 0x0e1724,
+        roughness: 0.95,
+        metalness: 0.02
+      })
+    );
+    ground.rotation.x = -Math.PI / 2;
+    ground.receiveShadow = true;
+    this.scene.add(ground);
+
+    if (this.options.showGrid) {
+      const grid = new THREE.GridHelper(180, 60, 0x5fa7ff, 0x173049);
+      grid.position.y = 0.02;
+      this.scene.add(grid);
+    }
+
+    this.overlayScene.background = null;
+    this.overlayCamera.position.set(0, 0, 5);
+    this.overlayCamera.lookAt(0, 0, 0);
+  }
+
+  private applyCamera(
+    pose: ReturnType<typeof buildCameraPose>,
+    frameCamera: ThreeJsWebGpuFrame["camera"]
+  ): void {
+    this.camera.position.set(...pose.position);
+    this.camera.quaternion.copy(pose.quaternion);
+    this.camera.fov = pose.fov;
+    this.camera.near = pose.near;
+    this.camera.far = pose.far;
+    this.camera.lookAt(...pose.target);
+    this.camera.updateProjectionMatrix();
+
+    const halfWidth = frameCamera.viewportWidth / 2;
+    const halfHeight = frameCamera.viewportHeight / 2;
+    this.overlayCamera.left = -halfWidth;
+    this.overlayCamera.right = halfWidth;
+    this.overlayCamera.top = halfHeight;
+    this.overlayCamera.bottom = -halfHeight;
+    this.overlayCamera.position.set(frameCamera.x, frameCamera.y, 5);
+    this.overlayCamera.zoom = Math.max(frameCamera.zoom, 0.1);
+    this.overlayCamera.rotation.z = frameCamera.rotation;
+    this.overlayCamera.updateProjectionMatrix();
+  }
+
+  private async syncMeshBatches(batches: PlannedMeshBatch[]): Promise<void> {
+    const activeKeys = new Set<string>();
+
+    for (const planned of batches) {
+      activeKeys.add(planned.key);
+      const geometry = await this.assetRegistry.resolveGeometry(planned.batch);
+      const material =
+        (await this.assetRegistry.resolveMeshMaterial?.(planned.batch)) ??
+        createMeshMaterial(planned.batch);
+      const existing = this.meshEntries.get(planned.key);
+      const entry = ensureInstancedEntry(
+        this.scene,
+        existing,
+        geometry,
+        material,
+        planned.matrices.length,
+        planned.key
+      );
+
+      entry.mesh.castShadow = planned.batch.castShadows;
+      entry.mesh.receiveShadow = planned.batch.receiveShadows;
+      entry.mesh.count = planned.matrices.length;
+      entry.mesh.renderOrder = planned.batch.renderOrder;
+      entry.mesh.visible = true;
+      entry.mesh.name = planned.key;
+      entry.mesh.frustumCulled = false;
+
+      for (let index = 0; index < planned.matrices.length; index += 1) {
+        entry.mesh.setMatrixAt(index, planned.matrices[index]);
+      }
+      entry.mesh.instanceMatrix.needsUpdate = true;
+      this.meshEntries.set(planned.key, entry);
+    }
+
+    cleanupUnusedEntries(this.scene, this.meshEntries, activeKeys);
+  }
+
+  private async syncSpriteBatches(batches: PlannedSpriteBatch[]): Promise<void> {
+    const activeKeys = new Set<string>();
+
+    for (const planned of batches) {
+      activeKeys.add(planned.key);
+      const resolved = await this.assetRegistry.resolveSpriteTexture({
+        texture: planned.batch.texture,
+        frame: planned.batch.frame
+      });
+      const material = createSpriteMaterial(
+        resolved,
+        planned.tint,
+        planned.batch.transparent,
+        planned.batch.depthWrite,
+        planned.batch.depthTest,
+        THREE.DoubleSide
+      );
+
+      const existing = this.spriteEntries.get(planned.key);
+      const entry = ensureInstancedEntry(
+        this.scene,
+        existing,
+        SPRITE_PLANE_GEOMETRY,
+        material,
+        planned.matrices.length,
+        planned.key
+      );
+
+      entry.mesh.castShadow = false;
+      entry.mesh.receiveShadow = false;
+      entry.mesh.count = planned.matrices.length;
+      entry.mesh.renderOrder = planned.batch.renderOrder;
+      entry.mesh.visible = true;
+      entry.mesh.frustumCulled = false;
+
+      for (let index = 0; index < planned.matrices.length; index += 1) {
+        entry.mesh.setMatrixAt(index, planned.matrices[index]);
+      }
+      entry.mesh.instanceMatrix.needsUpdate = true;
+      this.spriteEntries.set(planned.key, entry);
+    }
+
+    cleanupUnusedEntries(this.scene, this.spriteEntries, activeKeys);
+  }
+
+  private async syncOverlay(commands: RenderCommand[]): Promise<void> {
+    this.clearOverlay();
+
+    for (const command of commands) {
+      if (!command.visible) {
+        continue;
+      }
+
+      if (command.type === "rect") {
+        const rect = new THREE.Mesh(
+          OVERLAY_PLANE_GEOMETRY,
+          new THREE.MeshBasicMaterial({
+            color: new THREE.Color(
+              command.color[0],
+              command.color[1],
+              command.color[2]
+            ),
+            transparent: command.alpha < 0.999,
+            opacity: command.alpha,
+            depthWrite: false
+          })
+        );
+        rect.position.set(command.x, command.y, command.layer * 0.01);
+        rect.rotation.z = command.rotation;
+        rect.scale.set(command.width * command.scaleX, command.height * command.scaleY, 1);
+        this.overlayScene.add(rect);
+        this.overlayObjects.push(rect);
+        continue;
+      }
+
+      if (command.type === "sprite" && command.texture) {
+        const resolved = await this.assetRegistry.resolveSpriteTexture({
+          texture: command.texture,
+          frame: command.frame ?? 0
+        });
+        const sprite = new THREE.Mesh(
+          OVERLAY_PLANE_GEOMETRY,
+          createSpriteMaterial(
+            resolved,
+            command.color,
+            command.alpha < 0.999,
+            false,
+            true,
+            THREE.DoubleSide
+          )
+        );
+        sprite.position.set(command.x, command.y, command.layer * 0.01);
+        sprite.rotation.z = command.rotation;
+        sprite.scale.set(
+          Math.max(command.width * command.scaleX, 0.0001),
+          Math.max(command.height * command.scaleY, 0.0001),
+          1
+        );
+        this.overlayScene.add(sprite);
+        this.overlayObjects.push(sprite);
+      }
+    }
+  }
+
+  private clearOverlay(): void {
+    for (const object of this.overlayObjects) {
+      this.overlayScene.remove(object);
+      disposeObject(object);
+    }
+    this.overlayObjects.length = 0;
+  }
+
+  private async renderFrame(): Promise<void> {
+    await renderWithFallback(this.renderer, this.scene, this.camera);
+    this.renderer.clearDepth();
+    await renderWithFallback(this.renderer, this.overlayScene, this.overlayCamera);
+  }
+
+  private resize(): void {
+    const width = this.canvas.clientWidth || window.innerWidth;
+    const height = this.canvas.clientHeight || window.innerHeight;
+    const pixelRatio = Math.min(window.devicePixelRatio, this.options.maxPixelRatio ?? 2);
+    this.renderer.setPixelRatio(pixelRatio);
+    this.renderer.setSize(width, height, false);
+    this.camera.aspect = width / Math.max(height, 1);
+    this.camera.updateProjectionMatrix();
+  }
+}
+
+async function createRenderer(
+  canvas: HTMLCanvasElement,
+  options: PodThreeWorldRendererOptions
+): Promise<{ renderer: RuntimeRenderer; backend: "webgpu" | "webgl2" }> {
+  if ("gpu" in navigator) {
+    try {
+      const webgpuModule = await import("three/webgpu");
+      const renderer = new webgpuModule.WebGPURenderer({
+        canvas,
+        antialias: true,
+        alpha: false,
+        powerPreference: "high-performance"
+      }) as RuntimeRenderer;
+      await renderer.init?.();
+      renderer.shadowMap.enabled = options.enableShadows ?? true;
+      renderer.outputColorSpace = THREE.SRGBColorSpace;
+      return { renderer, backend: "webgpu" };
+    } catch (error) {
+      console.warn("Falling back to WebGL2 renderer", error);
+    }
+  }
+
+  const renderer = new THREE.WebGLRenderer({
+    canvas,
+    antialias: true,
+    alpha: false,
+    powerPreference: "high-performance"
+  }) as RuntimeRenderer;
+  renderer.shadowMap.enabled = options.enableShadows ?? true;
+  renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+  renderer.outputColorSpace = THREE.SRGBColorSpace;
+  return { renderer, backend: "webgl2" };
+}
+
+async function renderWithFallback(
+  renderer: RuntimeRenderer,
+  scene: THREE.Scene,
+  camera: THREE.Camera
+): Promise<void> {
+  await Promise.resolve(renderer.render(scene, camera));
+}
+
+function ensureInstancedEntry(
+  scene: THREE.Scene,
+  existing: InstancedEntry | undefined,
+  geometry: THREE.BufferGeometry,
+  material: THREE.Material,
+  requiredCapacity: number,
+  name: string
+): InstancedEntry {
+  if (
+    existing &&
+    existing.capacity >= Math.max(requiredCapacity, 1) &&
+    existing.mesh.geometry === geometry &&
+    existing.material === material
+  ) {
+    return existing;
+  }
+
+  if (existing) {
+    scene.remove(existing.mesh);
+    disposeInstancedEntry(existing);
+  }
+
+  const mesh = new THREE.InstancedMesh(
+    geometry,
+    material,
+    Math.max(requiredCapacity, 1)
+  );
+  mesh.name = name;
+  mesh.matrixAutoUpdate = false;
+  scene.add(mesh);
+
+  return {
+    capacity: Math.max(requiredCapacity, 1),
+    mesh,
+    material
+  };
+}
+
+function cleanupUnusedEntries(
+  scene: THREE.Scene,
+  entries: Map<string, InstancedEntry>,
+  activeKeys: Set<string>
+): void {
+  for (const [key, entry] of entries) {
+    if (activeKeys.has(key)) {
+      continue;
+    }
+
+    scene.remove(entry.mesh);
+    disposeInstancedEntry(entry);
+    entries.delete(key);
+  }
+}
+
+function disposeInstancedEntry(entry: InstancedEntry): void {
+  entry.mesh.dispose();
+  entry.material.dispose();
+}
+
+function disposeObject(object: THREE.Object3D): void {
+  object.traverse((child: THREE.Object3D) => {
+    if (!(child instanceof THREE.Mesh)) {
+      return;
+    }
+
+    if (Array.isArray(child.material)) {
+      for (const material of child.material) {
+        material.dispose();
+      }
+    } else {
+      child.material.dispose();
+    }
+  });
+}

--- a/apps/pod-web/src/sample-frame.ts
+++ b/apps/pod-web/src/sample-frame.ts
@@ -1,0 +1,179 @@
+import type {
+  ThreeJsInstance,
+  ThreeJsMeshBatch,
+  ThreeJsSpriteBatch,
+  ThreeJsWebGpuFrame
+} from "./contracts";
+
+export function createDemoFrame(seconds: number): ThreeJsWebGpuFrame {
+  const orbit = seconds * 0.18;
+
+  return {
+    camera: {
+      x: Math.sin(seconds * 0.22) * 8,
+      y: Math.cos(seconds * 0.18) * 6,
+      zoom: 1.05 + Math.sin(seconds * 0.35) * 0.12,
+      rotation: orbit,
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight
+    },
+    backgroundColor: [0.05, 0.09, 0.15, 1],
+    overlayCommands: [],
+    meshBatches: createMeshBatches(seconds),
+    spriteBatches: createSpriteBatches(seconds),
+    hints: {
+      renderer: "three/webgpu",
+      preferredBackend: "webgpu",
+      fallbackBackend: "webgl2",
+      useInstancing: true,
+      sortMetric: "world-z",
+      sortOpaqueFrontToBack: true,
+      preserveInstanceOrder: true,
+      sortTransparentBackToFront: true,
+      transparentInstancingStrategy: "shared-sort-depth",
+      opaqueDepthWrite: true,
+      transparentDepthWrite: false,
+      maxPixelRatio: 2
+    }
+  };
+}
+
+function createMeshBatches(seconds: number): ThreeJsMeshBatch[] {
+  const columns = new Array<ThreeJsInstance>();
+  for (let x = -4; x <= 4; x += 1) {
+    for (let z = -4; z <= 4; z += 1) {
+      columns.push({
+        position: [x * 6, 2.6 + Math.sin(seconds + x * 0.7 + z * 0.4) * 0.35, z * 6],
+        rotation: [0, 0, 0, 1],
+        scale: [1, 1 + ((x + z + 8) % 3) * 0.25, 1]
+      });
+    }
+  }
+
+  const glassNear: ThreeJsInstance[] = [
+    {
+      position: [12, 5.4, 16],
+      rotation: [0, 0, 0, 1],
+      scale: [1.8, 2.4, 1.8]
+    }
+  ];
+  const glassFar: ThreeJsInstance[] = [
+    {
+      position: [-14, 5.8, 34],
+      rotation: [0, 0, 0, 1],
+      scale: [2.1, 2.8, 2.1]
+    }
+  ];
+
+  return [
+    {
+      mesh: "basalt-column",
+      material: "obsidian",
+      layer: 0,
+      phase: "opaque",
+      sortDepth: 0,
+      renderOrder: 0,
+      transparent: false,
+      doubleSided: false,
+      castShadows: true,
+      receiveShadows: true,
+      tint: [0.19, 0.28, 0.38, 1],
+      roughness: 0.92,
+      metallic: 0.08,
+      emissive: [0.01, 0.02, 0.03],
+      depthWrite: true,
+      depthTest: true,
+      instances: columns
+    },
+    {
+      mesh: "glass-spire",
+      material: "aether-glass",
+      layer: 1,
+      phase: "transparent",
+      sortDepth: glassFar[0].position[2],
+      renderOrder: 1,
+      transparent: true,
+      doubleSided: true,
+      castShadows: false,
+      receiveShadows: true,
+      tint: [0.42, 0.78, 1, 0.42],
+      roughness: 0.08,
+      metallic: 0.12,
+      emissive: [0.07, 0.13, 0.19],
+      depthWrite: false,
+      depthTest: true,
+      instances: glassFar
+    },
+    {
+      mesh: "glass-spire",
+      material: "aether-glass",
+      layer: 1,
+      phase: "transparent",
+      sortDepth: glassNear[0].position[2],
+      renderOrder: 2,
+      transparent: true,
+      doubleSided: true,
+      castShadows: false,
+      receiveShadows: true,
+      tint: [0.42, 0.78, 1, 0.42],
+      roughness: 0.08,
+      metallic: 0.12,
+      emissive: [0.07, 0.13, 0.19],
+      depthWrite: false,
+      depthTest: true,
+      instances: glassNear
+    }
+  ];
+}
+
+function createSpriteBatches(seconds: number): ThreeJsSpriteBatch[] {
+  const shimmerAlpha = 0.34 + Math.sin(seconds * 1.5) * 0.05;
+  return [
+    {
+      texture: "mist-ring",
+      frame: 0,
+      layer: 2,
+      billboard: true,
+      phase: "transparent",
+      sortDepth: 24,
+      renderOrder: 3,
+      transparent: true,
+      depthWrite: false,
+      depthTest: true,
+      instances: [
+        {
+          position: [-8, 3.4, 24],
+          rotation: [0, 0, 0, 1],
+          scale: [7, 7, 1],
+          color: [0.58, 0.78, 1, shimmerAlpha]
+        },
+        {
+          position: [10, 4, 24],
+          rotation: [0, 0, 0, 1],
+          scale: [6.5, 6.5, 1],
+          color: [0.86, 0.96, 1, shimmerAlpha * 0.82]
+        }
+      ]
+    },
+    {
+      texture: "mist-ring",
+      frame: 0,
+      layer: 2,
+      billboard: true,
+      phase: "transparent",
+      sortDepth: 10,
+      renderOrder: 4,
+      transparent: true,
+      depthWrite: false,
+      depthTest: true,
+      instances: [
+        {
+          position: [0, 2.8, 10],
+          rotation: [0, 0, 0, 1],
+          scale: [4.5, 4.5, 1],
+          color: [0.41, 0.96, 0.82, 0.28]
+        }
+      ]
+    }
+  ];
+}

--- a/apps/pod-web/src/three-webgpu.d.ts
+++ b/apps/pod-web/src/three-webgpu.d.ts
@@ -1,0 +1,9 @@
+declare module "three/webgpu" {
+  import { Camera, Scene, WebGLRenderer } from "three";
+
+  export class WebGPURenderer extends WebGLRenderer {
+    init(): Promise<void>;
+    renderAsync(scene: Scene, camera: Camera): Promise<void>;
+    backend?: { isWebGPUBackend?: boolean };
+  }
+}

--- a/apps/pod-web/tsconfig.json
+++ b/apps/pod-web/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*.ts", "vite.config.ts"]
+}

--- a/apps/pod-web/vite.config.ts
+++ b/apps/pod-web/vite.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  server: {
+    host: "0.0.0.0",
+    port: 4173
+  }
+});

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,7 +26,7 @@ flowchart LR
     E --> I["pod-scripting"]
     E --> J["pod-animation / pod-physics / pod-spatial"]
     F --> K["Native Client"]
-    F --> L["Browser Client"]
+    F --> L["Browser Client (`apps/pod-web`)"]
     G --> K
     G --> L
     H --> M["SpacetimeDB Runtime"]
@@ -82,6 +82,8 @@ The renderer supports mixed-mode output:
 - 3D mesh draw data
 
 The render layer is downstream of the ECS world. It does not own gameplay state. Instead, it extracts render items from world components and serializes them into backend-specific draw data.
+
+`apps/pod-web` is now the concrete browser consumer for that bridge. It uses Three.js with `three/webgpu` when available, falls back to WebGL2 otherwise, consumes the batched `ThreeJsWebGpuFrame` contract, and still supports the legacy 2D `RenderFrame` path for incremental integration.
 
 ## Networking and persistence
 


### PR DESCRIPTION
## Summary
- add `apps/pod-web`, a real browser-side Three.js client for Prompt or Die
- consume both the legacy `RenderFrame` and batched `ThreeJsWebGpuFrame` browser contracts
- validate the new browser package with Bun tests, typecheck, Vite build, and a live browser smoke pass

## Validation
- cd apps/pod-web && bun run typecheck
- cd apps/pod-web && bun test
- cd apps/pod-web && bun run build
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a browser-based 3D client powered by Three.js with WebGPU rendering support and WebGL2 fallback.
  * Includes instanced mesh batching, sprite rendering, and 2D overlay capabilities.
  * Includes an interactive demo and bridge API for external frame control.

* **Documentation**
  * Updated README with quick start instructions and added workspace architecture documentation for the new client.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->