### PR TITLE
Improve pod-web quality scaling and LOD planning

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -352,5 +352,17 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cd apps/pod-web && bun test`
   - `cd apps/pod-web && bun run build`
 
-**Last updated**: Iteration 45
+### Iteration 46 — Browser Three.js Quality Scaling and LOD Pass
+
+- [x] Added hardware-aware quality profiles to `apps/pod-web` with adaptive resolution, anisotropy, shadow budgets, environment intensity, and explicit ultra/high/balanced/performance presets.
+- [x] Added CPU-side distance/frustum culling plus LOD-aware mesh instancing so the browser client can keep large authored worlds efficient without giving up high-detail near-field visuals.
+- [x] Improved the renderer baseline with ACES tone mapping, upgraded lighting/shadow defaults, cached materials, richer atmospheric dressing, correct overlay compositing, and runtime HUD stats.
+- [x] Added deterministic TypeScript coverage for LOD split/cull planning and quality profile selection, then verified the live browser client on `http://127.0.0.1:4173/` with WebGPU active.
+- [x] Suppressed the repeated upstream `THREE.TSL` inline-`Fn()` warning spam down to a single forwarded warning so the runtime console stays useful.
+- [x] Validated touched targets:
+  - `cd apps/pod-web && bun test`
+  - `cd apps/pod-web && bun run typecheck`
+  - `cd apps/pod-web && bun run build`
+
+**Last updated**: Iteration 46
 **Current focus**: Phase 8 shipping parity and Phase 9 hardening backlog

--- a/apps/pod-web/README.md
+++ b/apps/pod-web/README.md
@@ -5,8 +5,11 @@
 It consumes the `pod-render` browser frame contract and provides:
 
 - `three/webgpu` rendering with automatic WebGL2 fallback
-- instanced mesh batches for 3D authored content
+- instanced mesh batches for 3D authored content with distance LOD splitting
 - billboard sprite batches with transparent depth-order preservation
+- CPU-side frustum and distance culling before instance upload
+- adaptive resolution scaling and quality presets for different hardware classes
+- ACES tone mapping, tuned shadows, cached materials, and a richer atmospheric scene baseline
 - a 2D overlay scene for the legacy `RenderFrame` contract
 - a demo bridge via `window.podRender.*` so the app is useful before the Rust wasm entrypoint is wired in
 

--- a/apps/pod-web/index.html
+++ b/apps/pod-web/index.html
@@ -102,8 +102,12 @@
         <dl>
           <dt>Backend</dt>
           <dd id="backend-label">starting…</dd>
+          <dt>Quality</dt>
+          <dd id="quality-label">auto</dd>
           <dt>Source</dt>
           <dd id="frame-source">demo frame</dd>
+          <dt>Stats</dt>
+          <dd id="stats-label">warming up…</dd>
           <dt>Bridge</dt>
           <dd><code>window.podRender.renderThreeJsWebGpuFrame(...)</code></dd>
         </dl>

