### PR TITLE
Add runtime kernel and MMO observation contracts

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -364,5 +364,16 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cd apps/pod-web && bun run typecheck`
   - `cd apps/pod-web && bun run build`
 
-**Last updated**: Iteration 46
-**Current focus**: Phase 8 shipping parity and Phase 9 hardening backlog
+### Iteration 47 — Runtime Kernel MMO Contract Foundation
+
+- [x] Added a first-class `App` / `Plugin` / schedule kernel in `pod-core` with deterministic startup, fixed-tick update, render-prep, broadcast phases, typed resources, and a shared type registry for core components and contracts.
+- [x] Added explicit versioned runtime contracts in `pod-core` with `RuntimeContractVersion`, `AgentRuntimeProfile`, `AgentRole`, and `AgentCapabilities` so human clients, local AI, and remote AI can share one auditable parity envelope.
+- [x] Added MMO-native POD primitives for the flagship world direction: `CombatLoadout`, `SkillBook`, `Inventory`, `CreatureIdentity`, `CompanionRoster`, and `EncounterState`, designed around RuneScape-style progression/combat with collectible creature companions.
+- [x] Extended agent observations and default world spawns so runtime profiles, combat style, skills, inventory, companions, and encounter state are visible through the same observation pipeline used by both humans and AI.
+- [x] Added deterministic `pod-core` tests covering schedule ordering, versioned contracts, and MMO-state observation delivery.
+- [x] Validated touched crate:
+  - `cargo check -p pod-core`
+  - `cargo test -p pod-core --lib`
+
+**Last updated**: Iteration 47
+**Current focus**: Phase 1 runtime kernel parity for the RuneScape-style MMO + companion-creature vertical slice

--- a/crates/pod-core/src/agent.rs
+++ b/crates/pod-core/src/agent.rs
@@ -1,13 +1,15 @@
 use crate::action::{Action, AgentConstraints};
+use crate::contract::AgentRuntimeProfile;
 use crate::id::{AgentId, EntityId};
 use crate::observation::Observation;
 use serde::{Deserialize, Serialize};
 
 /// The type of agent — used for logging/analytics only.
 /// The engine treats all agents identically regardless of type.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum AgentType {
     /// Human player (input from keyboard/mouse/gamepad)
+    #[default]
     Human,
     /// LLM-powered agent (Claude, GPT, etc.)
     LlmAgent,
@@ -32,6 +34,11 @@ pub trait Agent: Send {
 
     /// What kind of agent (for analytics, not gameplay)
     fn agent_type(&self) -> AgentType;
+
+    /// Explicit runtime profile used by networking, replay, and parity audits.
+    fn runtime_profile(&self) -> AgentRuntimeProfile {
+        AgentRuntimeProfile::for_agent_type(self.agent_type())
+    }
 
     /// Receive observation for this tick.
     /// Called once per tick before decide().
@@ -145,8 +152,12 @@ impl HumanAgent {
 }
 
 impl Agent for HumanAgent {
-    fn id(&self) -> AgentId { self.id }
-    fn agent_type(&self) -> AgentType { AgentType::Human }
+    fn id(&self) -> AgentId {
+        self.id
+    }
+    fn agent_type(&self) -> AgentType {
+        AgentType::Human
+    }
 
     fn observe(&mut self, observation: Observation) {
         self.last_observation = Some(observation);
@@ -157,8 +168,12 @@ impl Agent for HumanAgent {
         std::mem::take(&mut self.input_buffer)
     }
 
-    fn constraints(&self) -> &AgentConstraints { &self.constraints }
-    fn constraints_mut(&mut self) -> &mut AgentConstraints { &mut self.constraints }
+    fn constraints(&self) -> &AgentConstraints {
+        &self.constraints
+    }
+    fn constraints_mut(&mut self) -> &mut AgentConstraints {
+        &mut self.constraints
+    }
 
     fn introspect(&self) -> AgentIntrospection {
         AgentIntrospection {
@@ -194,12 +209,22 @@ impl IdleAgent {
 }
 
 impl Agent for IdleAgent {
-    fn id(&self) -> AgentId { self.id }
-    fn agent_type(&self) -> AgentType { AgentType::ScriptedNpc }
+    fn id(&self) -> AgentId {
+        self.id
+    }
+    fn agent_type(&self) -> AgentType {
+        AgentType::ScriptedNpc
+    }
     fn observe(&mut self, _observation: Observation) {}
-    fn decide(&mut self) -> Vec<Action> { vec![Action::Idle] }
-    fn constraints(&self) -> &AgentConstraints { &self.constraints }
-    fn constraints_mut(&mut self) -> &mut AgentConstraints { &mut self.constraints }
+    fn decide(&mut self) -> Vec<Action> {
+        vec![Action::Idle]
+    }
+    fn constraints(&self) -> &AgentConstraints {
+        &self.constraints
+    }
+    fn constraints_mut(&mut self) -> &mut AgentConstraints {
+        &mut self.constraints
+    }
 
     fn introspect(&self) -> AgentIntrospection {
         AgentIntrospection {

--- a/crates/pod-core/src/app.rs
+++ b/crates/pod-core/src/app.rs
@@ -1,0 +1,395 @@
+use std::any::{Any, TypeId};
+use std::collections::HashMap;
+
+use crate::action::AgentAction;
+use crate::component::{
+    AgentControlled, ColorRect, CombatLoadout, CompanionRoster, CreatureIdentity, EncounterState,
+    Health, Inventory, Label, Movement, Perception, Script, SkillBook, Sprite, Transform,
+    Transform3D, Velocity,
+};
+use crate::contract::{VersionedAgentAction, VersionedObservation};
+use crate::observation::Observation;
+use crate::tick::TickResult;
+use crate::World;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SchedulePhase {
+    Startup,
+    PreTick,
+    PostTick,
+    RenderPrep,
+    Broadcast,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RegisteredTypeCategory {
+    Component,
+    Resource,
+    Contract,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypeMetadata {
+    pub key: &'static str,
+    pub rust_type_name: &'static str,
+    pub category: RegisteredTypeCategory,
+}
+
+#[derive(Default)]
+pub struct TypeRegistry {
+    entries: HashMap<TypeId, TypeMetadata>,
+}
+
+impl TypeRegistry {
+    pub fn register_component<T: 'static>(&mut self, key: &'static str) {
+        self.entries.insert(
+            TypeId::of::<T>(),
+            TypeMetadata {
+                key,
+                rust_type_name: std::any::type_name::<T>(),
+                category: RegisteredTypeCategory::Component,
+            },
+        );
+    }
+
+    pub fn register_resource<T: 'static>(&mut self, key: &'static str) {
+        self.entries.insert(
+            TypeId::of::<T>(),
+            TypeMetadata {
+                key,
+                rust_type_name: std::any::type_name::<T>(),
+                category: RegisteredTypeCategory::Resource,
+            },
+        );
+    }
+
+    pub fn register_contract<T: 'static>(&mut self, key: &'static str) {
+        self.entries.insert(
+            TypeId::of::<T>(),
+            TypeMetadata {
+                key,
+                rust_type_name: std::any::type_name::<T>(),
+                category: RegisteredTypeCategory::Contract,
+            },
+        );
+    }
+
+    pub fn metadata<T: 'static>(&self) -> Option<&TypeMetadata> {
+        self.entries.get(&TypeId::of::<T>())
+    }
+}
+
+#[derive(Default)]
+pub struct ResourceStore {
+    entries: HashMap<TypeId, Box<dyn Any + Send>>,
+}
+
+impl ResourceStore {
+    pub fn insert<T: Send + 'static>(&mut self, value: T) -> Option<T> {
+        self.entries
+            .insert(TypeId::of::<T>(), Box::new(value))
+            .and_then(|old| old.downcast::<T>().ok())
+            .map(|boxed| *boxed)
+    }
+
+    pub fn get<T: Send + 'static>(&self) -> Option<&T> {
+        self.entries
+            .get(&TypeId::of::<T>())
+            .and_then(|value| value.downcast_ref::<T>())
+    }
+
+    pub fn get_mut<T: Send + 'static>(&mut self) -> Option<&mut T> {
+        self.entries
+            .get_mut(&TypeId::of::<T>())
+            .and_then(|value| value.downcast_mut::<T>())
+    }
+}
+
+pub struct AppContext<'a> {
+    pub world: &'a mut World,
+    pub resources: &'a mut ResourceStore,
+    pub types: &'a mut TypeRegistry,
+}
+
+impl<'a> AppContext<'a> {
+    pub fn insert_resource<T: Send + 'static>(&mut self, value: T) {
+        self.types
+            .register_resource::<T>(std::any::type_name::<T>());
+        let _ = self.resources.insert(value);
+    }
+
+    pub fn resource<T: Send + 'static>(&self) -> Option<&T> {
+        self.resources.get::<T>()
+    }
+
+    pub fn resource_mut<T: Send + 'static>(&mut self) -> Option<&mut T> {
+        self.resources.get_mut::<T>()
+    }
+}
+
+type SystemFn = Box<dyn FnMut(&mut AppContext<'_>) + Send>;
+
+struct SystemEntry {
+    name: String,
+    system: SystemFn,
+}
+
+pub trait Plugin: Send + Sync {
+    fn build(&self, app: &mut App);
+}
+
+#[derive(Debug, Clone)]
+pub struct LastTickResult(pub TickResult);
+
+pub struct App {
+    world: World,
+    resources: ResourceStore,
+    types: TypeRegistry,
+    startup_ran: bool,
+    startup: Vec<SystemEntry>,
+    pre_tick: Vec<SystemEntry>,
+    post_tick: Vec<SystemEntry>,
+    render_prep: Vec<SystemEntry>,
+    broadcast: Vec<SystemEntry>,
+}
+
+impl App {
+    pub fn new(seed: u64) -> Self {
+        let mut app = Self {
+            world: World::new(seed),
+            resources: ResourceStore::default(),
+            types: TypeRegistry::default(),
+            startup_ran: false,
+            startup: Vec::new(),
+            pre_tick: Vec::new(),
+            post_tick: Vec::new(),
+            render_prep: Vec::new(),
+            broadcast: Vec::new(),
+        };
+        app.register_core_types();
+        app
+    }
+
+    pub fn world(&self) -> &World {
+        &self.world
+    }
+
+    pub fn world_mut(&mut self) -> &mut World {
+        &mut self.world
+    }
+
+    pub fn type_registry(&self) -> &TypeRegistry {
+        &self.types
+    }
+
+    pub fn resources(&self) -> &ResourceStore {
+        &self.resources
+    }
+
+    pub fn resources_mut(&mut self) -> &mut ResourceStore {
+        &mut self.resources
+    }
+
+    pub fn insert_resource<T: Send + 'static>(&mut self, value: T) -> &mut Self {
+        self.types
+            .register_resource::<T>(std::any::type_name::<T>());
+        let _ = self.resources.insert(value);
+        self
+    }
+
+    pub fn add_plugin<P: Plugin + 'static>(&mut self, plugin: P) -> &mut Self {
+        plugin.build(self);
+        self
+    }
+
+    pub fn add_system<F>(
+        &mut self,
+        phase: SchedulePhase,
+        name: impl Into<String>,
+        system: F,
+    ) -> &mut Self
+    where
+        F: FnMut(&mut AppContext<'_>) + Send + 'static,
+    {
+        self.systems_for_phase_mut(phase).push(SystemEntry {
+            name: name.into(),
+            system: Box::new(system),
+        });
+        self
+    }
+
+    pub fn update(&mut self) -> TickResult {
+        self.ensure_started();
+        self.run_phase(SchedulePhase::PreTick);
+
+        let result = self.world.step();
+        let _ = self.resources.insert(LastTickResult(result.clone()));
+
+        self.run_phase(SchedulePhase::PostTick);
+        self.run_phase(SchedulePhase::Broadcast);
+        result
+    }
+
+    pub fn prepare_render(&mut self) {
+        self.ensure_started();
+        self.run_phase(SchedulePhase::RenderPrep);
+    }
+
+    fn ensure_started(&mut self) {
+        if self.startup_ran {
+            return;
+        }
+
+        self.run_phase(SchedulePhase::Startup);
+        self.startup_ran = true;
+    }
+
+    fn run_phase(&mut self, phase: SchedulePhase) {
+        let mut systems = std::mem::take(self.systems_for_phase_mut(phase));
+        {
+            let mut ctx = AppContext {
+                world: &mut self.world,
+                resources: &mut self.resources,
+                types: &mut self.types,
+            };
+
+            for entry in systems.iter_mut() {
+                log::trace!("running {:?} system {}", phase, entry.name);
+                (entry.system)(&mut ctx);
+            }
+        }
+        *self.systems_for_phase_mut(phase) = systems;
+    }
+
+    fn systems_for_phase_mut(&mut self, phase: SchedulePhase) -> &mut Vec<SystemEntry> {
+        match phase {
+            SchedulePhase::Startup => &mut self.startup,
+            SchedulePhase::PreTick => &mut self.pre_tick,
+            SchedulePhase::PostTick => &mut self.post_tick,
+            SchedulePhase::RenderPrep => &mut self.render_prep,
+            SchedulePhase::Broadcast => &mut self.broadcast,
+        }
+    }
+
+    fn register_core_types(&mut self) {
+        self.types.register_component::<Transform>("Transform");
+        self.types.register_component::<Transform3D>("Transform3D");
+        self.types.register_component::<Velocity>("Velocity");
+        self.types.register_component::<Sprite>("Sprite");
+        self.types.register_component::<ColorRect>("ColorRect");
+        self.types
+            .register_component::<AgentControlled>("AgentControlled");
+        self.types.register_component::<Health>("Health");
+        self.types.register_component::<Label>("Label");
+        self.types.register_component::<Perception>("Perception");
+        self.types.register_component::<Script>("Script");
+        self.types.register_component::<Movement>("Movement");
+        self.types
+            .register_component::<CombatLoadout>("CombatLoadout");
+        self.types.register_component::<SkillBook>("SkillBook");
+        self.types.register_component::<Inventory>("Inventory");
+        self.types
+            .register_component::<CompanionRoster>("CompanionRoster");
+        self.types
+            .register_component::<CreatureIdentity>("CreatureIdentity");
+        self.types
+            .register_component::<EncounterState>("EncounterState");
+        self.types.register_contract::<Observation>("Observation");
+        self.types.register_contract::<AgentAction>("AgentAction");
+        self.types
+            .register_contract::<VersionedObservation>("VersionedObservation");
+        self.types
+            .register_contract::<VersionedAgentAction>("VersionedAgentAction");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{App, LastTickResult, Plugin, RegisteredTypeCategory, SchedulePhase};
+
+    struct TracePlugin;
+
+    impl Plugin for TracePlugin {
+        fn build(&self, app: &mut App) {
+            app.add_system(SchedulePhase::Startup, "startup", |ctx| {
+                ctx.insert_resource(Vec::<String>::new());
+                ctx.resource_mut::<Vec<String>>()
+                    .expect("trace resource")
+                    .push("startup".into());
+            });
+            app.add_system(SchedulePhase::PreTick, "pre", |ctx| {
+                ctx.resource_mut::<Vec<String>>()
+                    .expect("trace resource")
+                    .push("pre".into());
+            });
+            app.add_system(SchedulePhase::PostTick, "post", |ctx| {
+                ctx.resource_mut::<Vec<String>>()
+                    .expect("trace resource")
+                    .push("post".into());
+            });
+            app.add_system(SchedulePhase::Broadcast, "broadcast", |ctx| {
+                let tick = ctx
+                    .resource::<LastTickResult>()
+                    .expect("last tick result")
+                    .0
+                    .tick;
+                ctx.resource_mut::<Vec<String>>()
+                    .expect("trace resource")
+                    .push(format!("broadcast:{tick}"));
+            });
+            app.add_system(SchedulePhase::RenderPrep, "render", |ctx| {
+                ctx.resource_mut::<Vec<String>>()
+                    .expect("trace resource")
+                    .push("render".into());
+            });
+        }
+    }
+
+    #[test]
+    fn app_runs_startup_once_and_keeps_schedule_order_deterministic() {
+        let mut app = App::new(42);
+        app.add_plugin(TracePlugin);
+
+        let first = app.update();
+        assert_eq!(first.tick, 0);
+
+        app.prepare_render();
+
+        let second = app.update();
+        assert_eq!(second.tick, 1);
+
+        let trace = app
+            .resources()
+            .get::<Vec<String>>()
+            .expect("trace resource should exist");
+        assert_eq!(
+            trace,
+            &vec![
+                "startup".to_string(),
+                "pre".to_string(),
+                "post".to_string(),
+                "broadcast:0".to_string(),
+                "render".to_string(),
+                "pre".to_string(),
+                "post".to_string(),
+                "broadcast:1".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn app_registers_core_contracts_and_components() {
+        let app = App::new(7);
+        let transform = app
+            .type_registry()
+            .metadata::<crate::component::Transform>()
+            .expect("transform metadata");
+        assert_eq!(transform.category, RegisteredTypeCategory::Component);
+
+        let observation = app
+            .type_registry()
+            .metadata::<crate::observation::Observation>()
+            .expect("observation metadata");
+        assert_eq!(observation.category, RegisteredTypeCategory::Contract);
+    }
+}

--- a/crates/pod-core/src/component.rs
+++ b/crates/pod-core/src/component.rs
@@ -1,6 +1,6 @@
+use crate::id::{AgentId, EntityId};
 use glam::{Quat, Vec2, Vec3};
 use serde::{Deserialize, Serialize};
-use crate::id::AgentId;
 
 // ============================================================
 // SPATIAL COMPONENTS
@@ -381,10 +381,10 @@ impl Collider {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Sprite {
-    pub texture: String,     // asset key
-    pub frame: u32,          // for spritesheets
-    pub layer: i32,          // draw order
-    pub color: [f32; 4],     // RGBA tint
+    pub texture: String, // asset key
+    pub frame: u32,      // for spritesheets
+    pub layer: i32,      // draw order
+    pub color: [f32; 4], // RGBA tint
     pub visible: bool,
 }
 
@@ -492,6 +492,244 @@ impl Team {
     }
 }
 
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum CombatStyle {
+    #[default]
+    Melee,
+    Ranged,
+    Magic,
+    Summoning,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CombatLoadout {
+    pub style: CombatStyle,
+    pub attack_range: f32,
+    pub attack_speed_ticks: u32,
+    pub max_hit: f32,
+    pub auto_retaliate: bool,
+    pub equipped_weapon: Option<String>,
+    pub offhand_item: Option<String>,
+    pub active_ability_bar: Vec<String>,
+}
+
+impl Default for CombatLoadout {
+    fn default() -> Self {
+        Self {
+            style: CombatStyle::Melee,
+            attack_range: 80.0,
+            attack_speed_ticks: 30,
+            max_hit: 10.0,
+            auto_retaliate: true,
+            equipped_weapon: Some("bronze-sword".to_string()),
+            offhand_item: None,
+            active_ability_bar: vec!["slash".to_string(), "kick".to_string()],
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum SkillKind {
+    #[default]
+    Attack,
+    Strength,
+    Defence,
+    Ranged,
+    Magic,
+    Constitution,
+    Mining,
+    Woodcutting,
+    Fishing,
+    Cooking,
+    Smithing,
+    Crafting,
+    Slayer,
+    Taming,
+    Bonding,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct SkillProgress {
+    pub kind: SkillKind,
+    pub level: u16,
+    pub experience: u32,
+    pub xp_to_next_level: u32,
+}
+
+impl SkillProgress {
+    pub fn new(kind: SkillKind, level: u16, experience: u32, xp_to_next_level: u32) -> Self {
+        Self {
+            kind,
+            level,
+            experience,
+            xp_to_next_level,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkillBook {
+    pub combat_level: u16,
+    pub total_level: u16,
+    pub skills: Vec<SkillProgress>,
+}
+
+impl Default for SkillBook {
+    fn default() -> Self {
+        let skills = vec![
+            SkillProgress::new(SkillKind::Attack, 1, 0, 83),
+            SkillProgress::new(SkillKind::Strength, 1, 0, 83),
+            SkillProgress::new(SkillKind::Defence, 1, 0, 83),
+            SkillProgress::new(SkillKind::Ranged, 1, 0, 83),
+            SkillProgress::new(SkillKind::Magic, 1, 0, 83),
+            SkillProgress::new(SkillKind::Constitution, 10, 1_154, 1_358),
+            SkillProgress::new(SkillKind::Taming, 1, 0, 83),
+            SkillProgress::new(SkillKind::Bonding, 1, 0, 83),
+        ];
+        Self {
+            combat_level: 3,
+            total_level: skills.iter().map(|skill| skill.level).sum(),
+            skills,
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ItemStack {
+    pub item_id: String,
+    pub display_name: String,
+    pub quantity: u32,
+    pub stackable: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Inventory {
+    pub capacity: u8,
+    pub carried_weight: f32,
+    pub coins: u64,
+    pub items: Vec<ItemStack>,
+}
+
+impl Default for Inventory {
+    fn default() -> Self {
+        Self {
+            capacity: 28,
+            carried_weight: 0.0,
+            coins: 0,
+            items: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum CreatureTemperament {
+    Aggressive,
+    Timid,
+    #[default]
+    Neutral,
+    Loyal,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CreatureIdentity {
+    pub species_id: String,
+    pub species_name: String,
+    pub elemental_affinity: String,
+    pub level: u16,
+    pub temperament: CreatureTemperament,
+    pub capture_difficulty: f32,
+    pub is_wild: bool,
+}
+
+impl Default for CreatureIdentity {
+    fn default() -> Self {
+        Self {
+            species_id: String::new(),
+            species_name: String::new(),
+            elemental_affinity: "neutral".to_string(),
+            level: 1,
+            temperament: CreatureTemperament::Neutral,
+            capture_difficulty: 0.5,
+            is_wild: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CompanionCreature {
+    pub creature: CreatureIdentity,
+    pub nickname: Option<String>,
+    pub current_health: f32,
+    pub max_health: f32,
+    pub combat_style: CombatStyle,
+    pub mood: f32,
+}
+
+impl Default for CompanionCreature {
+    fn default() -> Self {
+        Self {
+            creature: CreatureIdentity::default(),
+            nickname: None,
+            current_health: 10.0,
+            max_health: 10.0,
+            combat_style: CombatStyle::Summoning,
+            mood: 1.0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CompanionRoster {
+    pub active_slot: Option<u8>,
+    pub party_capacity: u8,
+    pub creatures: Vec<CompanionCreature>,
+}
+
+impl Default for CompanionRoster {
+    fn default() -> Self {
+        Self {
+            active_slot: None,
+            party_capacity: 6,
+            creatures: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum EncounterKind {
+    #[default]
+    OpenWorld,
+    Duel,
+    WildCreature,
+    Boss,
+    Raid,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EncounterState {
+    pub encounter_id: u64,
+    pub kind: EncounterKind,
+    pub threat_level: f32,
+    pub primary_target: Option<EntityId>,
+    pub active_turn_owner: Option<EntityId>,
+    pub capture_allowed: bool,
+    pub in_combat: bool,
+}
+
+impl Default for EncounterState {
+    fn default() -> Self {
+        Self {
+            encounter_id: 0,
+            kind: EncounterKind::OpenWorld,
+            threat_level: 0.0,
+            primary_target: None,
+            active_turn_owner: None,
+            capture_allowed: false,
+            in_combat: false,
+        }
+    }
+}
+
 // ============================================================
 // AGENT PERCEPTION
 // ============================================================
@@ -524,7 +762,7 @@ impl Default for Perception {
 /// Attached Luau script for custom behavior
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Script {
-    pub source: String,       // script asset key
+    pub source: String, // script asset key
     pub enabled: bool,
 }
 

--- a/crates/pod-core/src/contract.rs
+++ b/crates/pod-core/src/contract.rs
@@ -1,0 +1,217 @@
+use serde::{Deserialize, Serialize};
+
+use crate::action::AgentAction;
+use crate::agent::AgentType;
+use crate::observation::Observation;
+
+pub const RUNTIME_CONTRACT_VERSION_V1: u16 = 1;
+
+/// Semantic version identifier for runtime contracts exchanged between
+/// human clients, local AI, and remote AI connectors.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum RuntimeContractVersion {
+    #[default]
+    V1,
+}
+
+impl RuntimeContractVersion {
+    pub fn as_u16(self) -> u16 {
+        match self {
+            Self::V1 => RUNTIME_CONTRACT_VERSION_V1,
+        }
+    }
+}
+
+/// Role is explicit and auditable. Permissions flow from capabilities,
+/// not from hidden engine-side branches.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum AgentRole {
+    #[default]
+    Player,
+    Npc,
+    Companion,
+    WorldSystem,
+}
+
+/// Capability gates sit above the shared action schema so humans and AI still
+/// speak the same language even when role permissions differ.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentCapabilities {
+    pub can_combat: bool,
+    pub can_trade: bool,
+    pub can_join_party: bool,
+    pub can_capture_creatures: bool,
+    pub can_command_companions: bool,
+    pub can_spawn_world_entities: bool,
+}
+
+impl AgentCapabilities {
+    pub fn player_default() -> Self {
+        Self {
+            can_combat: true,
+            can_trade: true,
+            can_join_party: true,
+            can_capture_creatures: true,
+            can_command_companions: true,
+            can_spawn_world_entities: false,
+        }
+    }
+
+    pub fn npc_default() -> Self {
+        Self {
+            can_combat: true,
+            can_trade: false,
+            can_join_party: false,
+            can_capture_creatures: false,
+            can_command_companions: false,
+            can_spawn_world_entities: false,
+        }
+    }
+
+    pub fn companion_default() -> Self {
+        Self {
+            can_combat: true,
+            can_trade: false,
+            can_join_party: false,
+            can_capture_creatures: false,
+            can_command_companions: false,
+            can_spawn_world_entities: false,
+        }
+    }
+
+    pub fn system_default() -> Self {
+        Self {
+            can_combat: false,
+            can_trade: false,
+            can_join_party: false,
+            can_capture_creatures: false,
+            can_command_companions: true,
+            can_spawn_world_entities: true,
+        }
+    }
+}
+
+impl Default for AgentCapabilities {
+    fn default() -> Self {
+        Self::player_default()
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentRuntimeProfile {
+    pub role: AgentRole,
+    pub agent_type: AgentType,
+    pub capabilities: AgentCapabilities,
+}
+
+impl AgentRuntimeProfile {
+    pub fn for_agent_type(agent_type: AgentType) -> Self {
+        match agent_type {
+            AgentType::Human | AgentType::LlmAgent | AgentType::NeuralAgent => Self {
+                role: AgentRole::Player,
+                agent_type,
+                capabilities: AgentCapabilities::player_default(),
+            },
+            AgentType::ScriptedNpc => Self {
+                role: AgentRole::Npc,
+                agent_type,
+                capabilities: AgentCapabilities::npc_default(),
+            },
+            AgentType::System => Self {
+                role: AgentRole::WorldSystem,
+                agent_type,
+                capabilities: AgentCapabilities::system_default(),
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VersionedAgentAction {
+    pub version: RuntimeContractVersion,
+    pub profile: AgentRuntimeProfile,
+    pub payload: AgentAction,
+}
+
+impl VersionedAgentAction {
+    pub fn new(profile: AgentRuntimeProfile, payload: AgentAction) -> Self {
+        Self {
+            version: RuntimeContractVersion::V1,
+            profile,
+            payload,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VersionedObservation {
+    pub version: RuntimeContractVersion,
+    pub profile: AgentRuntimeProfile,
+    pub payload: Observation,
+}
+
+impl VersionedObservation {
+    pub fn new(profile: AgentRuntimeProfile, payload: Observation) -> Self {
+        Self {
+            version: RuntimeContractVersion::V1,
+            profile,
+            payload,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::action::{Action, AgentAction};
+    use crate::agent::AgentType;
+    use crate::id::AgentId;
+    use crate::observation::Observation;
+
+    use super::{
+        AgentCapabilities, AgentRole, AgentRuntimeProfile, RuntimeContractVersion,
+        VersionedAgentAction, VersionedObservation, RUNTIME_CONTRACT_VERSION_V1,
+    };
+
+    #[test]
+    fn runtime_version_maps_to_wire_number() {
+        assert_eq!(
+            RuntimeContractVersion::V1.as_u16(),
+            RUNTIME_CONTRACT_VERSION_V1
+        );
+    }
+
+    #[test]
+    fn runtime_profile_defaults_match_agent_type() {
+        let player = AgentRuntimeProfile::for_agent_type(AgentType::Human);
+        assert_eq!(player.role, AgentRole::Player);
+        assert!(player.capabilities.can_capture_creatures);
+
+        let npc = AgentRuntimeProfile::for_agent_type(AgentType::ScriptedNpc);
+        assert_eq!(npc.role, AgentRole::Npc);
+        assert!(!npc.capabilities.can_trade);
+
+        let system = AgentRuntimeProfile::for_agent_type(AgentType::System);
+        assert_eq!(system.role, AgentRole::WorldSystem);
+        assert!(system.capabilities.can_spawn_world_entities);
+    }
+
+    #[test]
+    fn versioned_contracts_wrap_payloads_without_mutating_them() {
+        let profile = AgentRuntimeProfile {
+            role: AgentRole::Player,
+            agent_type: AgentType::Human,
+            capabilities: AgentCapabilities::player_default(),
+        };
+        let action = AgentAction {
+            agent_id: AgentId::new(),
+            tick: 7,
+            action: Action::Idle,
+        };
+        let versioned_action = VersionedAgentAction::new(profile, action.clone());
+        assert_eq!(versioned_action.payload.tick, 7);
+
+        let observation = Observation::default();
+        let versioned_observation = VersionedObservation::new(profile, observation.clone());
+        assert_eq!(versioned_observation.payload.tick, observation.tick);
+    }
+}

--- a/crates/pod-core/src/event.rs
+++ b/crates/pod-core/src/event.rs
@@ -1,6 +1,6 @@
+use crate::id::{AgentId, EntityId};
 use glam::Vec2;
 use serde::{Deserialize, Serialize};
-use crate::id::{AgentId, EntityId};
 
 /// Game events — things that happen in the world.
 /// Events are broadcast to agents based on their perception.
@@ -14,8 +14,13 @@ pub struct GameEvent {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Event {
     // === LIFECYCLE ===
-    EntitySpawned { entity: EntityId, entity_type: String },
-    EntityDestroyed { entity: EntityId },
+    EntitySpawned {
+        entity: EntityId,
+        entity_type: String,
+    },
+    EntityDestroyed {
+        entity: EntityId,
+    },
 
     // === COMBAT ===
     Damage {
@@ -31,6 +36,29 @@ pub enum Event {
         source: Option<EntityId>,
         target: EntityId,
         amount: f32,
+    },
+    SkillXpGained {
+        entity: EntityId,
+        skill: String,
+        amount: u32,
+        new_level: u16,
+    },
+    CreatureCaptured {
+        agent_id: AgentId,
+        species_id: String,
+        nickname: Option<String>,
+    },
+    CompanionSummoned {
+        agent_id: AgentId,
+        species_id: String,
+    },
+    EncounterStarted {
+        encounter_id: u64,
+        kind: String,
+    },
+    EncounterEnded {
+        encounter_id: u64,
+        victory: bool,
     },
 
     // === PHYSICS ===
@@ -50,27 +78,61 @@ pub enum Event {
     },
 
     // === AGENT ===
-    AgentJoined { agent_id: AgentId, agent_type: String },
-    AgentLeft { agent_id: AgentId },
-    AgentSpoke { agent_id: AgentId, message: String, volume: f32 },
+    AgentJoined {
+        agent_id: AgentId,
+        agent_type: String,
+    },
+    AgentLeft {
+        agent_id: AgentId,
+    },
+    AgentSpoke {
+        agent_id: AgentId,
+        message: String,
+        volume: f32,
+    },
 
     // === INTERACTION ===
-    ItemPickedUp { entity: EntityId, item: EntityId },
-    ItemDropped { entity: EntityId, item: EntityId },
-    ItemUsed { entity: EntityId, item: String },
+    ItemPickedUp {
+        entity: EntityId,
+        item: EntityId,
+    },
+    ItemDropped {
+        entity: EntityId,
+        item: EntityId,
+    },
+    ItemUsed {
+        entity: EntityId,
+        item: String,
+    },
 
     // === GAME ===
-    ObjectiveUpdated { id: String, progress: f32 },
-    ObjectiveCompleted { id: String },
-    GameStateChanged { new_state: String },
-    ScoreChanged { team: u8, score: i32 },
+    ObjectiveUpdated {
+        id: String,
+        progress: f32,
+    },
+    ObjectiveCompleted {
+        id: String,
+    },
+    GameStateChanged {
+        new_state: String,
+    },
+    ScoreChanged {
+        team: u8,
+        score: i32,
+    },
 
     // === AUDIO CUE ===
     /// Sound event — used for both actual audio AND agent perception
-    Sound { name: String, intensity: f32 },
+    Sound {
+        name: String,
+        intensity: f32,
+    },
 
     // === CUSTOM ===
-    Custom { name: String, data: String },
+    Custom {
+        name: String,
+        data: String,
+    },
 }
 
 /// Collects events during a tick, then broadcasts them

--- a/crates/pod-core/src/lib.rs
+++ b/crates/pod-core/src/lib.rs
@@ -29,33 +29,45 @@
 #![allow(clippy::unused_enumerate_index)]
 #![allow(clippy::unwrap_or_default)]
 
-pub mod component;
-pub mod agent;
 pub mod action;
-pub mod observation;
-pub mod event;
-pub mod world;
-pub mod tick;
-pub mod id;
-pub mod replay;
-pub mod orchestrator;
+pub mod agent;
+pub mod app;
+pub mod component;
 pub mod constraint;
+pub mod contract;
+pub mod event;
+pub mod id;
+pub mod observation;
 pub mod observation_filter;
+pub mod orchestrator;
+pub mod replay;
+pub mod tick;
+pub mod world;
 
-pub use component::*;
-pub use agent::*;
 pub use action::*;
-pub use observation::*;
-pub use event::*;
-pub use world::World;
-pub use id::*;
-pub use replay::{ReplayRecorder, ReplayPlayer, ReplayFile, ReplayHeader, DecisionTrace};
-pub use orchestrator::{AgentOrchestrator, AgentBatch, PriorityScore, DecisionFreshness};
+pub use agent::*;
+pub use app::{
+    App, AppContext, LastTickResult, Plugin, RegisteredTypeCategory, ResourceStore, SchedulePhase,
+    TypeMetadata, TypeRegistry,
+};
+pub use component::*;
 pub use constraint::{
-    CooldownTracker, ActionBudget, ReactionTimeGate, ConstraintProfile, ConstraintViolation,
+    ActionBudget, ConstraintProfile, ConstraintViolation, CooldownTracker, ReactionTimeGate,
     ValidationPipeline,
 };
-pub use observation_filter::{ObservationFilter, FilteredObservation, SalienceScore, ObservationHistory};
+pub use contract::{
+    AgentCapabilities, AgentRole, AgentRuntimeProfile, RuntimeContractVersion,
+    VersionedAgentAction, VersionedObservation, RUNTIME_CONTRACT_VERSION_V1,
+};
+pub use event::*;
+pub use id::*;
+pub use observation::*;
+pub use observation_filter::{
+    FilteredObservation, ObservationFilter, ObservationHistory, SalienceScore,
+};
+pub use orchestrator::{AgentBatch, AgentOrchestrator, DecisionFreshness, PriorityScore};
+pub use replay::{DecisionTrace, ReplayFile, ReplayHeader, ReplayPlayer, ReplayRecorder};
+pub use world::World;
 
 /// Fixed tick rate — all agents operate on the same clock
 pub const TICKS_PER_SECOND: u32 = 60;

--- a/crates/pod-core/src/observation.rs
+++ b/crates/pod-core/src/observation.rs
@@ -1,7 +1,11 @@
+use crate::component::{
+    CombatLoadout, CombatStyle, CompanionRoster, CreatureIdentity, EncounterState, Inventory,
+    SkillProgress, Team,
+};
+use crate::contract::AgentRuntimeProfile;
+use crate::id::{AgentId, EntityId};
 use glam::Vec2;
 use serde::{Deserialize, Serialize};
-use crate::id::{AgentId, EntityId};
-use crate::component::Team;
 
 /// Complete observation delivered to an agent each tick.
 /// This is the SAME structure for human and AI agents.
@@ -9,6 +13,7 @@ use crate::component::Team;
 /// For humans: this drives what's rendered on screen.
 /// For AI: this is serialized to JSON and sent to the decision backend.
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct Observation {
     /// Current tick number
     pub tick: u64,
@@ -36,9 +41,11 @@ pub struct Observation {
 
 /// What the agent knows about itself (always full info)
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct SelfState {
     pub agent_id: AgentId,
     pub entity_id: EntityId,
+    pub runtime_profile: AgentRuntimeProfile,
     pub position: Vec2,
     pub rotation: f32,
     pub velocity: Vec2,
@@ -46,6 +53,11 @@ pub struct SelfState {
     pub max_health: Option<f32>,
     pub team: Team,
     pub cooldowns: Vec<CooldownState>,
+    pub combat_loadout: Option<CombatLoadout>,
+    pub skills: Vec<SkillProgress>,
+    pub inventory: Option<Inventory>,
+    pub companion_roster: Option<CompanionRoster>,
+    pub encounter: Option<EncounterState>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -57,7 +69,8 @@ pub struct CooldownState {
 
 /// An entity visible to the observing agent.
 /// Information is limited by what the agent can actually see.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct VisibleEntity {
     pub entity_id: EntityId,
     pub entity_type: String,
@@ -68,12 +81,15 @@ pub struct VisibleEntity {
     pub relationship: Relationship,
     /// Only visible if the entity is close enough or has visible health bar
     pub health_fraction: Option<f32>,
+    pub combat_style: Option<CombatStyle>,
+    pub creature: Option<CreatureIdentity>,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize)]
 pub enum Relationship {
     Friendly,
     Hostile,
+    #[default]
     Neutral,
     Unknown,
 }
@@ -131,6 +147,69 @@ impl Observation {
             self.self_state.rotation.to_degrees(),
         ));
 
+        prompt.push_str(&format!(
+            "PROFILE: role={:?} type={:?} team={:?}\n",
+            self.self_state.runtime_profile.role,
+            self.self_state.runtime_profile.agent_type,
+            self.self_state.team,
+        ));
+
+        if let Some(loadout) = &self.self_state.combat_loadout {
+            prompt.push_str(&format!(
+                "COMBAT: {:?} range={:.0} speed={} max_hit={:.0} auto_retaliate={}\n",
+                loadout.style,
+                loadout.attack_range,
+                loadout.attack_speed_ticks,
+                loadout.max_hit,
+                loadout.auto_retaliate,
+            ));
+        }
+
+        if !self.self_state.skills.is_empty() {
+            let summary = self
+                .self_state
+                .skills
+                .iter()
+                .take(5)
+                .map(|skill| format!("{:?}:{}", skill.kind, skill.level))
+                .collect::<Vec<_>>()
+                .join(", ");
+            prompt.push_str(&format!("SKILLS: {summary}\n"));
+        }
+
+        if let Some(inventory) = &self.self_state.inventory {
+            prompt.push_str(&format!(
+                "INVENTORY: slots={}/{} coins={} weight={:.1}\n",
+                inventory.items.len(),
+                inventory.capacity,
+                inventory.coins,
+                inventory.carried_weight,
+            ));
+        }
+
+        if let Some(roster) = &self.self_state.companion_roster {
+            let active = roster
+                .active_slot
+                .map(|slot| slot.to_string())
+                .unwrap_or_else(|| "none".to_string());
+            prompt.push_str(&format!(
+                "COMPANIONS: active={} party={}/{}\n",
+                active,
+                roster.creatures.len(),
+                roster.party_capacity,
+            ));
+        }
+
+        if let Some(encounter) = &self.self_state.encounter {
+            prompt.push_str(&format!(
+                "ENCOUNTER: {:?} threat={:.1} capture_allowed={} in_combat={}\n",
+                encounter.kind,
+                encounter.threat_level,
+                encounter.capture_allowed,
+                encounter.in_combat,
+            ));
+        }
+
         if !self.visible_entities.is_empty() {
             prompt.push_str("VISIBLE:\n");
             for e in &self.visible_entities {
@@ -140,6 +219,15 @@ impl Observation {
                 ));
                 if let Some(hp) = e.health_fraction {
                     prompt.push_str(&format!(" hp={:.0}%", hp * 100.0));
+                }
+                if let Some(style) = e.combat_style {
+                    prompt.push_str(&format!(" style={style:?}"));
+                }
+                if let Some(creature) = &e.creature {
+                    prompt.push_str(&format!(
+                        " creature={} lvl={}",
+                        creature.species_name, creature.level
+                    ));
                 }
                 prompt.push('\n');
             }
@@ -165,7 +253,11 @@ impl Observation {
         if !self.objectives.is_empty() {
             prompt.push_str("OBJECTIVES:\n");
             for o in &self.objectives {
-                let status = if o.completed { "✓" } else { &format!("{:.0}%", o.progress * 100.0) };
+                let status = if o.completed {
+                    "✓"
+                } else {
+                    &format!("{:.0}%", o.progress * 100.0)
+                };
                 prompt.push_str(&format!("  {} [{}]\n", o.description, status));
             }
         }

--- a/crates/pod-core/src/observation_filter.rs
+++ b/crates/pod-core/src/observation_filter.rs
@@ -10,7 +10,7 @@
 //! - Estimates token count and compresses if needed
 //! - Maintains a sliding window of history for context
 
-use crate::observation::{Observation, VisibleEntity, AudibleEvent, Relationship};
+use crate::observation::{AudibleEvent, Observation, Relationship, VisibleEntity};
 use serde::{Deserialize, Serialize};
 
 /// Salience score for an entity (higher = more important)
@@ -57,7 +57,9 @@ impl SalienceScore {
 
 impl Ord for SalienceScore {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.0.partial_cmp(&other.0).unwrap_or(std::cmp::Ordering::Equal)
+        self.0
+            .partial_cmp(&other.0)
+            .unwrap_or(std::cmp::Ordering::Equal)
     }
 }
 
@@ -178,8 +180,12 @@ impl ObservationFilter {
             .take(self.max_events)
             .collect();
 
-        let estimated_tokens =
-            estimate_token_count(message_count, objective_count, &visible_entities, &audible_events);
+        let estimated_tokens = estimate_token_count(
+            message_count,
+            objective_count,
+            &visible_entities,
+            &audible_events,
+        );
 
         // Build filtered observation
         let was_compressed = estimated_tokens > self.token_budget as usize && self.token_budget > 0;
@@ -329,8 +335,8 @@ impl Default for ObservationHistory {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::id::EntityId;
     use crate::component::Team;
+    use crate::id::EntityId;
     use glam::Vec2;
 
     #[test]
@@ -344,6 +350,8 @@ mod tests {
             distance: 50.0,
             relationship: Relationship::Hostile,
             health_fraction: Some(0.2),
+            combat_style: None,
+            creature: None,
         };
 
         let score = SalienceScore::compute(&entity, 100.0, 100.0);
@@ -366,6 +374,7 @@ mod tests {
             self_state: crate::observation::SelfState {
                 agent_id: crate::id::AgentId::new(),
                 entity_id: EntityId(0),
+                runtime_profile: crate::contract::AgentRuntimeProfile::default(),
                 position: Vec2::ZERO,
                 rotation: 0.0,
                 velocity: Vec2::ZERO,
@@ -373,6 +382,11 @@ mod tests {
                 max_health: Some(100.0),
                 team: Team::None,
                 cooldowns: vec![],
+                combat_loadout: None,
+                skills: vec![],
+                inventory: None,
+                companion_roster: None,
+                encounter: None,
             },
             visible_entities: vec![],
             audible_events: vec![],
@@ -392,6 +406,8 @@ mod tests {
                 distance: 50.0 + i as f32,
                 relationship: Relationship::Hostile,
                 health_fraction: Some(0.5),
+                combat_style: None,
+                creature: None,
             });
         }
 

--- a/crates/pod-core/src/orchestrator.rs
+++ b/crates/pod-core/src/orchestrator.rs
@@ -185,13 +185,16 @@ impl AgentOrchestrator {
             .collect();
 
         // Sort by priority (fresh decisions first, then by priority score)
-        scheduled.sort_by(|a, b| {
-            match (a.freshness.is_fresh(), b.freshness.is_fresh()) {
+        scheduled.sort_by(
+            |a, b| match (a.freshness.is_fresh(), b.freshness.is_fresh()) {
                 (true, false) => std::cmp::Ordering::Less,
                 (false, true) => std::cmp::Ordering::Greater,
-                _ => b.priority.partial_cmp(&a.priority).unwrap_or(std::cmp::Ordering::Equal),
-            }
-        });
+                _ => b
+                    .priority
+                    .partial_cmp(&a.priority)
+                    .unwrap_or(std::cmp::Ordering::Equal),
+            },
+        );
 
         // Create batches
         let mut batches = Vec::new();
@@ -250,7 +253,8 @@ impl AgentOrchestrator {
 
     /// How many decisions left in budget
     pub fn decisions_remaining(&self) -> u32 {
-        self.decision_budget.saturating_sub(self.decisions_made_this_tick)
+        self.decision_budget
+            .saturating_sub(self.decisions_made_this_tick)
     }
 
     /// Reset budget for new tick
@@ -278,6 +282,7 @@ mod tests {
             self_state: SelfState {
                 agent_id: AgentId::new(),
                 entity_id: crate::id::EntityId(0),
+                runtime_profile: crate::contract::AgentRuntimeProfile::default(),
                 position: glam::Vec2::ZERO,
                 rotation: 0.0,
                 velocity: glam::Vec2::ZERO,
@@ -285,6 +290,11 @@ mod tests {
                 max_health: Some(100.0),
                 team: crate::component::Team::None,
                 cooldowns: vec![],
+                combat_loadout: None,
+                skills: vec![],
+                inventory: None,
+                companion_roster: None,
+                encounter: None,
             },
             visible_entities: vec![],
             audible_events: vec![],
@@ -307,6 +317,8 @@ mod tests {
             distance: 10.0,
             relationship: Relationship::Hostile,
             health_fraction: Some(0.5),
+            combat_style: None,
+            creature: None,
         });
 
         let score = PriorityScore::from_observation(&obs);

--- a/crates/pod-core/src/tick.rs
+++ b/crates/pod-core/src/tick.rs
@@ -1,4 +1,4 @@
-use crate::action::{validate_action, Action, AgentAction, ActionResult};
+use crate::action::{validate_action, Action, ActionResult, AgentAction};
 use crate::agent::AgentSlot;
 use crate::component::*;
 use crate::event::{Event, EventBus};
@@ -8,7 +8,7 @@ use crate::TICK_DURATION_SECS;
 use glam::{Vec2, Vec3};
 
 /// Result of a single tick
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TickResult {
     pub tick: u64,
     pub events: Vec<crate::event::GameEvent>,
@@ -71,7 +71,9 @@ pub fn execute_tick(
             .find(|s| s.agent.id() == agent_action.agent_id)
             .map(|s| s.agent.constraints().clone());
 
-        let Some(constraints) = constraints else { continue };
+        let Some(constraints) = constraints else {
+            continue;
+        };
 
         match validate_action(agent_action, &constraints, tick) {
             ActionResult::Valid => {
@@ -79,11 +81,7 @@ pub fn execute_tick(
                 actions_processed += 1;
             }
             ActionResult::Rejected(reason) => {
-                log::debug!(
-                    "Action rejected for {}: {}",
-                    agent_action.agent_id,
-                    reason
-                );
+                log::debug!("Action rejected for {}: {}", agent_action.agent_id, reason);
                 actions_rejected += 1;
             }
             ActionResult::Queued => {
@@ -155,6 +153,26 @@ fn build_observations(
             .get::<&Perception>(entity)
             .map(|p| *p)
             .unwrap_or_default();
+        let combat_loadout = ecs
+            .get::<&CombatLoadout>(entity)
+            .ok()
+            .map(|loadout| (*loadout).clone());
+        let skill_book = ecs
+            .get::<&SkillBook>(entity)
+            .ok()
+            .map(|book| (*book).clone());
+        let inventory = ecs
+            .get::<&Inventory>(entity)
+            .ok()
+            .map(|inventory| (*inventory).clone());
+        let companion_roster = ecs
+            .get::<&CompanionRoster>(entity)
+            .ok()
+            .map(|roster| (*roster).clone());
+        let encounter = ecs
+            .get::<&EncounterState>(entity)
+            .ok()
+            .map(|encounter| (*encounter).clone());
 
         let my_team = label.as_ref().map(|l| l.team).unwrap_or(Team::None);
         let my_pos = transform.position;
@@ -163,6 +181,7 @@ fn build_observations(
         let self_state = SelfState {
             agent_id: slot.agent.id(),
             entity_id: EntityId(entity.id() as u64),
+            runtime_profile: slot.agent.runtime_profile(),
             position: my_pos,
             rotation: my_rot,
             velocity,
@@ -170,6 +189,11 @@ fn build_observations(
             max_health: health.as_ref().map(|h| h.max),
             team: my_team,
             cooldowns: build_cooldowns(slot),
+            combat_loadout,
+            skills: skill_book.map(|book| book.skills).unwrap_or_default(),
+            inventory,
+            companion_roster,
+            encounter,
         };
 
         let event_source = if events.current_events().is_empty() {
@@ -237,6 +261,14 @@ fn build_observations(
                 distance,
                 relationship,
                 health_fraction: other_health,
+                combat_style: ecs
+                    .get::<&CombatLoadout>(other_entity)
+                    .ok()
+                    .map(|loadout| loadout.style),
+                creature: ecs
+                    .get::<&CreatureIdentity>(other_entity)
+                    .ok()
+                    .map(|creature| (*creature).clone()),
             });
         }
 
@@ -252,7 +284,12 @@ fn build_observations(
                 let dir = (e.origin - my_pos).normalize_or_zero();
                 let dist = e.origin.distance(my_pos);
                 AudibleEvent {
-                    event_type: format!("{:?}", e.event).split('{').next().unwrap_or("unknown").trim().to_string(),
+                    event_type: format!("{:?}", e.event)
+                        .split('{')
+                        .next()
+                        .unwrap_or("unknown")
+                        .trim()
+                        .to_string(),
                     direction: dir,
                     distance: dist,
                     intensity: 1.0 - (dist / perception.hearing_range).min(1.0),
@@ -271,7 +308,19 @@ fn build_observations(
             audible_events,
             messages,
             available_actions: vec![
-                "Move", "Stop", "Rotate", "LookAt", "Attack", "Interact", "Speak", "Idle",
+                "Move",
+                "Stop",
+                "Rotate",
+                "LookAt",
+                "Attack",
+                "UseAbility",
+                "Interact",
+                "Pickup",
+                "Drop",
+                "UseItem",
+                "Speak",
+                "Signal",
+                "Idle",
             ]
             .into_iter()
             .map(String::from)
@@ -299,15 +348,17 @@ fn build_cooldowns(slot: &AgentSlot) -> Vec<CooldownState> {
     ]
 }
 
-fn collect_messages(events: &[crate::event::GameEvent], my_pos: Vec2, hearing_range: f32) -> Vec<AgentMessage> {
+fn collect_messages(
+    events: &[crate::event::GameEvent],
+    my_pos: Vec2,
+    hearing_range: f32,
+) -> Vec<AgentMessage> {
     events
         .iter()
         .filter(|e| e.origin.distance(my_pos) <= hearing_range)
         .filter_map(|e| match &e.event {
             Event::AgentSpoke {
-                agent_id,
-                message,
-                ..
+                agent_id, message, ..
             } => Some(AgentMessage {
                 from: *agent_id,
                 content: message.clone(),
@@ -346,6 +397,7 @@ fn empty_observation(tick: u64, elapsed: f32, slot: &AgentSlot) -> Observation {
         self_state: SelfState {
             agent_id: slot.agent.id(),
             entity_id: EntityId(0),
+            runtime_profile: slot.agent.runtime_profile(),
             position: Vec2::ZERO,
             rotation: 0.0,
             velocity: Vec2::ZERO,
@@ -353,6 +405,11 @@ fn empty_observation(tick: u64, elapsed: f32, slot: &AgentSlot) -> Observation {
             max_health: None,
             team: Team::None,
             cooldowns: build_cooldowns(slot),
+            combat_loadout: None,
+            skills: vec![],
+            inventory: None,
+            companion_roster: None,
+            encounter: None,
         },
         visible_entities: vec![],
         audible_events: vec![],
@@ -384,10 +441,7 @@ fn execute_action(
     match &agent_action.action {
         Action::Move { direction } => {
             if let Ok(mut vel) = ecs.get::<&mut Velocity>(entity) {
-                let movement = ecs
-                    .get::<&Movement>(entity)
-                    .map(|m| *m)
-                    .unwrap_or_default();
+                let movement = ecs.get::<&Movement>(entity).map(|m| *m).unwrap_or_default();
                 vel.linear = direction.normalize_or_zero() * movement.max_speed;
             }
         }
@@ -523,7 +577,10 @@ fn in_range(ecs: &hecs::World, source: hecs::Entity, target: hecs::Entity, range
     let Ok(target_transform) = ecs.get::<&Transform>(target) else {
         return false;
     };
-    source_transform.position.distance(target_transform.position) <= range
+    source_transform
+        .position
+        .distance(target_transform.position)
+        <= range
 }
 
 fn is_hostile_target(ecs: &hecs::World, source: hecs::Entity, target: hecs::Entity) -> bool {
@@ -548,7 +605,9 @@ fn select_attack_target(
     explicit_target: Option<hecs::Entity>,
 ) -> Option<hecs::Entity> {
     if let Some(target) = explicit_target {
-        if target != source && in_range(ecs, source, target, ATTACK_RANGE) && is_hostile_target(ecs, source, target)
+        if target != source
+            && in_range(ecs, source, target, ATTACK_RANGE)
+            && is_hostile_target(ecs, source, target)
         {
             return Some(target);
         }
@@ -587,7 +646,8 @@ fn select_interaction_target(
     explicit_target: Option<hecs::Entity>,
 ) -> Option<hecs::Entity> {
     if let Some(target) = explicit_target {
-        return (target != source && in_range(ecs, source, target, INTERACT_RANGE)).then_some(target);
+        return (target != source && in_range(ecs, source, target, INTERACT_RANGE))
+            .then_some(target);
     }
 
     let source_pos = ecs.get::<&Transform>(source).ok()?.position;
@@ -674,7 +734,8 @@ fn apply_attack(
 
     for slot in agents.iter_mut() {
         if slot.entity_id == Some(target_entity) {
-            slot.agent.on_damage(applied_damage, Some(attacker_agent_id));
+            slot.agent
+                .on_damage(applied_damage, Some(attacker_agent_id));
             if target_dead {
                 slot.agent.on_death();
             }
@@ -700,8 +761,7 @@ fn step_camera_controllers(ecs: &mut hecs::World) {
 }
 
 fn step_orbit_camera_controllers(ecs: &mut hecs::World) {
-    for (_, (camera, controller)) in
-        ecs.query_mut::<(&mut Camera3D, &mut OrbitCameraController)>()
+    for (_, (camera, controller)) in ecs.query_mut::<(&mut Camera3D, &mut OrbitCameraController)>()
     {
         let target = Vec3::from_array(controller.target);
         let yaw = controller.yaw + controller.yaw_speed * TICK_DURATION_SECS;
@@ -709,7 +769,9 @@ fn step_orbit_camera_controllers(ecs: &mut hecs::World) {
 
         controller.yaw = yaw;
         controller.pitch = (controller.pitch + pitch_delta).clamp(-1.47, 1.47);
-        let radius = controller.radius.clamp(controller.min_radius, controller.max_radius);
+        let radius = controller
+            .radius
+            .clamp(controller.min_radius, controller.max_radius);
         let yaw_sin = yaw.sin();
         let yaw_cos = yaw.cos();
         let pitch_cos = controller.pitch.cos();
@@ -736,7 +798,8 @@ fn step_follow_camera_controllers(ecs: &mut hecs::World) {
         target_positions.insert(entity.id(), transform.position);
     }
 
-    for (_, (camera, controller)) in ecs.query_mut::<(&mut Camera3D, &mut FollowCameraController)>() {
+    for (_, (camera, controller)) in ecs.query_mut::<(&mut Camera3D, &mut FollowCameraController)>()
+    {
         if controller.target == FollowCameraController::default().target {
             continue;
         }
@@ -755,17 +818,19 @@ fn step_follow_camera_controllers(ecs: &mut hecs::World) {
 }
 
 fn step_fly_camera_controllers(ecs: &mut hecs::World) {
-    for (_, (camera, controller)) in
-        ecs.query_mut::<(&mut Camera3D, &mut FlyCameraController)>()
-    {
+    for (_, (camera, controller)) in ecs.query_mut::<(&mut Camera3D, &mut FlyCameraController)>() {
         let move_speed = controller.move_speed.max(0.0);
         let input = Vec3::from_array(controller.move_input);
-        if input.length_squared() <= 0.00001 && controller.yaw_delta.abs() <= 0.0001 && controller.pitch_delta.abs() <= 0.0001 {
+        if input.length_squared() <= 0.00001
+            && controller.yaw_delta.abs() <= 0.0001
+            && controller.pitch_delta.abs() <= 0.0001
+        {
             continue;
         }
 
         let yaw = controller.yaw + controller.yaw_delta * TICK_DURATION_SECS;
-        let pitch = (controller.pitch + controller.pitch_delta * TICK_DURATION_SECS).clamp(-1.45, 1.45);
+        let pitch =
+            (controller.pitch + controller.pitch_delta * TICK_DURATION_SECS).clamp(-1.45, 1.45);
         let distance = (camera.target - camera.position).length().max(0.1);
 
         let forward = Vec3::new(
@@ -852,12 +917,7 @@ mod tests {
         }
     }
 
-    fn spawn_actor(
-        ecs: &mut hecs::World,
-        pos: Vec2,
-        team: Team,
-        health: Health,
-    ) -> hecs::Entity {
+    fn spawn_actor(ecs: &mut hecs::World, pos: Vec2, team: Team, health: Health) -> hecs::Entity {
         ecs.spawn((
             Transform {
                 position: pos,
@@ -878,10 +938,18 @@ mod tests {
     #[test]
     fn attack_target_applies_damage_and_sets_cooldown() {
         let mut ecs = hecs::World::new();
-        let attacker_entity =
-            spawn_actor(&mut ecs, Vec2::new(0.0, 0.0), Team::Team(1), Health::new(100.0));
-        let target_entity =
-            spawn_actor(&mut ecs, Vec2::new(20.0, 0.0), Team::Team(2), Health::new(100.0));
+        let attacker_entity = spawn_actor(
+            &mut ecs,
+            Vec2::new(0.0, 0.0),
+            Team::Team(1),
+            Health::new(100.0),
+        );
+        let target_entity = spawn_actor(
+            &mut ecs,
+            Vec2::new(20.0, 0.0),
+            Team::Team(2),
+            Health::new(100.0),
+        );
         let target_id = EntityId(target_entity.id() as u64);
 
         let obs_store = Arc::new(Mutex::new(Vec::new()));
@@ -925,8 +993,12 @@ mod tests {
     #[test]
     fn attack_target_rejects_self_target_without_damage() {
         let mut ecs = hecs::World::new();
-        let attacker_entity =
-            spawn_actor(&mut ecs, Vec2::new(0.0, 0.0), Team::Team(1), Health::new(100.0));
+        let attacker_entity = spawn_actor(
+            &mut ecs,
+            Vec2::new(0.0, 0.0),
+            Team::Team(1),
+            Health::new(100.0),
+        );
         let self_target_id = EntityId(attacker_entity.id() as u64);
 
         let obs_store = Arc::new(Mutex::new(Vec::new()));
@@ -955,20 +1027,22 @@ mod tests {
         let self_health = ecs.get::<&Health>(attacker_entity).unwrap();
         assert_eq!(self_health.current, 100.0);
         assert_eq!(agents[0].attack_cooldown_remaining, 0);
-        assert!(
-            events
-                .last_events()
-                .iter()
-                .chain(events.current_events().iter())
-                .all(|event| !matches!(event.event, Event::Damage { .. }))
-        );
+        assert!(events
+            .last_events()
+            .iter()
+            .chain(events.current_events().iter())
+            .all(|event| !matches!(event.event, Event::Damage { .. })));
     }
 
     #[test]
     fn attack_target_respects_invulnerability() {
         let mut ecs = hecs::World::new();
-        let attacker_entity =
-            spawn_actor(&mut ecs, Vec2::new(0.0, 0.0), Team::Team(1), Health::new(100.0));
+        let attacker_entity = spawn_actor(
+            &mut ecs,
+            Vec2::new(0.0, 0.0),
+            Team::Team(1),
+            Health::new(100.0),
+        );
         let mut invulnerable_target = Health::new(100.0);
         invulnerable_target.invulnerable = true;
         let target_entity = spawn_actor(
@@ -1003,19 +1077,21 @@ mod tests {
         let target_health = ecs.get::<&Health>(target_entity).unwrap();
         assert_eq!(target_health.current, 100.0);
         assert_eq!(agents[0].attack_cooldown_remaining, 0);
-        assert!(
-            result
-                .events
-                .iter()
-                .all(|event| !matches!(event.event, Event::Damage { .. }))
-        );
+        assert!(result
+            .events
+            .iter()
+            .all(|event| !matches!(event.event, Event::Damage { .. })));
     }
 
     #[test]
     fn observations_include_cooldowns_messages_and_objectives() {
         let mut ecs = hecs::World::new();
-        let observer_entity =
-            spawn_actor(&mut ecs, Vec2::new(0.0, 0.0), Team::Team(1), Health::new(100.0));
+        let observer_entity = spawn_actor(
+            &mut ecs,
+            Vec2::new(0.0, 0.0),
+            Team::Team(1),
+            Health::new(100.0),
+        );
 
         let observed_messages = Arc::new(Mutex::new(Vec::<Observation>::new()));
         let (agent, _agent_id) = RecordingAgent::new(vec![], observed_messages.clone());
@@ -1064,13 +1140,199 @@ mod tests {
             .expect("attack cooldown should be present");
         assert_eq!(attack_cd.remaining_ticks, 4);
 
-        assert!(observation.messages.iter().any(|message| {
-            message.content == "ready" && message.from == speaker_id
-        }));
+        assert!(observation
+            .messages
+            .iter()
+            .any(|message| { message.content == "ready" && message.from == speaker_id }));
         assert!(observation.objectives.iter().any(|objective| {
             objective.id == "capture-point"
                 && (objective.progress - 0.25).abs() < f32::EPSILON
                 && !objective.completed
         }));
+    }
+
+    #[test]
+    fn observations_include_runtime_profile_and_mmo_state() {
+        let mut ecs = hecs::World::new();
+        let observer_entity = spawn_actor(
+            &mut ecs,
+            Vec2::new(0.0, 0.0),
+            Team::Team(1),
+            Health::new(100.0),
+        );
+        let wild_entity = spawn_actor(
+            &mut ecs,
+            Vec2::new(16.0, 0.0),
+            Team::None,
+            Health::new(24.0),
+        );
+
+        ecs.insert(
+            observer_entity,
+            (
+                CombatLoadout {
+                    style: CombatStyle::Magic,
+                    attack_range: 240.0,
+                    attack_speed_ticks: 24,
+                    max_hit: 18.0,
+                    auto_retaliate: true,
+                    equipped_weapon: Some("oak-staff".to_string()),
+                    offhand_item: Some("capture-focus".to_string()),
+                    active_ability_bar: vec!["wind-strike".to_string(), "bind".to_string()],
+                },
+                SkillBook {
+                    combat_level: 12,
+                    total_level: 38,
+                    skills: vec![
+                        SkillProgress::new(SkillKind::Magic, 12, 1_980, 2_744),
+                        SkillProgress::new(SkillKind::Taming, 7, 650, 801),
+                    ],
+                },
+                Inventory {
+                    capacity: 28,
+                    carried_weight: 3.5,
+                    coins: 420,
+                    items: vec![ItemStack {
+                        item_id: "capture-orb".to_string(),
+                        display_name: "Capture Orb".to_string(),
+                        quantity: 3,
+                        stackable: true,
+                    }],
+                },
+                CompanionRoster {
+                    active_slot: Some(0),
+                    party_capacity: 6,
+                    creatures: vec![CompanionCreature {
+                        creature: CreatureIdentity {
+                            species_id: "ember-fox".to_string(),
+                            species_name: "Ember Fox".to_string(),
+                            elemental_affinity: "fire".to_string(),
+                            level: 9,
+                            temperament: CreatureTemperament::Loyal,
+                            capture_difficulty: 0.3,
+                            is_wild: false,
+                        },
+                        nickname: Some("Cinder".to_string()),
+                        current_health: 22.0,
+                        max_health: 24.0,
+                        combat_style: CombatStyle::Summoning,
+                        mood: 0.9,
+                    }],
+                },
+                EncounterState {
+                    encounter_id: 55,
+                    kind: EncounterKind::WildCreature,
+                    threat_level: 0.7,
+                    primary_target: Some(EntityId(wild_entity.id() as u64)),
+                    active_turn_owner: Some(EntityId(observer_entity.id() as u64)),
+                    capture_allowed: true,
+                    in_combat: true,
+                },
+            ),
+        )
+        .unwrap();
+
+        ecs.insert(
+            wild_entity,
+            (
+                CombatLoadout {
+                    style: CombatStyle::Summoning,
+                    attack_range: 64.0,
+                    attack_speed_ticks: 30,
+                    max_hit: 8.0,
+                    auto_retaliate: true,
+                    equipped_weapon: None,
+                    offhand_item: None,
+                    active_ability_bar: vec!["scratch".to_string()],
+                },
+                CreatureIdentity {
+                    species_id: "moss-turtle".to_string(),
+                    species_name: "Moss Turtle".to_string(),
+                    elemental_affinity: "nature".to_string(),
+                    level: 6,
+                    temperament: CreatureTemperament::Timid,
+                    capture_difficulty: 0.45,
+                    is_wild: true,
+                },
+            ),
+        )
+        .unwrap();
+
+        let observed_messages = Arc::new(Mutex::new(Vec::<Observation>::new()));
+        let (agent, _agent_id) = RecordingAgent::new(vec![], observed_messages.clone());
+        let mut slot = AgentSlot::new(Box::new(agent));
+        slot.entity_id = Some(observer_entity);
+        let mut agents = vec![slot];
+        let mut events = EventBus::new();
+        let mut next_entity_id = 1;
+
+        execute_tick(
+            &mut ecs,
+            &mut agents,
+            &mut events,
+            1,
+            vec![],
+            &mut next_entity_id,
+        );
+
+        let snapshots = observed_messages.lock().unwrap();
+        let observation = snapshots.last().expect("expected an observation");
+        assert_eq!(
+            observation.self_state.runtime_profile.role,
+            crate::AgentRole::Npc
+        );
+        assert_eq!(
+            observation
+                .self_state
+                .combat_loadout
+                .as_ref()
+                .expect("combat loadout")
+                .style,
+            CombatStyle::Magic
+        );
+        assert_eq!(observation.self_state.skills.len(), 2);
+        assert_eq!(
+            observation
+                .self_state
+                .inventory
+                .as_ref()
+                .expect("inventory")
+                .coins,
+            420
+        );
+        assert_eq!(
+            observation
+                .self_state
+                .companion_roster
+                .as_ref()
+                .expect("roster")
+                .creatures[0]
+                .creature
+                .species_name,
+            "Ember Fox"
+        );
+        assert!(
+            observation
+                .self_state
+                .encounter
+                .as_ref()
+                .expect("encounter")
+                .capture_allowed
+        );
+
+        let visible_creature = observation
+            .visible_entities
+            .iter()
+            .find(|entity| entity.entity_id == EntityId(wild_entity.id() as u64))
+            .expect("wild creature should be visible");
+        assert_eq!(visible_creature.combat_style, Some(CombatStyle::Summoning));
+        assert_eq!(
+            visible_creature
+                .creature
+                .as_ref()
+                .expect("creature identity")
+                .species_name,
+            "Moss Turtle"
+        );
     }
 }

--- a/crates/pod-core/src/world.rs
+++ b/crates/pod-core/src/world.rs
@@ -102,6 +102,10 @@ impl World {
             Collider::circle(16.0),
             Health::new(100.0),
             Perception::default(),
+            CombatLoadout::default(),
+            SkillBook::default(),
+            Inventory::default(),
+            CompanionRoster::default(),
             ColorRect::new(32.0, 32.0, [0.2, 0.8, 0.3, 1.0]),
             Label {
                 name: "Player".into(),
@@ -180,6 +184,12 @@ enum ComponentToAdd {
     Perception(Perception),
     Movement(Movement),
     Script(Script),
+    CombatLoadout(CombatLoadout),
+    SkillBook(SkillBook),
+    Inventory(Inventory),
+    CreatureIdentity(CreatureIdentity),
+    CompanionRoster(CompanionRoster),
+    EncounterState(EncounterState),
 }
 
 impl<'w> EntityBuilder<'w> {
@@ -197,7 +207,8 @@ impl<'w> EntityBuilder<'w> {
     }
 
     pub fn with_health(mut self, max: f32) -> Self {
-        self.components.push(ComponentToAdd::Health(Health::new(max)));
+        self.components
+            .push(ComponentToAdd::Health(Health::new(max)));
         self
     }
 
@@ -224,11 +235,10 @@ impl<'w> EntityBuilder<'w> {
     }
 
     pub fn with_perception(mut self, vision_range: f32) -> Self {
-        self.components
-            .push(ComponentToAdd::Perception(Perception {
-                vision_range,
-                ..Default::default()
-            }));
+        self.components.push(ComponentToAdd::Perception(Perception {
+            vision_range,
+            ..Default::default()
+        }));
         self
     }
 
@@ -247,12 +257,42 @@ impl<'w> EntityBuilder<'w> {
         self
     }
 
+    pub fn with_combat_loadout(mut self, loadout: CombatLoadout) -> Self {
+        self.components.push(ComponentToAdd::CombatLoadout(loadout));
+        self
+    }
+
+    pub fn with_skill_book(mut self, skill_book: SkillBook) -> Self {
+        self.components.push(ComponentToAdd::SkillBook(skill_book));
+        self
+    }
+
+    pub fn with_inventory(mut self, inventory: Inventory) -> Self {
+        self.components.push(ComponentToAdd::Inventory(inventory));
+        self
+    }
+
+    pub fn with_creature_identity(mut self, creature: CreatureIdentity) -> Self {
+        self.components
+            .push(ComponentToAdd::CreatureIdentity(creature));
+        self
+    }
+
+    pub fn with_companion_roster(mut self, roster: CompanionRoster) -> Self {
+        self.components
+            .push(ComponentToAdd::CompanionRoster(roster));
+        self
+    }
+
+    pub fn with_encounter_state(mut self, encounter: EncounterState) -> Self {
+        self.components
+            .push(ComponentToAdd::EncounterState(encounter));
+        self
+    }
+
     /// Finalize and spawn the entity
     pub fn build(self) -> hecs::Entity {
-        let entity = self
-            .world
-            .ecs
-            .spawn((self.transform, Velocity::default()));
+        let entity = self.world.ecs.spawn((self.transform, Velocity::default()));
 
         for component in self.components {
             match component {
@@ -285,6 +325,24 @@ impl<'w> EntityBuilder<'w> {
                 }
                 ComponentToAdd::Script(s) => {
                     self.world.ecs.insert_one(entity, s).unwrap();
+                }
+                ComponentToAdd::CombatLoadout(loadout) => {
+                    self.world.ecs.insert_one(entity, loadout).unwrap();
+                }
+                ComponentToAdd::SkillBook(skill_book) => {
+                    self.world.ecs.insert_one(entity, skill_book).unwrap();
+                }
+                ComponentToAdd::Inventory(inventory) => {
+                    self.world.ecs.insert_one(entity, inventory).unwrap();
+                }
+                ComponentToAdd::CreatureIdentity(creature) => {
+                    self.world.ecs.insert_one(entity, creature).unwrap();
+                }
+                ComponentToAdd::CompanionRoster(roster) => {
+                    self.world.ecs.insert_one(entity, roster).unwrap();
+                }
+                ComponentToAdd::EncounterState(encounter) => {
+                    self.world.ecs.insert_one(entity, encounter).unwrap();
                 }
             }
         }


### PR DESCRIPTION
## Summary
- add a first-class pod-core app/plugin schedule kernel with typed resources and core type registration
- add versioned runtime contracts and explicit agent role/capability profiles for human/AI parity
- add RuneScape-style combat/progression plus companion-creature observation primitives for the MMO vertical slice

## Testing
- cargo check -p pod-core
- cargo test -p pod-core --lib