--- a/apps/pod-web/src/assets.ts
+++ b/apps/pod-web/src/assets.ts
@@ -16,6 +16,7 @@ import {
 import type { BufferGeometry, Material, Side } from "three";
 
 import type { RgbaTuple, ThreeJsMeshBatch, ThreeJsSpriteBatch } from "./contracts";
+import type { PodThreeQualityProfile } from "./quality";
 
 export interface ResolvedSpriteTexture {
   texture: Texture;
@@ -24,10 +25,18 @@ export interface ResolvedSpriteTexture {
 }
 
 export interface PodThreeAssetRegistry {
-  resolveGeometry(batch: ThreeJsMeshBatch): BufferGeometry | Promise<BufferGeometry>;
-  resolveMeshMaterial?(batch: ThreeJsMeshBatch): Material | Promise<Material>;
+  resolveGeometry(
+    batch: ThreeJsMeshBatch,
+    lodLevel?: 0 | 1 | 2
+  ): BufferGeometry | Promise<BufferGeometry>;
+  resolveMeshMaterial?(
+    batch: ThreeJsMeshBatch,
+    lodLevel?: 0 | 1 | 2,
+    quality?: PodThreeQualityProfile
+  ): Material | Promise<Material>;
   resolveSpriteTexture(
-    batch: Pick<ThreeJsSpriteBatch, "texture" | "frame">
+    batch: Pick<ThreeJsSpriteBatch, "texture" | "frame">,
+    anisotropy?: number
   ): ResolvedSpriteTexture | Promise<ResolvedSpriteTexture>;
 }
 
@@ -35,8 +44,9 @@ export class DefaultPodThreeAssetRegistry implements PodThreeAssetRegistry {
   private geometryCache = new Map<string, BufferGeometry>();
   private textureCache = new Map<string, Texture>();
 
-  resolveGeometry(batch: ThreeJsMeshBatch): BufferGeometry {
-    const cached = this.geometryCache.get(batch.mesh);
+  resolveGeometry(batch: ThreeJsMeshBatch, lodLevel: 0 | 1 | 2 = 0): BufferGeometry {
+    const cacheKey = `${batch.mesh}:lod:${lodLevel}`;
+    const cached = this.geometryCache.get(cacheKey);
     if (cached) {
       return cached;
     }
@@ -45,39 +55,58 @@ export class DefaultPodThreeAssetRegistry implements PodThreeAssetRegistry {
     let geometry: BufferGeometry;
 
     if (meshName.includes("spire") || meshName.includes("obelisk") || meshName.includes("spike")) {
-      geometry = new ConeGeometry(1.2, 4.8, 6);
+      geometry = new ConeGeometry(1.2, 4.8, lodSegments([20, 12, 6], lodLevel));
     } else if (meshName.includes("rock") || meshName.includes("boulder")) {
-      geometry = new DodecahedronGeometry(1.35, 0);
+      geometry =
+        lodLevel === 0
+          ? new DodecahedronGeometry(1.35, 1)
+          : lodLevel === 1
+            ? new DodecahedronGeometry(1.35, 0)
+            : new BoxGeometry(2.2, 1.8, 1.9);
     } else if (
       meshName.includes("column") ||
       meshName.includes("tower") ||
       meshName.includes("pillar")
     ) {
-      geometry = new CylinderGeometry(0.65, 0.9, 5.2, 12);
+      geometry = new CylinderGeometry(
+        0.65,
+        0.9,
+        5.2,
+        lodSegments([20, 12, 8], lodLevel)
+      );
     } else if (meshName.includes("tree") || meshName.includes("pine")) {
-      geometry = new ConeGeometry(1.4, 3.4, 10);
+      geometry = new ConeGeometry(1.4, 3.4, lodSegments([18, 10, 6], lodLevel));
     } else {
       geometry = new BoxGeometry(2, 2, 2);
     }
 
-    this.geometryCache.set(batch.mesh, geometry);
+    this.geometryCache.set(cacheKey, geometry);
     return geometry;
   }
 
-  resolveSpriteTexture(batch: Pick<ThreeJsSpriteBatch, "texture" | "frame">): ResolvedSpriteTexture {
+  resolveSpriteTexture(
+    batch: Pick<ThreeJsSpriteBatch, "texture" | "frame">,
+    anisotropy = 1
+  ): ResolvedSpriteTexture {
     const key = `${batch.texture}:${batch.frame}`;
     const cached = this.textureCache.get(key);
     if (cached) {
+      cached.anisotropy = anisotropy;
       return { texture: cached };
     }
 
     const texture = createRadialTexture(hashColor(batch.texture));
+    texture.anisotropy = anisotropy;
     this.textureCache.set(key, texture);
     return { texture };
   }
 }
 
-export function createMeshMaterial(batch: ThreeJsMeshBatch): MeshStandardMaterial {
+export function createMeshMaterial(
+  batch: ThreeJsMeshBatch,
+  lodLevel: 0 | 1 | 2,
+  quality: Pick<PodThreeQualityProfile, "environmentIntensity">
+): MeshStandardMaterial {
   const material = new MeshStandardMaterial({
     color: new Color(batch.tint[0], batch.tint[1], batch.tint[2]),
     transparent: batch.transparent,
@@ -89,6 +118,10 @@ export function createMeshMaterial(batch: ThreeJsMeshBatch): MeshStandardMateria
     depthTest: batch.depthTest,
     side: batch.doubleSided ? 2 : FrontSide
   });
+  material.dithering = true;
+  material.envMapIntensity =
+    quality.environmentIntensity * (lodLevel === 0 ? 1 : lodLevel === 1 ? 0.92 : 0.82);
+  material.flatShading = lodLevel === 2;
   material.name = `pod-mesh:${batch.mesh}:${batch.material}`;
   return material;
 }
@@ -167,4 +200,8 @@ function hashColor(input: string): [number, number, number] {
     96 + ((hash >> 8) & 0x7f),
     96 + ((hash >> 16) & 0x7f)
   ];
+}
+
+function lodSegments(levels: [number, number, number], lodLevel: 0 | 1 | 2): number {
+  return levels[lodLevel];
 }

--- a/apps/pod-web/src/frame-plan.test.ts
+++ b/apps/pod-web/src/frame-plan.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import type { ThreeJsWebGpuFrame } from "./contracts";
 import { buildCameraPose, buildFramePlan, splitSpriteBatchesByTint } from "./frame-plan";
+import { resolveQualityProfile } from "./quality";
 
 describe("buildCameraPose", () => {
   test("maps 2D camera target and zoom into a perspective rig", () => {
@@ -95,7 +96,7 @@ describe("buildFramePlan", () => {
         x: 0,
         y: 0,
         zoom: 1,
-        rotation: 0,
+        rotation: Math.PI,
         viewportWidth: 1280,
         viewportHeight: 720
       },
@@ -172,5 +173,175 @@ describe("buildFramePlan", () => {
     expect(plan.meshBatches[0]?.batch.renderOrder).toBe(0);
     expect(plan.spriteBatches[0]?.batch.renderOrder).toBe(1);
     expect(plan.spriteBatches[0]?.matrices).toHaveLength(1);
+  });
+
+  test("culls far instances and splits visible meshes into lod tiers", () => {
+    const frame: ThreeJsWebGpuFrame = {
+      camera: {
+        x: 0,
+        y: 0,
+        zoom: 1,
+        rotation: Math.PI,
+        viewportWidth: 1280,
+        viewportHeight: 720
+      },
+      backgroundColor: [0, 0, 0, 1],
+      overlayCommands: [],
+      meshBatches: [
+        {
+          mesh: "tower",
+          material: "stone",
+          layer: 0,
+          phase: "opaque",
+          sortDepth: 0,
+          renderOrder: 0,
+          transparent: false,
+          doubleSided: false,
+          castShadows: true,
+          receiveShadows: true,
+          tint: [1, 1, 1, 1],
+          roughness: 1,
+          metallic: 0,
+          emissive: [0, 0, 0],
+          depthWrite: true,
+          depthTest: true,
+          instances: [
+            { position: [0, 0, 0], rotation: [0, 0, 0, 1], scale: [1, 1, 1] },
+            { position: [0, 0, 24], rotation: [0, 0, 0, 1], scale: [1, 1, 1] },
+            { position: [0, 0, 60], rotation: [0, 0, 0, 1], scale: [1, 1, 1] },
+            { position: [0, 0, 240], rotation: [0, 0, 0, 1], scale: [1, 1, 1] }
+          ]
+        }
+      ],
+      spriteBatches: [],
+      hints: {
+        renderer: "three/webgpu",
+        preferredBackend: "webgpu",
+        fallbackBackend: "webgl2",
+        useInstancing: true,
+        sortMetric: "world-z",
+        sortOpaqueFrontToBack: true,
+        preserveInstanceOrder: true,
+        sortTransparentBackToFront: true,
+        transparentInstancingStrategy: "shared-sort-depth",
+        opaqueDepthWrite: true,
+        transparentDepthWrite: false,
+        maxPixelRatio: 2
+      }
+    };
+
+    const plan = buildFramePlan(frame, {
+      frustumCulling: false,
+      fov: 140,
+      pitch: 0.18,
+      height: 0,
+      baseDistance: 20,
+      minDistance: 20,
+      maxDistance: 20,
+      meshCullDistance: 120,
+      highDetailDistance: 21,
+      mediumDetailDistance: 55,
+      shadowDistance: 36
+    });
+
+    expect(plan.meshBatches).toHaveLength(3);
+    expect(plan.meshBatches.map((batch) => batch.lodLevel)).toEqual([0, 1, 2]);
+    expect(plan.meshBatches[0]?.visibleCount).toBe(1);
+    expect(plan.meshBatches[0]?.batch.castShadows).toBe(true);
+    expect(plan.meshBatches[1]?.visibleCount).toBe(1);
+    expect(plan.meshBatches[1]?.batch.castShadows).toBe(false);
+    expect(plan.meshBatches[2]?.visibleCount).toBe(1);
+  });
+
+  test("drops instances outside the distance budget", () => {
+    const frame: ThreeJsWebGpuFrame = {
+      camera: {
+        x: 0,
+        y: 0,
+        zoom: 1,
+        rotation: 0,
+        viewportWidth: 1280,
+        viewportHeight: 720
+      },
+      backgroundColor: [0, 0, 0, 1],
+      overlayCommands: [],
+      meshBatches: [
+        {
+          mesh: "column",
+          material: "stone",
+          layer: 0,
+          phase: "opaque",
+          sortDepth: 0,
+          renderOrder: 0,
+          transparent: false,
+          doubleSided: false,
+          castShadows: true,
+          receiveShadows: true,
+          tint: [1, 1, 1, 1],
+          roughness: 1,
+          metallic: 0,
+          emissive: [0, 0, 0],
+          depthWrite: true,
+          depthTest: true,
+          instances: [
+            { position: [0, 0, -10], rotation: [0, 0, 0, 1], scale: [1, 1, 1] },
+            { position: [0, 0, -220], rotation: [0, 0, 0, 1], scale: [1, 1, 1] }
+          ]
+        }
+      ],
+      spriteBatches: [],
+      hints: {
+        renderer: "three/webgpu",
+        preferredBackend: "webgpu",
+        fallbackBackend: "webgl2",
+        useInstancing: true,
+        sortMetric: "world-z",
+        sortOpaqueFrontToBack: true,
+        preserveInstanceOrder: true,
+        sortTransparentBackToFront: true,
+        transparentInstancingStrategy: "shared-sort-depth",
+        opaqueDepthWrite: true,
+        transparentDepthWrite: false,
+        maxPixelRatio: 2
+      }
+    };
+
+    const plan = buildFramePlan(frame, {
+      frustumCulling: false,
+      meshCullDistance: 120,
+      highDetailDistance: 30,
+      mediumDetailDistance: 80
+    });
+
+    expect(plan.meshBatches).toHaveLength(1);
+    expect(plan.meshBatches[0]?.visibleCount).toBe(1);
+  });
+});
+
+describe("resolveQualityProfile", () => {
+  test("selects an ultra profile for stronger webgpu hardware", () => {
+    const quality = resolveQualityProfile({
+      backend: "webgpu",
+      hardwareConcurrency: 12,
+      deviceMemory: 16,
+      devicePixelRatio: 2
+    });
+
+    expect(quality.preset).toBe("ultra");
+    expect(quality.maxPixelRatio).toBe(2);
+    expect(quality.enableShadows).toBe(true);
+  });
+
+  test("drops to performance on weaker webgl hardware", () => {
+    const quality = resolveQualityProfile({
+      backend: "webgl2",
+      hardwareConcurrency: 2,
+      deviceMemory: 2,
+      devicePixelRatio: 1
+    });
+
+    expect(quality.preset).toBe("performance");
+    expect(quality.enableShadows).toBe(false);
+    expect(quality.meshCullDistance).toBeLessThan(quality.spriteCullDistance + 80);
   });
 });

--- a/apps/pod-web/src/frame-plan.ts
+++ b/apps/pod-web/src/frame-plan.ts
@@ -1,4 +1,4 @@
-import { Matrix4, Quaternion, Vector3 } from "three";
+import { Frustum, Matrix4, PerspectiveCamera, Quaternion, Sphere, Vector3 } from "three";
 
 import type {
   CameraState,
@@ -8,8 +8,11 @@ import type {
   ThreeJsSpriteBatch,
   ThreeJsWebGpuFrame
 } from "./contracts";
+import type { PodThreeQualityProfile } from "./quality";
 
 const DEFAULT_UP = new Vector3(0, 1, 0);
+const DEFAULT_RADIUS = 1.25;
+const TEMP_VIEW_PROJECTION = new Matrix4();
 
 export interface PodThreeCameraRigOptions {
   pitch?: number;
@@ -20,6 +23,15 @@ export interface PodThreeCameraRigOptions {
   fov?: number;
   near?: number;
   far?: number;
+}
+
+export interface PodThreePlanningOptions extends PodThreeCameraRigOptions {
+  frustumCulling?: boolean;
+  meshCullDistance?: number;
+  spriteCullDistance?: number;
+  highDetailDistance?: number;
+  mediumDetailDistance?: number;
+  shadowDistance?: number;
 }
 
 export interface PlannedCameraPose {
@@ -34,6 +46,8 @@ export interface PlannedCameraPose {
 export interface PlannedMeshBatch {
   key: string;
   batch: ThreeJsMeshBatch;
+  lodLevel: 0 | 1 | 2;
+  visibleCount: number;
   matrices: Matrix4[];
 }
 
@@ -41,6 +55,7 @@ export interface PlannedSpriteBatch {
   key: string;
   batch: Omit<ThreeJsSpriteBatch, "instances">;
   tint: RgbaTuple;
+  visibleCount: number;
   instances: ThreeJsInstance[];
   matrices: Matrix4[];
 }
@@ -85,26 +100,60 @@ export function buildCameraPose(
 
 export function buildFramePlan(
   frame: ThreeJsWebGpuFrame,
-  options: PodThreeCameraRigOptions = {}
+  options: PodThreePlanningOptions = {}
 ): PlannedFrame {
   const camera = buildCameraPose(frame.camera, options);
+  const viewCamera = createViewCamera(frame.camera, camera);
+  const frustum = new Frustum().setFromProjectionMatrix(
+    TEMP_VIEW_PROJECTION.multiplyMatrices(viewCamera.projectionMatrix, viewCamera.matrixWorldInverse)
+  );
+  const cameraPosition = new Vector3(...camera.position);
+  const meshCullDistance = options.meshCullDistance ?? Number.POSITIVE_INFINITY;
+  const spriteCullDistance = options.spriteCullDistance ?? Number.POSITIVE_INFINITY;
+  const frustumCulling = options.frustumCulling ?? true;
+  const highDetailDistance = options.highDetailDistance ?? 36;
+  const mediumDetailDistance = options.mediumDetailDistance ?? 108;
+  const shadowDistance = options.shadowDistance ?? 72;
 
   return {
     camera,
-    meshBatches: frame.meshBatches.map((batch) => ({
-      key: createMeshBatchKey(batch),
-      batch,
-      matrices: batch.instances.map((instance) => composeInstanceMatrix(instance))
-    })),
-    spriteBatches: splitSpriteBatchesByTint(frame.spriteBatches).map((batch) => ({
-      ...batch,
-      matrices: batch.instances.map((instance) =>
-        composeInstanceMatrix(
-          instance,
-          batch.batch.billboard ? camera.quaternion : undefined
-        )
-      )
-    }))
+    meshBatches: planMeshBatches(
+      frame.meshBatches,
+      frustum,
+      cameraPosition,
+      highDetailDistance,
+      mediumDetailDistance,
+      meshCullDistance,
+      shadowDistance,
+      frustumCulling
+    ),
+    spriteBatches: planSpriteBatches(
+      frame.spriteBatches,
+      frustum,
+      cameraPosition,
+      spriteCullDistance,
+      camera.quaternion,
+      frustumCulling
+    )
+  };
+}
+
+export function planningOptionsFromQuality(
+  quality: Pick<
+    PodThreeQualityProfile,
+    | "meshCullDistance"
+    | "spriteCullDistance"
+    | "highDetailDistance"
+    | "mediumDetailDistance"
+    | "shadowDistance"
+  >
+): PodThreePlanningOptions {
+  return {
+    meshCullDistance: quality.meshCullDistance,
+    spriteCullDistance: quality.spriteCullDistance,
+    highDetailDistance: quality.highDetailDistance,
+    mediumDetailDistance: quality.mediumDetailDistance,
+    shadowDistance: quality.shadowDistance
   };
 }
 
@@ -147,6 +196,7 @@ export function splitSpriteBatchesByTint(
           depthTest: batch.depthTest
         },
         tint,
+        visibleCount: instances.length,
         instances
       });
       tintIndex += 1;
@@ -177,7 +227,7 @@ export function composeInstanceMatrix(
   return matrix;
 }
 
-function createMeshBatchKey(batch: ThreeJsMeshBatch): string {
+function createMeshBatchKey(batch: ThreeJsMeshBatch, lodLevel?: number): string {
   return [
     "mesh",
     batch.mesh,
@@ -185,7 +235,8 @@ function createMeshBatchKey(batch: ThreeJsMeshBatch): string {
     batch.layer,
     batch.renderOrder,
     batch.phase,
-    batch.transparent ? "transparent" : "opaque"
+    batch.transparent ? "transparent" : "opaque",
+    lodLevel ?? "base"
   ].join(":");
 }
 
@@ -203,4 +254,156 @@ function createSpriteBatchKey(batch: ThreeJsSpriteBatch): string {
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
+}
+
+function createViewCamera(
+  frameCamera: CameraState,
+  pose: PlannedCameraPose
+): PerspectiveCamera {
+  const camera = new PerspectiveCamera(
+    pose.fov,
+    frameCamera.viewportWidth / Math.max(frameCamera.viewportHeight, 1),
+    pose.near,
+    pose.far
+  );
+  camera.position.set(...pose.position);
+  camera.quaternion.copy(pose.quaternion);
+  camera.updateProjectionMatrix();
+  camera.updateMatrixWorld(true);
+  camera.matrixWorldInverse.copy(camera.matrixWorld).invert();
+  return camera;
+}
+
+function planMeshBatches(
+  batches: ThreeJsMeshBatch[],
+  frustum: Frustum,
+  cameraPosition: Vector3,
+  highDetailDistance: number,
+  mediumDetailDistance: number,
+  meshCullDistance: number,
+  shadowDistance: number,
+  frustumCulling: boolean
+): PlannedMeshBatch[] {
+  const planned = new Array<PlannedMeshBatch>();
+
+  for (const batch of batches) {
+    const lodGroups = new Map<
+      0 | 1 | 2,
+      {
+        matrices: Matrix4[];
+        instances: ThreeJsInstance[];
+        nearestDistance: number;
+      }
+    >();
+
+    for (const instance of batch.instances) {
+      const radius = estimateInstanceRadius(instance);
+      const center = new Vector3(...instance.position);
+      const distance = center.distanceTo(cameraPosition);
+
+      if (distance - radius > meshCullDistance) {
+        continue;
+      }
+
+      if (frustumCulling && !frustum.intersectsSphere(new Sphere(center, radius))) {
+        continue;
+      }
+
+      const lodLevel = classifyLod(distance, highDetailDistance, mediumDetailDistance);
+      const group = lodGroups.get(lodLevel) ?? {
+        matrices: [],
+        instances: [],
+        nearestDistance: Number.POSITIVE_INFINITY
+      };
+      group.instances.push(instance);
+      group.matrices.push(composeInstanceMatrix(instance));
+      group.nearestDistance = Math.min(group.nearestDistance, distance);
+      lodGroups.set(lodLevel, group);
+    }
+
+    for (const [lodLevel, group] of lodGroups) {
+      planned.push({
+        key: createMeshBatchKey(batch, lodLevel),
+        batch: {
+          ...batch,
+          castShadows:
+            batch.castShadows && lodLevel < 2 && group.nearestDistance <= shadowDistance
+        },
+        lodLevel,
+        visibleCount: group.instances.length,
+        matrices: group.matrices
+      });
+    }
+  }
+
+  planned.sort((left, right) => {
+    if (left.batch.renderOrder !== right.batch.renderOrder) {
+      return left.batch.renderOrder - right.batch.renderOrder;
+    }
+
+    if (left.lodLevel !== right.lodLevel) {
+      return left.lodLevel - right.lodLevel;
+    }
+
+    return left.key.localeCompare(right.key);
+  });
+
+  return planned;
+}
+
+function planSpriteBatches(
+  batches: ThreeJsSpriteBatch[],
+  frustum: Frustum,
+  cameraPosition: Vector3,
+  spriteCullDistance: number,
+  cameraQuaternion: Quaternion,
+  frustumCulling: boolean
+): PlannedSpriteBatch[] {
+  const visibleBatches = batches
+    .map((batch) => ({
+      ...batch,
+      instances: batch.instances.filter((instance) => {
+        const radius = estimateInstanceRadius(instance);
+        const center = new Vector3(...instance.position);
+        const distance = center.distanceTo(cameraPosition);
+
+        if (distance - radius > spriteCullDistance) {
+          return false;
+        }
+
+        return !frustumCulling || frustum.intersectsSphere(new Sphere(center, radius));
+      })
+    }))
+    .filter((batch) => batch.instances.length > 0);
+
+  return splitSpriteBatchesByTint(visibleBatches).map((batch) => ({
+    ...batch,
+    visibleCount: batch.instances.length,
+    matrices: batch.instances.map((instance) =>
+      composeInstanceMatrix(
+        instance,
+        batch.batch.billboard ? cameraQuaternion : undefined
+      )
+    )
+  }));
+}
+
+function classifyLod(
+  distance: number,
+  highDetailDistance: number,
+  mediumDetailDistance: number
+): 0 | 1 | 2 {
+  if (distance <= highDetailDistance) {
+    return 0;
+  }
+
+  if (distance <= mediumDetailDistance) {
+    return 1;
+  }
+
+  return 2;
+}
+
+function estimateInstanceRadius(instance: ThreeJsInstance): number {
+  return Math.max(...instance.scale) * DEFAULT_RADIUS;
 }

--- a/apps/pod-web/src/main.ts
+++ b/apps/pod-web/src/main.ts
@@ -9,6 +9,7 @@ declare global {
       renderThreeJsWebGpuFrame: (frame: string) => void;
       resetDemo: () => void;
       getBackend: () => string;
+      getStats: () => ReturnType<PodThreeWorldRenderer["getStats"]>;
     };
   }
 }
@@ -16,13 +17,17 @@ declare global {
 const canvas = document.querySelector<HTMLCanvasElement>("#pod-web-canvas");
 const backendLabel = document.querySelector<HTMLElement>("#backend-label");
 const frameSourceLabel = document.querySelector<HTMLElement>("#frame-source");
+const qualityLabel = document.querySelector<HTMLElement>("#quality-label");
+const statsLabel = document.querySelector<HTMLElement>("#stats-label");
 
-if (!canvas || !backendLabel || !frameSourceLabel) {
+if (!canvas || !backendLabel || !frameSourceLabel || !qualityLabel || !statsLabel) {
   throw new Error("pod-web bootstrap failed: required DOM nodes are missing");
 }
 
 const renderer = await PodThreeWorldRenderer.create(canvas);
 backendLabel.textContent = renderer.backend;
+qualityLabel.textContent = renderer.quality.preset;
+const runtimeStatsLabel = statsLabel;
 
 let liveFrameSource: "demo" | "legacy" | "threejs" = "demo";
 let latestFrameJson: string | null = null;
@@ -45,6 +50,9 @@ window.podRender = {
   },
   getBackend() {
     return renderer.backend;
+  },
+  getStats() {
+    return renderer.getStats();
   }
 };
 
@@ -58,6 +66,11 @@ async function tick(timestamp: number): Promise<void> {
   } else {
     await renderer.applyFrame(createDemoFrame(timestamp / 1000));
   }
+
+  const stats = renderer.getStats();
+  runtimeStatsLabel.textContent = `${stats.drawCalls} calls · ${stats.triangles} tris · ${stats.pixelRatio.toFixed(
+    2
+  )}x DPR · ${stats.frameMs.toFixed(1)}ms`;
 
   requestAnimationFrame((nextTimestamp) => {
     void tick(nextTimestamp);

--- a/apps/pod-web/src/quality.ts
+++ b/apps/pod-web/src/quality.ts
@@ -1,0 +1,152 @@
+export type PodThreeQualityPreset =
+  | "ultra"
+  | "high"
+  | "balanced"
+  | "performance";
+
+export interface PodThreeQualityProfile {
+  preset: PodThreeQualityPreset;
+  meshCullDistance: number;
+  spriteCullDistance: number;
+  highDetailDistance: number;
+  mediumDetailDistance: number;
+  shadowDistance: number;
+  shadowMapSize: number;
+  anisotropy: number;
+  toneMappingExposure: number;
+  maxPixelRatio: number;
+  minPixelRatio: number;
+  adaptiveResolutionStep: number;
+  targetFrameMs: number;
+  environmentIntensity: number;
+  enableAdaptiveResolution: boolean;
+  enableShadows: boolean;
+  showGrid: boolean;
+}
+
+export interface PodThreeQualityInput {
+  backend: "webgpu" | "webgl2";
+  preferredPreset?: PodThreeQualityPreset;
+  hardwareConcurrency?: number;
+  deviceMemory?: number;
+  devicePixelRatio?: number;
+}
+
+const PRESETS: Record<PodThreeQualityPreset, PodThreeQualityProfile> = {
+  ultra: {
+    preset: "ultra",
+    meshCullDistance: 340,
+    spriteCullDistance: 240,
+    highDetailDistance: 42,
+    mediumDetailDistance: 132,
+    shadowDistance: 88,
+    shadowMapSize: 2048,
+    anisotropy: 16,
+    toneMappingExposure: 1.14,
+    maxPixelRatio: 2,
+    minPixelRatio: 1.15,
+    adaptiveResolutionStep: 0.08,
+    targetFrameMs: 16.7,
+    environmentIntensity: 1.15,
+    enableAdaptiveResolution: true,
+    enableShadows: true,
+    showGrid: true
+  },
+  high: {
+    preset: "high",
+    meshCullDistance: 300,
+    spriteCullDistance: 220,
+    highDetailDistance: 34,
+    mediumDetailDistance: 110,
+    shadowDistance: 72,
+    shadowMapSize: 1536,
+    anisotropy: 12,
+    toneMappingExposure: 1.1,
+    maxPixelRatio: 1.75,
+    minPixelRatio: 1,
+    adaptiveResolutionStep: 0.08,
+    targetFrameMs: 16.7,
+    environmentIntensity: 1.05,
+    enableAdaptiveResolution: true,
+    enableShadows: true,
+    showGrid: true
+  },
+  balanced: {
+    preset: "balanced",
+    meshCullDistance: 240,
+    spriteCullDistance: 180,
+    highDetailDistance: 28,
+    mediumDetailDistance: 92,
+    shadowDistance: 54,
+    shadowMapSize: 1024,
+    anisotropy: 8,
+    toneMappingExposure: 1.02,
+    maxPixelRatio: 1.35,
+    minPixelRatio: 0.85,
+    adaptiveResolutionStep: 0.07,
+    targetFrameMs: 16.7,
+    environmentIntensity: 0.92,
+    enableAdaptiveResolution: true,
+    enableShadows: true,
+    showGrid: false
+  },
+  performance: {
+    preset: "performance",
+    meshCullDistance: 180,
+    spriteCullDistance: 132,
+    highDetailDistance: 18,
+    mediumDetailDistance: 60,
+    shadowDistance: 32,
+    shadowMapSize: 768,
+    anisotropy: 4,
+    toneMappingExposure: 0.96,
+    maxPixelRatio: 1,
+    minPixelRatio: 0.72,
+    adaptiveResolutionStep: 0.06,
+    targetFrameMs: 16.7,
+    environmentIntensity: 0.8,
+    enableAdaptiveResolution: true,
+    enableShadows: false,
+    showGrid: false
+  }
+};
+
+export function resolveQualityProfile(
+  input: PodThreeQualityInput
+): PodThreeQualityProfile {
+  const preset =
+    input.preferredPreset ?? pickPreset(input.backend, input.hardwareConcurrency, input.deviceMemory);
+  const profile = { ...PRESETS[preset] };
+  const devicePixelRatio = input.devicePixelRatio ?? 1;
+  profile.maxPixelRatio = Math.min(profile.maxPixelRatio, Math.max(devicePixelRatio, 1));
+
+  return profile;
+}
+
+function pickPreset(
+  backend: "webgpu" | "webgl2",
+  hardwareConcurrency = 4,
+  deviceMemory = 4
+): PodThreeQualityPreset {
+  if (backend === "webgpu") {
+    if (hardwareConcurrency >= 8 && deviceMemory >= 8) {
+      return "ultra";
+    }
+
+    if (hardwareConcurrency >= 6 && deviceMemory >= 4) {
+      return "high";
+    }
+
+    return "balanced";
+  }
+
+  if (hardwareConcurrency >= 8 && deviceMemory >= 8) {
+    return "high";
+  }
+
+  if (hardwareConcurrency >= 4 && deviceMemory >= 4) {
+    return "balanced";
+  }
+
+  return "performance";
+}

--- a/apps/pod-web/src/renderer.ts
+++ b/apps/pod-web/src/renderer.ts
@@ -11,6 +11,7 @@ import {
 import {
   buildCameraPose,
   buildFramePlan,
+  planningOptionsFromQuality,
   type PodThreeCameraRigOptions,
   type PlannedMeshBatch,
   type PlannedSpriteBatch
@@ -21,6 +22,11 @@ import {
   type RenderFrame,
   type ThreeJsWebGpuFrame
 } from "./contracts";
+import {
+  resolveQualityProfile,
+  type PodThreeQualityPreset,
+  type PodThreeQualityProfile
+} from "./quality";
 
 type RuntimeRenderer = THREE.WebGLRenderer & {
   init?: () => Promise<void>;
@@ -28,15 +34,39 @@ type RuntimeRenderer = THREE.WebGLRenderer & {
   renderAsync?: (scene: THREE.Scene, camera: THREE.Camera) => Promise<void>;
 };
 
+type ThreeConsoleLevel = Parameters<typeof THREE.setConsoleFunction>[0] extends (
+  level: infer Level,
+  ...args: unknown[]
+) => void
+  ? Level
+  : "log" | "warn" | "error";
+
 interface InstancedEntry {
   capacity: number;
   mesh: THREE.InstancedMesh;
   material: THREE.Material;
 }
 
+const INLINE_TSL_FN_WARNING =
+  "THREE.TSL: Return statement used in an inline 'Fn()'. Define a layout struct to allow return values.";
+let installedThreeConsoleFilter = false;
+let didReportInlineFnWarning = false;
+
+export interface PodThreeRendererStats {
+  backend: "webgpu" | "webgl2";
+  qualityPreset: PodThreeQualityPreset;
+  pixelRatio: number;
+  drawCalls: number;
+  triangles: number;
+  textures: number;
+  frameMs: number;
+}
+
 export interface PodThreeWorldRendererOptions {
   assetRegistry?: PodThreeAssetRegistry;
   cameraRig?: PodThreeCameraRigOptions;
+  qualityPreset?: PodThreeQualityPreset;
+  qualityProfile?: Partial<PodThreeQualityProfile>;
   clearColor?: number;
   enableShadows?: boolean;
   showGrid?: boolean;
@@ -58,13 +88,18 @@ export class PodThreeWorldRenderer {
   readonly overlayCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, -10, 10);
   readonly assetRegistry: PodThreeAssetRegistry;
   readonly backend: "webgpu" | "webgl2";
+  readonly quality: PodThreeQualityProfile;
 
   private readonly meshEntries = new Map<string, InstancedEntry>();
   private readonly spriteEntries = new Map<string, InstancedEntry>();
+  private readonly meshMaterialCache = new Map<string, THREE.Material>();
+  private readonly spriteMaterialCache = new Map<string, THREE.Material>();
   private readonly overlayObjects = new Array<THREE.Object3D>();
   private readonly resizeObserver: ResizeObserver;
-  private readonly options: Required<Pick<PodThreeWorldRendererOptions, "showGrid" | "enableShadows">> &
-    Omit<PodThreeWorldRendererOptions, "showGrid" | "enableShadows">;
+  private readonly options: PodThreeWorldRendererOptions;
+  private adaptivePixelRatio: number;
+  private smoothedFrameMs = 16.7;
+  private adjustmentCooldown = 0;
 
   constructor(
     private readonly canvas: HTMLCanvasElement,
@@ -74,11 +109,32 @@ export class PodThreeWorldRenderer {
   ) {
     this.backend = backend;
     this.assetRegistry = options.assetRegistry ?? new DefaultPodThreeAssetRegistry();
-    this.options = {
-      ...options,
-      showGrid: options.showGrid ?? true,
-      enableShadows: options.enableShadows ?? true
+    const deviceMemory = readNavigatorDeviceMemory();
+    const baseQuality = resolveQualityProfile({
+      backend,
+      preferredPreset: options.qualityPreset,
+      hardwareConcurrency: navigator.hardwareConcurrency,
+      deviceMemory,
+      devicePixelRatio: window.devicePixelRatio
+    });
+    this.quality = {
+      ...baseQuality,
+      ...options.qualityProfile,
+      maxPixelRatio: Math.min(
+        options.maxPixelRatio ??
+          options.qualityProfile?.maxPixelRatio ??
+          Number.POSITIVE_INFINITY,
+        options.qualityProfile?.maxPixelRatio ?? baseQuality.maxPixelRatio
+      ),
+      enableShadows:
+        options.enableShadows ??
+        options.qualityProfile?.enableShadows ?? baseQuality.enableShadows,
+      showGrid:
+        options.showGrid ??
+        options.qualityProfile?.showGrid ?? baseQuality.showGrid
     };
+    this.options = options;
+    this.adaptivePixelRatio = this.quality.maxPixelRatio;
 
     this.bootstrapScenes();
     this.resizeObserver = new ResizeObserver(() => this.resize());
@@ -89,7 +145,10 @@ export class PodThreeWorldRenderer {
   async applyFrame(frame: ThreeJsWebGpuFrame): Promise<void> {
     this.scene.background = new THREE.Color(...frame.backgroundColor.slice(0, 3));
 
-    const planned = buildFramePlan(frame, this.options.cameraRig);
+    const planned = buildFramePlan(frame, {
+      ...this.options.cameraRig,
+      ...planningOptionsFromQuality(this.quality)
+    });
     this.applyCamera(planned.camera, frame.camera);
     await this.syncMeshBatches(planned.meshBatches);
     await this.syncSpriteBatches(planned.spriteBatches);
@@ -110,6 +169,12 @@ export class PodThreeWorldRenderer {
     for (const entry of this.spriteEntries.values()) {
       disposeInstancedEntry(entry);
     }
+    for (const material of this.meshMaterialCache.values()) {
+      material.dispose();
+    }
+    for (const material of this.spriteMaterialCache.values()) {
+      material.dispose();
+    }
 
     this.clearOverlay();
     this.renderer.dispose();
@@ -117,14 +182,15 @@ export class PodThreeWorldRenderer {
 
   private bootstrapScenes(): void {
     this.scene.fog = new THREE.Fog(0x09111b, 28, 180);
+    this.scene.backgroundIntensity = 0.8;
 
     const hemisphere = new THREE.HemisphereLight(0xa8d1ff, 0x14263f, 1.2);
     this.scene.add(hemisphere);
 
     const sun = new THREE.DirectionalLight(0xfff0cf, 2.6);
     sun.position.set(24, 42, 18);
-    sun.castShadow = this.options.enableShadows;
-    sun.shadow.mapSize.set(2048, 2048);
+    sun.castShadow = this.quality.enableShadows;
+    sun.shadow.mapSize.set(this.quality.shadowMapSize, this.quality.shadowMapSize);
     sun.shadow.camera.near = 1;
     sun.shadow.camera.far = 160;
     sun.shadow.camera.left = -60;
@@ -136,6 +202,10 @@ export class PodThreeWorldRenderer {
     const fill = new THREE.DirectionalLight(0x6cbcff, 0.7);
     fill.position.set(-18, 14, -10);
     this.scene.add(fill);
+
+    const rim = new THREE.PointLight(0x4bc1ff, 12, 180, 2.2);
+    rim.position.set(0, 26, 0);
+    this.scene.add(rim);
 
     const ground = new THREE.Mesh(
       new THREE.CircleGeometry(140, 64),
@@ -149,11 +219,25 @@ export class PodThreeWorldRenderer {
     ground.receiveShadow = true;
     this.scene.add(ground);
 
-    if (this.options.showGrid) {
+    if (this.quality.showGrid) {
       const grid = new THREE.GridHelper(180, 60, 0x5fa7ff, 0x173049);
       grid.position.y = 0.02;
       this.scene.add(grid);
     }
+
+    const skyline = new THREE.Points(
+      createStarfieldGeometry(640, 220),
+      new THREE.PointsMaterial({
+        color: 0xcde7ff,
+        size: 0.9,
+        sizeAttenuation: true,
+        transparent: true,
+        opacity: 0.9,
+        depthWrite: false
+      })
+    );
+    skyline.position.y = 36;
+    this.scene.add(skyline);
 
     this.overlayScene.background = null;
     this.overlayCamera.position.set(0, 0, 5);
@@ -188,11 +272,22 @@ export class PodThreeWorldRenderer {
     const activeKeys = new Set<string>();
 
     for (const planned of batches) {
+      if (planned.visibleCount === 0) {
+        continue;
+      }
+
       activeKeys.add(planned.key);
-      const geometry = await this.assetRegistry.resolveGeometry(planned.batch);
+      const geometry = await this.assetRegistry.resolveGeometry(
+        planned.batch,
+        planned.lodLevel
+      );
       const material =
-        (await this.assetRegistry.resolveMeshMaterial?.(planned.batch)) ??
-        createMeshMaterial(planned.batch);
+        (await this.assetRegistry.resolveMeshMaterial?.(
+          planned.batch,
+          planned.lodLevel,
+          this.quality
+        )) ??
+        this.getOrCreateMeshMaterial(planned);
       const existing = this.meshEntries.get(planned.key);
       const entry = ensureInstancedEntry(
         this.scene,
@@ -225,19 +320,16 @@ export class PodThreeWorldRenderer {
     const activeKeys = new Set<string>();
 
     for (const planned of batches) {
+      if (planned.visibleCount === 0) {
+        continue;
+      }
+
       activeKeys.add(planned.key);
       const resolved = await this.assetRegistry.resolveSpriteTexture({
         texture: planned.batch.texture,
         frame: planned.batch.frame
-      });
-      const material = createSpriteMaterial(
-        resolved,
-        planned.tint,
-        planned.batch.transparent,
-        planned.batch.depthWrite,
-        planned.batch.depthTest,
-        THREE.DoubleSide
-      );
+      }, this.quality.anisotropy);
+      const material = this.getOrCreateSpriteMaterial(planned, resolved);
 
       const existing = this.spriteEntries.get(planned.key);
       const entry = ensureInstancedEntry(
@@ -334,19 +426,133 @@ export class PodThreeWorldRenderer {
   }
 
   private async renderFrame(): Promise<void> {
+    const frameStart = performance.now();
+    const previousAutoClear = this.renderer.autoClear;
+    this.renderer.autoClear = true;
     await renderWithFallback(this.renderer, this.scene, this.camera);
+    this.renderer.autoClear = false;
     this.renderer.clearDepth();
     await renderWithFallback(this.renderer, this.overlayScene, this.overlayCamera);
+    this.renderer.autoClear = previousAutoClear;
+    this.updateAdaptiveResolution(performance.now() - frameStart);
   }
 
   private resize(): void {
     const width = this.canvas.clientWidth || window.innerWidth;
     const height = this.canvas.clientHeight || window.innerHeight;
-    const pixelRatio = Math.min(window.devicePixelRatio, this.options.maxPixelRatio ?? 2);
+    const pixelRatio = Math.min(window.devicePixelRatio, this.adaptivePixelRatio);
     this.renderer.setPixelRatio(pixelRatio);
     this.renderer.setSize(width, height, false);
     this.camera.aspect = width / Math.max(height, 1);
     this.camera.updateProjectionMatrix();
+  }
+
+  getStats(): PodThreeRendererStats {
+    return {
+      backend: this.backend,
+      qualityPreset: this.quality.preset,
+      pixelRatio: this.renderer.getPixelRatio(),
+      drawCalls: this.renderer.info.render.calls,
+      triangles: this.renderer.info.render.triangles,
+      textures: this.renderer.info.memory.textures,
+      frameMs: Number(this.smoothedFrameMs.toFixed(2))
+    };
+  }
+
+  private getOrCreateMeshMaterial(planned: PlannedMeshBatch): THREE.Material {
+    const key = [
+      planned.batch.mesh,
+      planned.batch.material,
+      planned.lodLevel,
+      planned.batch.transparent,
+      planned.batch.doubleSided,
+      planned.batch.tint.join(","),
+      planned.batch.emissive.join(","),
+      planned.batch.roughness,
+      planned.batch.metallic,
+      planned.batch.depthWrite,
+      planned.batch.depthTest,
+      this.quality.environmentIntensity
+    ].join("|");
+    const cached = this.meshMaterialCache.get(key);
+    if (cached) {
+      return cached;
+    }
+
+    const material = createMeshMaterial(planned.batch, planned.lodLevel, this.quality);
+    this.meshMaterialCache.set(key, material);
+    return material;
+  }
+
+  private getOrCreateSpriteMaterial(
+    planned: PlannedSpriteBatch,
+    resolved: Parameters<typeof createSpriteMaterial>[0]
+  ): THREE.Material {
+    const key = [
+      planned.batch.texture,
+      planned.batch.frame,
+      planned.batch.transparent,
+      planned.batch.depthWrite,
+      planned.batch.depthTest,
+      planned.tint.join(",")
+    ].join("|");
+    const cached = this.spriteMaterialCache.get(key);
+    if (cached) {
+      return cached;
+    }
+
+    const material = createSpriteMaterial(
+      resolved,
+      planned.tint,
+      planned.batch.transparent,
+      planned.batch.depthWrite,
+      planned.batch.depthTest,
+      THREE.DoubleSide
+    );
+    this.spriteMaterialCache.set(key, material);
+    return material;
+  }
+
+  private updateAdaptiveResolution(frameMs: number): void {
+    if (!this.quality.enableAdaptiveResolution) {
+      this.smoothedFrameMs = frameMs;
+      return;
+    }
+
+    this.smoothedFrameMs = this.smoothedFrameMs * 0.9 + frameMs * 0.1;
+
+    if (this.adjustmentCooldown > 0) {
+      this.adjustmentCooldown -= 1;
+      return;
+    }
+
+    const upperBound = this.quality.targetFrameMs * 1.08;
+    const lowerBound = this.quality.targetFrameMs * 0.8;
+
+    if (
+      this.smoothedFrameMs > upperBound &&
+      this.adaptivePixelRatio > this.quality.minPixelRatio
+    ) {
+      this.adaptivePixelRatio = Math.max(
+        this.quality.minPixelRatio,
+        this.adaptivePixelRatio - this.quality.adaptiveResolutionStep
+      );
+      this.adjustmentCooldown = 18;
+      this.resize();
+      return;
+    }
+
+    if (
+      this.smoothedFrameMs < lowerBound &&
+      this.adaptivePixelRatio < this.quality.maxPixelRatio
+    ) {
+      this.adaptivePixelRatio = Math.min(
+        this.quality.maxPixelRatio,
+        this.adaptivePixelRatio + this.quality.adaptiveResolutionStep
+      );
+      this.adjustmentCooldown = 24;
+      this.resize();
+    }
   }
 }
 
@@ -354,6 +560,8 @@ async function createRenderer(
   canvas: HTMLCanvasElement,
   options: PodThreeWorldRendererOptions
 ): Promise<{ renderer: RuntimeRenderer; backend: "webgpu" | "webgl2" }> {
+  installThreeConsoleFilter();
+
   if ("gpu" in navigator) {
     try {
       const webgpuModule = await import("three/webgpu");
@@ -365,6 +573,9 @@ async function createRenderer(
       }) as RuntimeRenderer;
       await renderer.init?.();
       renderer.shadowMap.enabled = options.enableShadows ?? true;
+      renderer.shadowMap.type = THREE.VSMShadowMap;
+      renderer.toneMapping = THREE.ACESFilmicToneMapping;
+      renderer.toneMappingExposure = options.qualityProfile?.toneMappingExposure ?? 1.05;
       renderer.outputColorSpace = THREE.SRGBColorSpace;
       return { renderer, backend: "webgpu" };
     } catch (error) {
@@ -380,6 +591,8 @@ async function createRenderer(
   }) as RuntimeRenderer;
   renderer.shadowMap.enabled = options.enableShadows ?? true;
   renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+  renderer.toneMapping = THREE.ACESFilmicToneMapping;
+  renderer.toneMappingExposure = options.qualityProfile?.toneMappingExposure ?? 1.0;
   renderer.outputColorSpace = THREE.SRGBColorSpace;
   return { renderer, backend: "webgl2" };
 }
@@ -465,4 +678,70 @@ function disposeObject(object: THREE.Object3D): void {
       child.material.dispose();
     }
   });
+}
+
+function createStarfieldGeometry(count: number, radius: number): THREE.BufferGeometry {
+  const positions = new Float32Array(count * 3);
+
+  for (let index = 0; index < count; index += 1) {
+    const theta = (index * 2.399963229728653) % (Math.PI * 2);
+    const phi = Math.acos(1 - 2 * ((index + 0.5) / count));
+    const distance = radius * (0.65 + (index % 17) / 32);
+    const sinPhi = Math.sin(phi);
+    positions[index * 3] = Math.cos(theta) * sinPhi * distance;
+    positions[index * 3 + 1] = Math.cos(phi) * distance;
+    positions[index * 3 + 2] = Math.sin(theta) * sinPhi * distance;
+  }
+
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute("position", new THREE.BufferAttribute(positions, 3));
+  return geometry;
+}
+
+function readNavigatorDeviceMemory(): number | undefined {
+  const navigatorWithMemory = navigator as Navigator & { deviceMemory?: number };
+  return navigatorWithMemory.deviceMemory;
+}
+
+function installThreeConsoleFilter(): void {
+  if (installedThreeConsoleFilter) {
+    return;
+  }
+
+  const previous = THREE.getConsoleFunction();
+  THREE.setConsoleFunction((level, message, ...params) => {
+    if (level === "warn" && message === INLINE_TSL_FN_WARNING) {
+      if (didReportInlineFnWarning) {
+        return;
+      }
+
+      didReportInlineFnWarning = true;
+      forwardThreeConsoleMessage(
+        level,
+        `${message} Duplicate warnings suppressed by POD; this is currently an upstream Three.js WebGPU material compilation warning.`,
+        params,
+        previous
+      );
+      return;
+    }
+
+    forwardThreeConsoleMessage(level, message, params, previous);
+  });
+  installedThreeConsoleFilter = true;
+}
+
+function forwardThreeConsoleMessage(
+  level: ThreeConsoleLevel,
+  message: string,
+  params: unknown[],
+  previous: ReturnType<typeof THREE.getConsoleFunction> | undefined
+): void {
+  if (previous) {
+    previous(level, message, ...params);
+    return;
+  }
+
+  const consoleMethod =
+    level === "warn" ? console.warn : level === "error" ? console.error : console.log;
+  consoleMethod(message, ...params);
 }


### PR DESCRIPTION
## Summary
- add hardware-aware quality profiles, adaptive resolution, and LOD-aware culling/planning for pod-web
- improve the browser renderer baseline with cached materials, tuned lighting/shadows, runtime stats, and cleaner Three.js WebGPU logging
- fix the overlay compositing bug that was clearing the main 3D frame to black

## Validation
- cd apps/pod-web && bun test
- cd apps/pod-web && bun run typecheck
- cd apps/pod-web && bun run build
- live browser smoke on http://127.0.0.1:4173/ confirming visible scene output, WebGPU backend, and single filtered upstream warning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added dynamic quality presets that automatically adjust rendering settings based on device hardware capabilities.
  * Introduced real-time statistics display showing draw calls, triangles, pixel ratio, and frame timing.
  * Implemented distance-based mesh culling and level-of-detail system for improved performance.
  * Added adaptive resolution scaling that adjusts quality during rendering based on frame performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->