### PR TITLE
Add MMO gameplay verbs and transport parity

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -375,5 +375,19 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cargo check -p pod-core`
   - `cargo test -p pod-core --lib`
 
-**Last updated**: Iteration 47
-**Current focus**: Phase 1 runtime kernel parity for the RuneScape-style MMO + companion-creature vertical slice
+### Iteration 48 — MMO Gameplay Verb and Transport Parity
+
+- [x] Added RuneScape-style MMO gameplay verbs to `pod-core` with strict validation for capture, summon, companion commands, gathering, looting, and auto-retaliate toggling under the shared human/AI action contract.
+- [x] Added supporting native runtime primitives `ResourceNode` and `LootContainer`, plus deterministic tick execution for companion capture/summon flows, skill XP gains, loot transfer, and combat cadence driven by `CombatLoadout`.
+- [x] Extended the agent parser and network/SpacetimeDB transport layers so the new MMO verbs survive parsing, serialization, authority mirroring, and local simulated reducer paths without being dropped.
+- [x] Expanded deterministic coverage in `pod-core` for loadout-driven combat range/damage/cooldowns, capture, summon, companion attack commands, gathering, looting, and auto-retaliate state changes.
+- [x] Updated agent-side observation fixtures to stay compatible with the expanded MMO observation schema (`combat_style`, `creature`, and extended `SelfState` fields).
+- [x] Validated touched crates:
+  - `cargo check -p pod-core -p pod-agents -p pod-net -p pod-stdb`
+  - `cargo test -p pod-core --lib`
+  - `cargo test -p pod-agents --lib`
+  - `cargo test -p pod-net --lib`
+  - `cargo test -p pod-stdb --lib`
+
+**Last updated**: Iteration 48
+**Current focus**: Phase 1 MMO action validation and Phase 3 authority parity for the RuneScape-style MMO + companion-creature vertical slice

--- a/crates/pod-agents/src/action_parser.rs
+++ b/crates/pod-agents/src/action_parser.rs
@@ -8,11 +8,12 @@
 //!
 //! All parsers are fallible — unknown or malformed responses degrade gracefully to Idle.
 
-use pod_core::action::{Action, SpeakVolume};
-use pod_core::id::EntityId;
 use glam::Vec2;
-use serde::Deserialize;
 use log::{debug, warn};
+use pod_core::action::{Action, CompanionCommand, SpeakVolume};
+use pod_core::component::SkillKind;
+use pod_core::id::EntityId;
+use serde::Deserialize;
 use std::collections::HashMap;
 
 // ============================================================
@@ -95,9 +96,8 @@ impl ActionParser for JsonActionParser {
         // Try to extract JSON from response (LLMs sometimes wrap in markdown)
         let json_str = extract_json(response).unwrap_or(response);
 
-        let parsed: LlmJsonResponse = serde_json::from_str(json_str).map_err(|e| {
-            ActionParseError::InvalidFormat(format!("JSON parse failed: {}", e))
-        })?;
+        let parsed: LlmJsonResponse = serde_json::from_str(json_str)
+            .map_err(|e| ActionParseError::InvalidFormat(format!("JSON parse failed: {}", e)))?;
 
         let reasoning = parsed
             .reasoning
@@ -170,14 +170,8 @@ impl ActionParser for ToonActionParser {
 
         let sections = parse_toon_sections(response)?;
 
-        let action_rows = sections
-            .get("actions")
-            .cloned()
-            .unwrap_or_else(Vec::new);
-        let reasoning_rows = sections
-            .get("reasoning")
-            .cloned()
-            .unwrap_or_else(Vec::new);
+        let action_rows = sections.get("actions").cloned().unwrap_or_else(Vec::new);
+        let reasoning_rows = sections.get("reasoning").cloned().unwrap_or_else(Vec::new);
 
         let mut actions = Vec::new();
         let mut warnings = Vec::new();
@@ -254,13 +248,17 @@ impl ActionParser for KeyValueParser {
             {
                 match parse_action_string(action_str.trim()) {
                     Ok(action) => actions.push(action),
-                    Err(e) => warnings.push(format!("Unknown action '{}': {}", action_str.trim(), e)),
+                    Err(e) => {
+                        warnings.push(format!("Unknown action '{}': {}", action_str.trim(), e))
+                    }
                 }
             } else if let Some(reason) = line
                 .strip_prefix("REASON:")
                 .or_else(|| line.strip_prefix("reason:"))
-                .or_else(|| line.strip_prefix("Reason:")
-                .or_else(|| line.strip_prefix("REASONING:")))
+                .or_else(|| {
+                    line.strip_prefix("Reason:")
+                        .or_else(|| line.strip_prefix("REASONING:"))
+                })
             {
                 reasoning = reason.trim().to_string();
             }
@@ -316,11 +314,19 @@ impl ActionParser for FallbackParser {
         for parser in &self.parsers {
             match parser.parse(response) {
                 Ok(result) if result.confidence > 0.5 => {
-                    debug!("Parser '{}' succeeded with confidence {:.2}", parser.name(), result.confidence);
+                    debug!(
+                        "Parser '{}' succeeded with confidence {:.2}",
+                        parser.name(),
+                        result.confidence
+                    );
                     return Ok(result);
                 }
                 Ok(result) => {
-                    debug!("Parser '{}' low confidence {:.2}, trying next", parser.name(), result.confidence);
+                    debug!(
+                        "Parser '{}' low confidence {:.2}, trying next",
+                        parser.name(),
+                        result.confidence
+                    );
                 }
                 Err(e) => {
                     debug!("Parser '{}' failed: {}, trying next", parser.name(), e);
@@ -397,6 +403,99 @@ pub fn parse_action_string(s: &str) -> Result<Action, String> {
         });
     }
 
+    // "capture <id>"
+    if let Some(id_str) = s.strip_prefix("capture ") {
+        let id: u64 = id_str
+            .trim()
+            .parse()
+            .map_err(|_| format!("Invalid entity id: {}", id_str))?;
+        return Ok(Action::CaptureCreature {
+            target: EntityId(id),
+            tool_slot: None,
+        });
+    }
+
+    // "summon companion <slot>"
+    if let Some(slot_str) = s
+        .strip_prefix("summon companion ")
+        .or_else(|| s.strip_prefix("summon "))
+    {
+        let slot: u8 = slot_str
+            .trim()
+            .parse()
+            .map_err(|_| format!("Invalid companion slot: {}", slot_str))?;
+        return Ok(Action::SummonCompanion { slot });
+    }
+
+    // "loot <id>"
+    if let Some(id_str) = s.strip_prefix("loot ") {
+        let id: u64 = id_str
+            .trim()
+            .parse()
+            .map_err(|_| format!("Invalid entity id: {}", id_str))?;
+        return Ok(Action::Loot {
+            target: EntityId(id),
+        });
+    }
+
+    // "gather <skill> <id>"
+    if let Some(rest) = s.strip_prefix("gather ") {
+        let mut parts = rest.split_whitespace();
+        let skill = parts
+            .next()
+            .ok_or_else(|| "Gather action missing skill".to_string())
+            .and_then(parse_skill_kind_str)?;
+        let id_str = parts
+            .next()
+            .ok_or_else(|| "Gather action missing entity id".to_string())?;
+        let id: u64 = id_str
+            .parse()
+            .map_err(|_| format!("Invalid entity id: {}", id_str))?;
+        return Ok(Action::GatherResource {
+            target: EntityId(id),
+            skill,
+        });
+    }
+
+    // "auto retaliate on/off"
+    if let Some(rest) = s.strip_prefix("auto retaliate ") {
+        let enabled = match rest.trim() {
+            "on" | "true" | "enable" | "enabled" => true,
+            "off" | "false" | "disable" | "disabled" => false,
+            other => return Err(format!("Invalid auto retaliate state: {}", other)),
+        };
+        return Ok(Action::SetAutoRetaliate { enabled });
+    }
+
+    // "command companion <slot> <command> [target]"
+    if let Some(rest) = s.strip_prefix("command companion ") {
+        let mut parts = rest.split_whitespace();
+        let slot_str = parts
+            .next()
+            .ok_or_else(|| "Command companion missing slot".to_string())?;
+        let slot: u8 = slot_str
+            .parse()
+            .map_err(|_| format!("Invalid companion slot: {}", slot_str))?;
+        let command_str = parts
+            .next()
+            .ok_or_else(|| "Command companion missing command".to_string())?;
+        let command = parse_companion_command(command_str)?;
+        let target = if let Some(id_str) = parts.next() {
+            Some(EntityId(
+                id_str
+                    .parse()
+                    .map_err(|_| format!("Invalid entity id: {}", id_str))?,
+            ))
+        } else {
+            None
+        };
+        return Ok(Action::CommandCompanion {
+            slot,
+            command,
+            target,
+        });
+    }
+
     // "speak <message>"
     if let Some(msg) = s.strip_prefix("speak ").or_else(|| s.strip_prefix("say ")) {
         return Ok(Action::Speak {
@@ -443,7 +542,10 @@ pub fn parse_action_string(s: &str) -> Result<Action, String> {
     }
 
     // "ability <slot>"
-    if let Some(slot_str) = s.strip_prefix("ability ").or_else(|| s.strip_prefix("use ability ")) {
+    if let Some(slot_str) = s
+        .strip_prefix("ability ")
+        .or_else(|| s.strip_prefix("use ability "))
+    {
         let slot: u8 = slot_str
             .trim()
             .parse()
@@ -513,6 +615,77 @@ fn parse_action_object(obj: &serde_json::Map<String, serde_json::Value>) -> Resu
                 volume: SpeakVolume::Normal,
             })
         }
+        "capture" => {
+            let target = obj
+                .get("target")
+                .and_then(|v| v.as_u64())
+                .ok_or("Capture missing 'target'")?;
+            let tool_slot = obj
+                .get("tool_slot")
+                .and_then(|v| v.as_u64())
+                .map(|v| v as u8);
+            Ok(Action::CaptureCreature {
+                target: EntityId(target),
+                tool_slot,
+            })
+        }
+        "summon_companion" => {
+            let slot = obj
+                .get("slot")
+                .and_then(|v| v.as_u64())
+                .ok_or("SummonCompanion missing 'slot'")?;
+            Ok(Action::SummonCompanion { slot: slot as u8 })
+        }
+        "command_companion" => {
+            let slot = obj
+                .get("slot")
+                .and_then(|v| v.as_u64())
+                .ok_or("CommandCompanion missing 'slot'")?;
+            let command = obj
+                .get("command")
+                .and_then(|v| v.as_str())
+                .ok_or("CommandCompanion missing 'command'")
+                .map_err(str::to_string)
+                .and_then(parse_companion_command)?;
+            let target = obj.get("target").and_then(|v| v.as_u64()).map(EntityId);
+            Ok(Action::CommandCompanion {
+                slot: slot as u8,
+                command,
+                target,
+            })
+        }
+        "gather" => {
+            let target = obj
+                .get("target")
+                .and_then(|v| v.as_u64())
+                .ok_or("Gather missing 'target'")?;
+            let skill = obj
+                .get("skill")
+                .and_then(|v| v.as_str())
+                .ok_or("Gather missing 'skill'")
+                .map_err(str::to_string)
+                .and_then(parse_skill_kind_str)?;
+            Ok(Action::GatherResource {
+                target: EntityId(target),
+                skill,
+            })
+        }
+        "loot" => {
+            let target = obj
+                .get("target")
+                .and_then(|v| v.as_u64())
+                .ok_or("Loot missing 'target'")?;
+            Ok(Action::Loot {
+                target: EntityId(target),
+            })
+        }
+        "set_auto_retaliate" => {
+            let enabled = obj
+                .get("enabled")
+                .and_then(|v| v.as_bool())
+                .ok_or("SetAutoRetaliate missing 'enabled'")?;
+            Ok(Action::SetAutoRetaliate { enabled })
+        }
         _ => Err(format!("Unknown action type: {}", action_type)),
     }
 }
@@ -537,8 +710,14 @@ pub fn parse_direction(s: &str) -> Result<Vec2, String> {
             // Try parsing as "x,y" coordinates
             let parts: Vec<&str> = s.split(',').collect();
             if parts.len() == 2 {
-                let x: f32 = parts[0].trim().parse().map_err(|_| format!("Invalid x: {}", parts[0]))?;
-                let y: f32 = parts[1].trim().parse().map_err(|_| format!("Invalid y: {}", parts[1]))?;
+                let x: f32 = parts[0]
+                    .trim()
+                    .parse()
+                    .map_err(|_| format!("Invalid x: {}", parts[0]))?;
+                let y: f32 = parts[1]
+                    .trim()
+                    .parse()
+                    .map_err(|_| format!("Invalid y: {}", parts[1]))?;
                 Ok(Vec2::new(x, y).normalize_or_zero())
             } else {
                 Err(format!("Unknown direction: {}", s))
@@ -563,6 +742,37 @@ pub fn parse_vec2(s: &str) -> Result<Vec2, String> {
         .parse()
         .map_err(|_| "Invalid y coordinate".to_string())?;
     Ok(Vec2::new(x, y))
+}
+
+fn parse_skill_kind_str(s: &str) -> Result<SkillKind, String> {
+    match s.trim().to_lowercase().as_str() {
+        "attack" => Ok(SkillKind::Attack),
+        "strength" => Ok(SkillKind::Strength),
+        "defence" | "defense" => Ok(SkillKind::Defence),
+        "ranged" | "range" => Ok(SkillKind::Ranged),
+        "magic" | "mage" => Ok(SkillKind::Magic),
+        "constitution" | "health" => Ok(SkillKind::Constitution),
+        "mining" => Ok(SkillKind::Mining),
+        "woodcutting" | "woodcut" => Ok(SkillKind::Woodcutting),
+        "fishing" => Ok(SkillKind::Fishing),
+        "cooking" => Ok(SkillKind::Cooking),
+        "smithing" => Ok(SkillKind::Smithing),
+        "crafting" => Ok(SkillKind::Crafting),
+        "slayer" => Ok(SkillKind::Slayer),
+        "taming" => Ok(SkillKind::Taming),
+        "bonding" => Ok(SkillKind::Bonding),
+        other => Err(format!("Unknown skill kind: {}", other)),
+    }
+}
+
+fn parse_companion_command(s: &str) -> Result<CompanionCommand, String> {
+    match s.trim().to_lowercase().as_str() {
+        "attack" => Ok(CompanionCommand::Attack),
+        "follow" => Ok(CompanionCommand::Follow),
+        "guard" => Ok(CompanionCommand::Guard),
+        "recall" => Ok(CompanionCommand::Recall),
+        other => Err(format!("Unknown companion command: {}", other)),
+    }
 }
 
 /// Extract JSON from a response that may include markdown code fences.
@@ -681,7 +891,9 @@ fn parse_toon_sections(raw: &str) -> Result<HashMap<String, Vec<String>>, Action
     if let Some((name, expected_rows, rows)) = current {
         return Err(ActionParseError::InvalidFormat(format!(
             "TOON section '{}' missing closing brace (expected {} rows, got {})",
-            name, expected_rows, rows.len()
+            name,
+            expected_rows,
+            rows.len()
         )));
     }
     if !saw_section {
@@ -793,19 +1005,83 @@ mod tests {
     fn test_parse_action_strings() {
         assert!(matches!(parse_action_string("idle"), Ok(Action::Idle)));
         assert!(matches!(parse_action_string("attack"), Ok(Action::Attack)));
-        assert!(matches!(parse_action_string("move north"), Ok(Action::Move { .. })));
-        assert!(matches!(parse_action_string("speak hello"), Ok(Action::Speak { .. })));
-        assert!(matches!(parse_action_string("rotate 45"), Ok(Action::Rotate { .. })));
-        assert!(matches!(parse_action_string("drop"), Ok(Action::Drop { .. })));
-        assert!(matches!(parse_action_string("ability 0"), Ok(Action::UseAbility { .. })));
+        assert!(matches!(
+            parse_action_string("move north"),
+            Ok(Action::Move { .. })
+        ));
+        assert!(matches!(
+            parse_action_string("speak hello"),
+            Ok(Action::Speak { .. })
+        ));
+        assert!(matches!(
+            parse_action_string("rotate 45"),
+            Ok(Action::Rotate { .. })
+        ));
+        assert!(matches!(
+            parse_action_string("drop"),
+            Ok(Action::Drop { .. })
+        ));
+        assert!(matches!(
+            parse_action_string("ability 0"),
+            Ok(Action::UseAbility { .. })
+        ));
+        assert!(matches!(
+            parse_action_string("capture 42"),
+            Ok(Action::CaptureCreature { .. })
+        ));
+        assert!(matches!(
+            parse_action_string("summon companion 2"),
+            Ok(Action::SummonCompanion { slot: 2 })
+        ));
+        assert!(matches!(
+            parse_action_string("gather mining 19"),
+            Ok(Action::GatherResource {
+                skill: SkillKind::Mining,
+                ..
+            })
+        ));
+        assert!(matches!(
+            parse_action_string("loot 8"),
+            Ok(Action::Loot { .. })
+        ));
+        assert!(matches!(
+            parse_action_string("auto retaliate on"),
+            Ok(Action::SetAutoRetaliate { enabled: true })
+        ));
+    }
+
+    #[test]
+    fn test_parse_action_object_supports_mmo_verbs() {
+        let action = parse_action_object(
+            &serde_json::json!({
+                "type": "command_companion",
+                "slot": 1,
+                "command": "attack",
+                "target": 77
+            })
+            .as_object()
+            .unwrap()
+            .clone(),
+        )
+        .unwrap();
+        assert!(matches!(
+            action,
+            Action::CommandCompanion {
+                slot: 1,
+                command: CompanionCommand::Attack,
+                target: Some(EntityId(77))
+            }
+        ));
     }
 
     #[test]
     fn test_extract_json() {
         assert_eq!(
-            extract_json(r#"```json
+            extract_json(
+                r#"```json
 {"a": 1}
-```"#),
+```"#
+            ),
             Some(r#"{"a": 1}"#)
         );
         assert_eq!(extract_json(r#"blah {"a": 1} blah"#), Some(r#"{"a": 1}"#));
@@ -861,9 +1137,11 @@ reasoning[1]{
     fn test_fallback_parser_includes_toon() {
         let parser = FallbackParser::default_chain();
         let result = parser
-            .parse(r#"actions[1]{
+            .parse(
+                r#"actions[1]{
   stop
-}"#)
+}"#,
+            )
             .unwrap();
         assert!(matches!(result.actions[0], Action::Stop));
     }

--- a/crates/pod-agents/src/conversation_memory.rs
+++ b/crates/pod-agents/src/conversation_memory.rs
@@ -38,11 +38,7 @@ pub struct MemoryEntry {
 
 impl MemoryEntry {
     /// Create from observation and decision data
-    pub fn from_decision(
-        obs: &Observation,
-        actions: &[Action],
-        reasoning: &str,
-    ) -> Self {
+    pub fn from_decision(obs: &Observation, actions: &[Action], reasoning: &str) -> Self {
         let summary = Self::summarize_observation(obs);
         let importance = Self::compute_importance(obs, actions);
         let estimated_tokens = (summary.len() + reasoning.len() + 20) as u32 / 4;
@@ -132,9 +128,7 @@ impl MemoryEntry {
         }
 
         // Communication is somewhat important
-        let has_speech = actions
-            .iter()
-            .any(|a| matches!(a, Action::Speak { .. }));
+        let has_speech = actions.iter().any(|a| matches!(a, Action::Speak { .. }));
         if has_speech || !obs.messages.is_empty() {
             score += 0.1;
         }
@@ -219,12 +213,7 @@ impl ConversationMemory {
 
     /// Record a new memory entry from an observation and decision.
     /// Returns true if recorded, false if skipped (too soon or below threshold).
-    pub fn record(
-        &mut self,
-        obs: &Observation,
-        actions: &[Action],
-        reasoning: &str,
-    ) -> bool {
+    pub fn record(&mut self, obs: &Observation, actions: &[Action], reasoning: &str) -> bool {
         // Check record interval (skip for first entry — allow initial recording)
         if !self.entries.is_empty()
             && obs.tick < self.last_record_tick + self.config.record_interval
@@ -353,8 +342,8 @@ impl ConversationMemory {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pod_core::observation::*;
     use glam::Vec2;
+    use pod_core::observation::*;
 
     fn make_obs(tick: u64, hostile: bool) -> Observation {
         let mut obs = Observation {
@@ -377,6 +366,7 @@ mod tests {
                 distance: 50.0,
                 relationship: Relationship::Hostile,
                 health_fraction: Some(0.5),
+                ..Default::default()
             });
         }
         obs

--- a/crates/pod-agents/src/decision_log.rs
+++ b/crates/pod-agents/src/decision_log.rs
@@ -46,9 +46,9 @@ use std::collections::{HashMap, VecDeque};
 use glam::Vec2;
 use serde::{Deserialize, Serialize};
 
-use pod_core::{Action, AgentId, AgentType, Observation};
 use pod_core::observation::Relationship;
 use pod_core::replay::{DecisionTrace, ReplayFile, ReplayHeader};
+use pod_core::{Action, AgentId, AgentType, Observation};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // ObservationSummary
@@ -104,11 +104,7 @@ impl ObservationSummary {
             _ => None,
         };
 
-        let active_objectives = obs
-            .objectives
-            .iter()
-            .filter(|o| !o.completed)
-            .count();
+        let active_objectives = obs.objectives.iter().filter(|o| !o.completed).count();
 
         Self {
             visible_entity_count: obs.visible_entities.len(),
@@ -260,9 +256,10 @@ impl LogFilter {
             LogFilter::TickRange { start, end } => entry.tick >= *start && entry.tick <= *end,
             LogFilter::ActionType(needle) => {
                 let needle_lower = needle.to_lowercase();
-                entry.actions_produced.iter().any(|a| {
-                    format!("{:?}", a).to_lowercase().contains(&needle_lower)
-                })
+                entry
+                    .actions_produced
+                    .iter()
+                    .any(|a| format!("{:?}", a).to_lowercase().contains(&needle_lower))
             }
             LogFilter::MinDecisionTime(min_us) => entry.timing.total_us >= *min_us,
         }
@@ -421,7 +418,10 @@ impl DecisionLogger {
 
     /// Return all entries recorded on the given tick.
     pub fn entries_for_tick(&self, tick: u64) -> Vec<&DecisionEntry> {
-        self.query(&[LogFilter::TickRange { start: tick, end: tick }])
+        self.query(&[LogFilter::TickRange {
+            start: tick,
+            end: tick,
+        }])
     }
 
     // ── Aggregation ───────────────────────────────────────────────────────────
@@ -440,7 +440,8 @@ impl DecisionLogger {
         }
 
         let mut by_type: HashMap<AgentType, usize> = HashMap::new();
-        let mut unique_agents: std::collections::HashSet<AgentId> = std::collections::HashSet::new();
+        let mut unique_agents: std::collections::HashSet<AgentId> =
+            std::collections::HashSet::new();
         let mut sum_us: u64 = 0;
         let mut max_us: u64 = 0;
         let mut min_tick = u64::MAX;
@@ -518,18 +519,28 @@ impl DecisionLogger {
             }
 
             let (prompt_sent, raw_response, latency_ms) = match &entry.decision_method {
-                DecisionMethod::LlmResponse { model, prompt_tokens, completion_tokens } => (
+                DecisionMethod::LlmResponse {
+                    model,
+                    prompt_tokens,
+                    completion_tokens,
+                } => (
                     format!("model={} prompt_tokens={}", model, prompt_tokens),
                     format!("completion_tokens={}", completion_tokens),
                     // total_us / 1000 gives ms; clamp to u32::MAX
                     (entry.timing.total_us / 1_000).min(u32::MAX as u64) as u32,
                 ),
-                DecisionMethod::BehaviorTree { active_node, tree_depth } => (
+                DecisionMethod::BehaviorTree {
+                    active_node,
+                    tree_depth,
+                } => (
                     format!("bt_node={} depth={}", active_node, tree_depth),
                     String::new(),
                     (entry.timing.total_us / 1_000).min(u32::MAX as u64) as u32,
                 ),
-                DecisionMethod::FiniteStateMachine { current_state, transition } => (
+                DecisionMethod::FiniteStateMachine {
+                    current_state,
+                    transition,
+                } => (
                     format!("fsm_state={}", current_state),
                     transition.clone().unwrap_or_default(),
                     (entry.timing.total_us / 1_000).min(u32::MAX as u64) as u32,
@@ -539,13 +550,22 @@ impl DecisionLogger {
                     String::new(),
                     (entry.timing.total_us / 1_000).min(u32::MAX as u64) as u32,
                 ),
-                DecisionMethod::NeuralNetwork { action_index, confidence } => (
+                DecisionMethod::NeuralNetwork {
+                    action_index,
+                    confidence,
+                } => (
                     format!("nn_action={} confidence={:.4}", action_index, confidence),
                     String::new(),
                     (entry.timing.total_us / 1_000).min(u32::MAX as u64) as u32,
                 ),
-                DecisionMethod::Hybrid { strategy_source, execution_source } => (
-                    format!("strategy={} execution={}", strategy_source, execution_source),
+                DecisionMethod::Hybrid {
+                    strategy_source,
+                    execution_source,
+                } => (
+                    format!(
+                        "strategy={} execution={}",
+                        strategy_source, execution_source
+                    ),
                     String::new(),
                     (entry.timing.total_us / 1_000).min(u32::MAX as u64) as u32,
                 ),
@@ -607,7 +627,7 @@ impl DecisionLogger {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pod_core::{AgentId, AgentType, Action, Observation};
+    use pod_core::{Action, AgentId, AgentType, Observation};
 
     // ── helpers ────────────────────────────────────────────────────────────
 
@@ -697,11 +717,7 @@ mod tests {
         assert_eq!(logger.len(), capacity);
 
         // The five entries kept must be the most recent (ticks 5–9)
-        let remaining: Vec<u64> = logger
-            .query(&[])
-            .into_iter()
-            .map(|e| e.tick)
-            .collect();
+        let remaining: Vec<u64> = logger.query(&[]).into_iter().map(|e| e.tick).collect();
         assert_eq!(remaining, vec![5, 6, 7, 8, 9]);
     }
 
@@ -769,16 +785,28 @@ mod tests {
         logger.log(make_entry(0, npc_id, AgentType::ScriptedNpc)); // total_us = 300
         logger.log(make_entry(1, npc_id, AgentType::ScriptedNpc)); // 300
         logger.log(make_entry(2, npc_id, AgentType::ScriptedNpc)); // 300
-        logger.log(make_llm_entry(3, llm_id));                     // total_us = 121_000
-        logger.log(make_llm_entry(4, llm_id));                     // 121_000
+        logger.log(make_llm_entry(3, llm_id)); // total_us = 121_000
+        logger.log(make_llm_entry(4, llm_id)); // 121_000
 
         let stats = logger.summary_stats();
 
         assert_eq!(stats.total_entries, 5);
         assert_eq!(stats.unique_agents, 2);
         assert_eq!(stats.tick_range, (0, 4));
-        assert_eq!(*stats.entries_by_agent_type.get(&AgentType::ScriptedNpc).unwrap(), 3);
-        assert_eq!(*stats.entries_by_agent_type.get(&AgentType::LlmAgent).unwrap(), 2);
+        assert_eq!(
+            *stats
+                .entries_by_agent_type
+                .get(&AgentType::ScriptedNpc)
+                .unwrap(),
+            3
+        );
+        assert_eq!(
+            *stats
+                .entries_by_agent_type
+                .get(&AgentType::LlmAgent)
+                .unwrap(),
+            2
+        );
         assert_eq!(stats.max_decision_time_us, 121_000);
 
         // avg = (300*3 + 121_000*2) / 5 = (900 + 242_000) / 5 = 242_900 / 5 = 48_580
@@ -857,7 +885,11 @@ mod tests {
         assert!(logger.is_enabled());
 
         logger.log(make_entry(3, agent_id, AgentType::ScriptedNpc));
-        assert_eq!(logger.len(), 2, "re-enabled logger should accept new entries");
+        assert_eq!(
+            logger.len(),
+            2,
+            "re-enabled logger should accept new entries"
+        );
     }
 
     // ── test_observation_summary_from_observation ──────────────────────────
@@ -865,8 +897,8 @@ mod tests {
     /// ObservationSummary::from_observation correctly derives each field.
     #[test]
     fn test_observation_summary_from_observation() {
-        use pod_core::observation::{VisibleEntity, Objective};
         use pod_core::id::EntityId;
+        use pod_core::observation::{Objective, VisibleEntity};
 
         let obs = Observation {
             tick: 5,
@@ -886,6 +918,7 @@ mod tests {
                     distance: 7.0,
                     relationship: Relationship::Hostile,
                     health_fraction: None,
+                    ..Default::default()
                 },
                 VisibleEntity {
                     entity_id: EntityId(2),
@@ -896,11 +929,22 @@ mod tests {
                     distance: 15.0,
                     relationship: Relationship::Friendly,
                     health_fraction: None,
+                    ..Default::default()
                 },
             ],
             objectives: vec![
-                Objective { id: "obj1".into(), description: "Survive".into(), progress: 0.5, completed: false },
-                Objective { id: "obj2".into(), description: "Done".into(), progress: 1.0, completed: true },
+                Objective {
+                    id: "obj1".into(),
+                    description: "Survive".into(),
+                    progress: 0.5,
+                    completed: false,
+                },
+                Objective {
+                    id: "obj2".into(),
+                    description: "Done".into(),
+                    progress: 1.0,
+                    completed: true,
+                },
             ],
             ..Default::default()
         };

--- a/crates/pod-agents/src/hybrid_agent.rs
+++ b/crates/pod-agents/src/hybrid_agent.rs
@@ -49,10 +49,10 @@
 //! | `"retreat_to_y"`   | f32     | World-Y coordinate for retreat              |
 //! | `"reasoning"`      | String  | LLM's reasoning (for logging/debug)         |
 
-use std::sync::{mpsc, Arc};
 use glam::Vec2;
 use log::{debug, info, warn};
 use serde::{Deserialize, Serialize};
+use std::sync::{mpsc, Arc};
 
 use pod_core::action::{Action, AgentConstraints};
 use pod_core::agent::{Agent, AgentIntrospection, AgentType};
@@ -62,9 +62,9 @@ use pod_core::observation::{Observation, Relationship};
 use crate::conversation_memory::{ConversationMemory, MemoryConfig};
 use crate::llm_provider::{CompletionRequest, LlmProvider, MockProvider, TokenBudget};
 use crate::scripted_agent::{
-    Blackboard, BehaviorNode, BehaviorStatus, BehaviorTree,
     attack_nearest as _attack_nearest, chase_nearest_hostile as _chase_nearest_hostile,
-    flee_from as _flee_from, guard as _guard, patrol as _patrol, wander as _wander,
+    flee_from as _flee_from, guard as _guard, patrol as _patrol, wander as _wander, BehaviorNode,
+    BehaviorStatus, BehaviorTree, Blackboard,
 };
 
 // ============================================================
@@ -99,7 +99,9 @@ pub struct StrategyDirective {
     pub reasoning: String,
 }
 
-fn default_urgency() -> f32 { 0.5 }
+fn default_urgency() -> f32 {
+    0.5
+}
 
 impl Default for StrategyDirective {
     fn default() -> Self {
@@ -266,7 +268,8 @@ Rules:
 - "explore" when nothing notable is happening
 - "patrol" as a default fallback
 - "hold" when waiting is tactically best
-Respond ONLY with the JSON object, no other text."#.to_string()
+Respond ONLY with the JSON object, no other text."#
+        .to_string()
 }
 
 // ============================================================
@@ -375,11 +378,15 @@ impl HybridAgent {
 
     /// Returns `true` if any trigger condition fires for the current observation.
     fn triggers_fired(&self, obs: &Observation) -> bool {
-        let hostile_count = obs.visible_entities.iter()
+        let hostile_count = obs
+            .visible_entities
+            .iter()
             .filter(|e| matches!(e.relationship, Relationship::Hostile))
             .count();
 
-        let health_frac = obs.self_state.health
+        let health_frac = obs
+            .self_state
+            .health
             .zip(obs.self_state.max_health)
             .map(|(h, m)| if m > 0.0 { h / m } else { 0.0 })
             .unwrap_or(1.0);
@@ -388,14 +395,19 @@ impl HybridAgent {
             match trigger {
                 StrategyTrigger::HealthBelow(threshold) => {
                     if health_frac < *threshold && self.last_health_fraction >= *threshold {
-                        debug!("HybridAgent {}: trigger HealthBelow({})", self.id, threshold);
+                        debug!(
+                            "HybridAgent {}: trigger HealthBelow({})",
+                            self.id, threshold
+                        );
                         return true;
                     }
                 }
                 StrategyTrigger::NewHostileVisible => {
                     if hostile_count > self.last_hostile_count {
-                        debug!("HybridAgent {}: trigger NewHostileVisible ({} → {})",
-                            self.id, self.last_hostile_count, hostile_count);
+                        debug!(
+                            "HybridAgent {}: trigger NewHostileVisible ({} → {})",
+                            self.id, self.last_hostile_count, hostile_count
+                        );
                         return true;
                     }
                 }
@@ -406,10 +418,15 @@ impl HybridAgent {
                     }
                 }
                 StrategyTrigger::ObjectiveProgress(threshold) => {
-                    let any_at_threshold = obs.objectives.iter()
+                    let any_at_threshold = obs
+                        .objectives
+                        .iter()
                         .any(|o| o.progress >= *threshold && !o.completed);
                     if any_at_threshold {
-                        debug!("HybridAgent {}: trigger ObjectiveProgress({})", self.id, threshold);
+                        debug!(
+                            "HybridAgent {}: trigger ObjectiveProgress({})",
+                            self.id, threshold
+                        );
                         return true;
                     }
                 }
@@ -437,7 +454,10 @@ impl HybridAgent {
             + self.provider.estimate_tokens(&self.config.system_prompt);
 
         if !self.budget.can_request(estimated) {
-            warn!("HybridAgent {}: token budget exceeded, skipping strategy re-plan", self.id);
+            warn!(
+                "HybridAgent {}: token budget exceeded, skipping strategy re-plan",
+                self.id
+            );
             return;
         }
 
@@ -457,23 +477,27 @@ impl HybridAgent {
         self.strategy_in_flight = true;
         self.ticks_since_strategy = 0;
 
-        std::thread::spawn(move || {
-            match provider.complete(&request) {
-                Ok(completion) => {
-                    let directive = StrategyDirective::parse(&completion.content);
-                    debug!("HybridAgent {}: new strategy = {:?}", agent_id, directive.strategy);
-                    let _ = tx.send(StrategyResult { directive, tick });
-                }
-                Err(e) => {
-                    warn!("HybridAgent {}: LLM error: {}, keeping current strategy", agent_id, e);
-                    let _ = tx.send(StrategyResult {
-                        directive: StrategyDirective {
-                            reasoning: format!("LLM error: {}", e),
-                            ..Default::default()
-                        },
-                        tick,
-                    });
-                }
+        std::thread::spawn(move || match provider.complete(&request) {
+            Ok(completion) => {
+                let directive = StrategyDirective::parse(&completion.content);
+                debug!(
+                    "HybridAgent {}: new strategy = {:?}",
+                    agent_id, directive.strategy
+                );
+                let _ = tx.send(StrategyResult { directive, tick });
+            }
+            Err(e) => {
+                warn!(
+                    "HybridAgent {}: LLM error: {}, keeping current strategy",
+                    agent_id, e
+                );
+                let _ = tx.send(StrategyResult {
+                    directive: StrategyDirective {
+                        reasoning: format!("LLM error: {}", e),
+                        ..Default::default()
+                    },
+                    tick,
+                });
             }
         });
     }
@@ -488,16 +512,21 @@ impl HybridAgent {
             "strategy".to_string(),
             serde_json::Value::String(directive.strategy.clone()),
         );
-        self.tree.blackboard.set(
-            "urgency".to_string(),
-            serde_json::json!(directive.urgency),
-        );
+        self.tree
+            .blackboard
+            .set("urgency".to_string(), serde_json::json!(directive.urgency));
         if let Some(id) = directive.target_id {
-            self.tree.blackboard.set("target_id".to_string(), serde_json::json!(id));
+            self.tree
+                .blackboard
+                .set("target_id".to_string(), serde_json::json!(id));
         }
         if let Some([x, y]) = directive.retreat_position {
-            self.tree.blackboard.set("retreat_to_x".to_string(), serde_json::json!(x));
-            self.tree.blackboard.set("retreat_to_y".to_string(), serde_json::json!(y));
+            self.tree
+                .blackboard
+                .set("retreat_to_x".to_string(), serde_json::json!(x));
+            self.tree
+                .blackboard
+                .set("retreat_to_y".to_string(), serde_json::json!(y));
         }
         self.tree.blackboard.set(
             "reasoning".to_string(),
@@ -511,15 +540,23 @@ impl HybridAgent {
 // ============================================================
 
 impl Agent for HybridAgent {
-    fn id(&self) -> AgentId { self.id }
-    fn agent_type(&self) -> AgentType { AgentType::LlmAgent }
+    fn id(&self) -> AgentId {
+        self.id
+    }
+    fn agent_type(&self) -> AgentType {
+        AgentType::LlmAgent
+    }
 
     fn observe(&mut self, observation: Observation) {
         // 1. Update trigger-tracking state
-        let hostile_count = observation.visible_entities.iter()
+        let hostile_count = observation
+            .visible_entities
+            .iter()
             .filter(|e| matches!(e.relationship, Relationship::Hostile))
             .count();
-        let health_frac = observation.self_state.health
+        let health_frac = observation
+            .self_state
+            .health
             .zip(observation.self_state.max_health)
             .map(|(h, m)| if m > 0.0 { h / m } else { 0.0 })
             .unwrap_or(1.0);
@@ -539,7 +576,8 @@ impl Agent for HybridAgent {
                 if self.config.debug_logging {
                     info!(
                         "HybridAgent {} [tick {}]: strategy = {} (urgency={:.2}): {}",
-                        self.id, result.tick,
+                        self.id,
+                        result.tick,
                         result.directive.strategy,
                         result.directive.urgency,
                         result.directive.reasoning
@@ -548,7 +586,9 @@ impl Agent for HybridAgent {
                 // Log the new directive (memory.record requires obs+actions, not available here)
                 log::debug!(
                     "HybridAgent {}: new directive strategy={} urgency={:.2}",
-                    self.id, result.directive.strategy, result.directive.urgency,
+                    self.id,
+                    result.directive.strategy,
+                    result.directive.urgency,
                 );
                 let directive = result.directive.clone();
                 self.apply_directive_to_blackboard(&directive);
@@ -575,7 +615,10 @@ impl Agent for HybridAgent {
         let (actions, status) = self.tree.tick(&obs);
 
         if self.config.debug_logging {
-            let strategy = self.tree.blackboard.get_string("strategy")
+            let strategy = self
+                .tree
+                .blackboard
+                .get_string("strategy")
                 .unwrap_or_else(|| "patrol".to_string());
             debug!(
                 "HybridAgent {} [tick {}]: BT={:?} strategy={} actions={:?}",
@@ -591,11 +634,18 @@ impl Agent for HybridAgent {
         actions
     }
 
-    fn constraints(&self) -> &AgentConstraints { &self.constraints }
-    fn constraints_mut(&mut self) -> &mut AgentConstraints { &mut self.constraints }
+    fn constraints(&self) -> &AgentConstraints {
+        &self.constraints
+    }
+    fn constraints_mut(&mut self) -> &mut AgentConstraints {
+        &mut self.constraints
+    }
 
     fn introspect(&self) -> AgentIntrospection {
-        let strategy = self.tree.blackboard.get_string("strategy")
+        let strategy = self
+            .tree
+            .blackboard
+            .get_string("strategy")
             .unwrap_or_else(|| "patrol".to_string());
         let urgency = self.tree.blackboard.get_f32("urgency").unwrap_or(0.5);
         AgentIntrospection {
@@ -604,9 +654,7 @@ impl Agent for HybridAgent {
             constraints: self.constraints.clone(),
             state_description: format!(
                 "strategy={} urgency={:.2} ticks_since_plan={} in_flight={}",
-                strategy, urgency,
-                self.ticks_since_strategy,
-                self.strategy_in_flight,
+                strategy, urgency, self.ticks_since_strategy, self.strategy_in_flight,
             ),
         }
     }
@@ -624,33 +672,52 @@ fn format_observation_for_strategy(obs: &Observation) -> String {
         obs.tick,
         obs.self_state.position.x,
         obs.self_state.position.y,
-        obs.self_state.health
+        obs.self_state
+            .health
             .zip(obs.self_state.max_health)
             .map(|(h, m)| if m > 0.0 { h / m * 100.0 } else { 0.0 })
             .unwrap_or(100.0),
         obs.self_state.rotation.to_degrees(),
     ));
 
-    let hostiles: Vec<_> = obs.visible_entities.iter()
+    let hostiles: Vec<_> = obs
+        .visible_entities
+        .iter()
         .filter(|e| matches!(e.relationship, Relationship::Hostile))
         .collect();
-    let friendlies: Vec<_> = obs.visible_entities.iter()
+    let friendlies: Vec<_> = obs
+        .visible_entities
+        .iter()
         .filter(|e| matches!(e.relationship, Relationship::Friendly))
         .collect();
 
-    s.push_str(&format!("enemies={} allies={}\n", hostiles.len(), friendlies.len()));
+    s.push_str(&format!(
+        "enemies={} allies={}\n",
+        hostiles.len(),
+        friendlies.len()
+    ));
 
-    if let Some(nearest) = hostiles.iter().min_by(|a, b| a.distance.partial_cmp(&b.distance).unwrap()) {
-        s.push_str(&format!("nearest_enemy dist={:.0} hp={}\n",
+    if let Some(nearest) = hostiles
+        .iter()
+        .min_by(|a, b| a.distance.partial_cmp(&b.distance).unwrap())
+    {
+        s.push_str(&format!(
+            "nearest_enemy dist={:.0} hp={}\n",
             nearest.distance,
-            nearest.health_fraction.map(|h| format!("{:.0}%", h * 100.0)).unwrap_or_else(|| "?".to_string())
+            nearest
+                .health_fraction
+                .map(|h| format!("{:.0}%", h * 100.0))
+                .unwrap_or_else(|| "?".to_string())
         ));
     }
 
     if !obs.objectives.is_empty() {
         let obj = &obs.objectives[0];
-        s.push_str(&format!("objective=\"{}\" progress={:.0}%\n",
-            obj.description, obj.progress * 100.0));
+        s.push_str(&format!(
+            "objective=\"{}\" progress={:.0}%\n",
+            obj.description,
+            obj.progress * 100.0
+        ));
     }
 
     s
@@ -662,21 +729,29 @@ fn strategy_fallback_actions(directive: &StrategyDirective, obs: &Observation) -
     match directive.strategy.as_str() {
         "attack" | "engage" => {
             // Find nearest hostile and attack it
-            if let Some(target) = obs.visible_entities.iter()
+            if let Some(target) = obs
+                .visible_entities
+                .iter()
                 .filter(|e| matches!(e.relationship, Relationship::Hostile))
                 .min_by(|a, b| a.distance.partial_cmp(&b.distance).unwrap())
             {
-                vec![Action::AttackTarget { target: pod_core::id::EntityId(target.entity_id.0) }]
+                vec![Action::AttackTarget {
+                    target: pod_core::id::EntityId(target.entity_id.0),
+                }]
             } else {
                 vec![Action::Idle]
             }
         }
         "flee" | "retreat" => {
             if let Some([x, y]) = directive.retreat_position {
-                vec![Action::Move { direction: Vec2::new(x, y).normalize_or_zero() }]
+                vec![Action::Move {
+                    direction: Vec2::new(x, y).normalize_or_zero(),
+                }]
             } else {
                 // Move away from nearest hostile
-                if let Some(hostile) = obs.visible_entities.iter()
+                if let Some(hostile) = obs
+                    .visible_entities
+                    .iter()
                     .filter(|e| matches!(e.relationship, Relationship::Hostile))
                     .min_by(|a, b| a.distance.partial_cmp(&b.distance).unwrap())
                 {
@@ -712,23 +787,26 @@ fn default_strategy_tree() -> BehaviorTree {
         BehaviorNode::sequence(vec![
             BehaviorNode::HasTarget,
             BehaviorNode::EnemyInRange { range: 200.0 },
-            BehaviorNode::ActionNode { action: Action::Idle }, // placeholder: real BT would call attack
+            BehaviorNode::ActionNode {
+                action: Action::Idle,
+            }, // placeholder: real BT would call attack
         ]),
-
         // --- chase branch: hostile visible but not in attack range ---
         BehaviorNode::sequence(vec![
             BehaviorNode::HasTarget,
-            BehaviorNode::MoveToNearest { relationship: Relationship::Hostile },
+            BehaviorNode::MoveToNearest {
+                relationship: Relationship::Hostile,
+            },
         ]),
-
         // --- flee branch: low health ---
         BehaviorNode::sequence(vec![
             BehaviorNode::HealthBelow { threshold: 0.3 },
             BehaviorNode::FleeFromNearest,
         ]),
-
         // --- default: wander/patrol ---
-        BehaviorNode::ActionNode { action: Action::Idle },
+        BehaviorNode::ActionNode {
+            action: Action::Idle,
+        },
     ]);
 
     BehaviorTree::new(root)
@@ -747,13 +825,17 @@ pub fn aggressive_hybrid(config: HybridAgentConfig) -> HybridAgent {
     let attack_root = BehaviorNode::selector(vec![
         BehaviorNode::sequence(vec![
             BehaviorNode::HasTarget,
-            BehaviorNode::MoveToNearest { relationship: Relationship::Hostile },
+            BehaviorNode::MoveToNearest {
+                relationship: Relationship::Hostile,
+            },
         ]),
         BehaviorNode::sequence(vec![
             BehaviorNode::HealthBelow { threshold: 0.25 },
             BehaviorNode::FleeFromNearest,
         ]),
-        BehaviorNode::ActionNode { action: Action::Idle },
+        BehaviorNode::ActionNode {
+            action: Action::Idle,
+        },
     ]);
 
     HybridAgent::new(config).with_tree(BehaviorTree::new(attack_root))
@@ -771,13 +853,17 @@ pub fn defensive_hybrid(mut config: HybridAgentConfig) -> HybridAgent {
     let guard_root = BehaviorNode::selector(vec![
         BehaviorNode::sequence(vec![
             BehaviorNode::EnemyInRange { range: 100.0 },
-            BehaviorNode::MoveToNearest { relationship: Relationship::Hostile },
+            BehaviorNode::MoveToNearest {
+                relationship: Relationship::Hostile,
+            },
         ]),
         BehaviorNode::sequence(vec![
             BehaviorNode::HealthBelow { threshold: 0.3 },
             BehaviorNode::FleeFromNearest,
         ]),
-        BehaviorNode::ActionNode { action: Action::Idle },
+        BehaviorNode::ActionNode {
+            action: Action::Idle,
+        },
     ]);
 
     HybridAgent::new(config).with_tree(BehaviorTree::new(guard_root))
@@ -790,8 +876,8 @@ pub fn defensive_hybrid(mut config: HybridAgentConfig) -> HybridAgent {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pod_core::observation::{Observation, SelfState, VisibleEntity};
     use glam::Vec2;
+    use pod_core::observation::{Observation, SelfState, VisibleEntity};
 
     fn make_obs_with_hostile(health_pct: f32, hostile_distance: Option<f32>) -> Observation {
         let mut obs = Observation::default();
@@ -812,6 +898,7 @@ mod tests {
                 distance: dist,
                 relationship: Relationship::Hostile,
                 health_fraction: Some(1.0),
+                ..Default::default()
             });
         }
         obs
@@ -819,7 +906,8 @@ mod tests {
 
     #[test]
     fn test_strategy_directive_parse_json() {
-        let json = r#"{"strategy":"attack","urgency":0.9,"target_id":42,"reasoning":"enemy close"}"#;
+        let json =
+            r#"{"strategy":"attack","urgency":0.9,"target_id":42,"reasoning":"enemy close"}"#;
         let d = StrategyDirective::parse(json);
         assert_eq!(d.strategy, "attack");
         assert!((d.urgency - 0.9).abs() < 0.01);
@@ -918,7 +1006,7 @@ mod tests {
         let agent = HybridAgent::new(config);
         // Initially health is 1.0 (from last_health_fraction init)
         let obs = make_obs_with_hostile(0.25, None); // 25% health — below threshold
-        // Should trigger because 0.25 < 0.3 and last was >= 0.3
+                                                     // Should trigger because 0.25 < 0.3 and last was >= 0.3
         assert!(agent.triggers_fired(&obs));
     }
 
@@ -957,7 +1045,10 @@ mod tests {
             reasoning: "hold the line".to_string(),
         };
         agent.apply_directive_to_blackboard(&directive);
-        assert_eq!(agent.blackboard().get_string("strategy").as_deref(), Some("guard"));
+        assert_eq!(
+            agent.blackboard().get_string("strategy").as_deref(),
+            Some("guard")
+        );
         assert!((agent.blackboard().get_f32("urgency").unwrap() - 0.7).abs() < 0.01);
     }
 

--- a/crates/pod-agents/src/llm_agent.rs
+++ b/crates/pod-agents/src/llm_agent.rs
@@ -10,6 +10,7 @@
 //! - Reaction time normalization: configurable delay (200-400ms) prevents inhuman response
 //! - Decision trace recording: every observation→prompt→response→action for replay
 
+use log::{debug, error, warn};
 use pod_core::action::{Action, AgentConstraints};
 use pod_core::agent::{Agent, AgentType};
 use pod_core::id::AgentId;
@@ -18,16 +19,13 @@ use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
 use std::sync::{mpsc, Arc};
 use std::time::{Duration, Instant};
-use log::{debug, warn, error};
 
-use crate::llm_provider::{
-    CompletionRequest, LlmProvider, MockProvider, TokenBudget, TokenUsage,
-};
-use crate::prompt_template::{PromptTemplate, ToonTemplate};
-#[cfg(test)]
-use crate::prompt_template::CompactTemplate;
 use crate::action_parser::{ActionParser, FallbackParser};
 use crate::conversation_memory::{ConversationMemory, MemoryConfig};
+use crate::llm_provider::{CompletionRequest, LlmProvider, MockProvider, TokenBudget, TokenUsage};
+#[cfg(test)]
+use crate::prompt_template::CompactTemplate;
+use crate::prompt_template::{PromptTemplate, ToonTemplate};
 
 // ============================================================
 // CONFIGURATION
@@ -278,11 +276,16 @@ impl LlmAgent {
         let memory_section = self.memory.to_prompt_section();
 
         // Build system prompt via template
-        let system_prompt = self.template.format_system_prompt(&self.config.system_prompt, action_instructions);
+        let system_prompt = self
+            .template
+            .format_system_prompt(&self.config.system_prompt, action_instructions);
 
         // Combine user prompt: memory + observation
         let user_prompt = if memory_section.is_empty() {
-            format!("Current observation:\n{}\n\n{}", obs_str, action_instructions)
+            format!(
+                "Current observation:\n{}\n\n{}",
+                obs_str, action_instructions
+            )
         } else {
             format!(
                 "{}\nCurrent observation:\n{}\n\n{}",
@@ -335,7 +338,11 @@ impl LlmAgent {
                                 "LLM agent {} parse failed ({}), falling back to Idle",
                                 agent_id, e
                             );
-                            (vec![Action::Idle], "Parse error fallback".to_string(), completion.content.clone())
+                            (
+                                vec![Action::Idle],
+                                "Parse error fallback".to_string(),
+                                completion.content.clone(),
+                            )
                         }
                     };
 
@@ -343,7 +350,10 @@ impl LlmAgent {
                         Some(DecisionTrace {
                             tick,
                             compressed_observation: obs_compressed,
-                            llm_prompt: format!("{}\n\n{}", request.system_prompt, request.user_prompt),
+                            llm_prompt: format!(
+                                "{}\n\n{}",
+                                request.system_prompt, request.user_prompt
+                            ),
                             llm_response: raw.clone(),
                             parsed_actions: actions.clone(),
                             reasoning: reasoning.clone(),
@@ -398,15 +408,17 @@ impl LlmAgent {
         match action {
             Action::Move { direction } => {
                 let decayed_dir = *direction * self.stale_action_decay;
-                Action::Move { direction: decayed_dir }
+                Action::Move {
+                    direction: decayed_dir,
+                }
             }
             Action::Attack | Action::UseAbility { .. } => {
                 // Don't repeat offensive actions while waiting
                 Action::Idle
             }
-            Action::Rotate { angle } => {
-                Action::Rotate { angle: angle * self.stale_action_decay }
-            }
+            Action::Rotate { angle } => Action::Rotate {
+                angle: angle * self.stale_action_decay,
+            },
             other => other.clone(),
         }
     }
@@ -482,11 +494,8 @@ impl Agent for LlmAgent {
                 // Record to conversation memory
                 let reasoning = self.decision_buffer.ready_reasoning.clone();
                 if let Some(pending) = &self.decision_buffer.pending {
-                    self.memory.record(
-                        &pending.observation,
-                        &ready_actions,
-                        &reasoning,
-                    );
+                    self.memory
+                        .record(&pending.observation, &ready_actions, &reasoning);
                 }
 
                 // Record trace if available
@@ -556,8 +565,8 @@ Follow the action format specified by the system instructions."#
 mod tests {
     use super::*;
     use crate::llm_provider::{CompletionResponse, LlmError};
-    use pod_core::observation::*;
     use glam::Vec2;
+    use pod_core::observation::*;
     use std::sync::Arc;
     use std::sync::Mutex;
 
@@ -582,6 +591,7 @@ mod tests {
                 distance: 50.0,
                 relationship: Relationship::Hostile,
                 health_fraction: Some(0.5),
+                ..Default::default()
             });
         }
         obs
@@ -593,10 +603,7 @@ mod tests {
     }
 
     impl CapturingProvider {
-        fn new(
-            response: String,
-            captured: Arc<Mutex<Option<CompletionRequest>>>,
-        ) -> Self {
+        fn new(response: String, captured: Arc<Mutex<Option<CompletionRequest>>>) -> Self {
             Self { response, captured }
         }
     }
@@ -669,7 +676,9 @@ reasoning[1]{
         assert!(request.user_prompt.contains("self["));
         assert!(request.user_prompt.contains("visible_entities["));
         assert!(request.user_prompt.contains("available_actions["));
-        assert!(request.system_prompt.contains("TOON-formatted observations"));
+        assert!(request
+            .system_prompt
+            .contains("TOON-formatted observations"));
         assert!(request.system_prompt.contains("actions["));
         assert!(request.system_prompt.contains("reasoning["));
 
@@ -734,7 +743,9 @@ reasoning[1]{
     fn test_stale_action_decay() {
         let agent = LlmAgent::new(LlmAgentConfig::default());
 
-        let move_action = Action::Move { direction: Vec2::new(1.0, 0.0) };
+        let move_action = Action::Move {
+            direction: Vec2::new(1.0, 0.0),
+        };
         let decayed = agent.create_decayed_action(&move_action);
         // With decay=1.0 (initial), should be same direction
         if let Action::Move { direction } = decayed {

--- a/crates/pod-agents/src/neural_agent.rs
+++ b/crates/pod-agents/src/neural_agent.rs
@@ -7,14 +7,14 @@
 //! - Experience buffer: stores transitions for potential training
 //! - Support for multi-action policies and continuous control
 
+use glam::Vec2;
+use log::debug;
 use pod_core::action::{Action, AgentConstraints};
 use pod_core::agent::{Agent, AgentType};
 use pod_core::id::AgentId;
 use pod_core::observation::{Observation, Relationship};
-use glam::Vec2;
 use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
-use log::debug;
 
 /// Experience transition for training
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -85,15 +85,25 @@ impl ActionSelector for GreedyActionSelector {
 const ACTION_COUNT: usize = 10;
 const ACTION_SPACE: &[fn() -> Action] = &[
     || Action::Idle,
-    || Action::Move { direction: Vec2::new(0.0, -1.0) }, // up
-    || Action::Move { direction: Vec2::new(0.0, 1.0) },  // down
-    || Action::Move { direction: Vec2::new(-1.0, 0.0) }, // left
-    || Action::Move { direction: Vec2::new(1.0, 0.0) },  // right
+    || Action::Move {
+        direction: Vec2::new(0.0, -1.0),
+    }, // up
+    || Action::Move {
+        direction: Vec2::new(0.0, 1.0),
+    }, // down
+    || Action::Move {
+        direction: Vec2::new(-1.0, 0.0),
+    }, // left
+    || Action::Move {
+        direction: Vec2::new(1.0, 0.0),
+    }, // right
     || Action::Stop,
     || Action::Attack,
     || Action::Interact,
     || Action::Drop { slot: 0 },
-    || Action::Rotate { angle: std::f32::consts::PI / 4.0 }, // turn 45°
+    || Action::Rotate {
+        angle: std::f32::consts::PI / 4.0,
+    }, // turn 45°
 ];
 
 fn index_to_action(index: usize) -> Action {
@@ -180,7 +190,9 @@ impl NeuralAgent {
         next_observation: &Observation,
         terminal: bool,
     ) {
-        if let (Some(features), Some(action_idx)) = (self.last_features.take(), self.last_action.take()) {
+        if let (Some(features), Some(action_idx)) =
+            (self.last_features.take(), self.last_action.take())
+        {
             let next_features = Self::observation_to_features(next_observation);
 
             let exp = Experience {
@@ -208,8 +220,8 @@ impl NeuralAgent {
         // ===== SELF STATE (6 features) =====
         features.push((obs.self_state.position.x / 1000.0).clamp(-1.0, 1.0)); // position x
         features.push((obs.self_state.position.y / 1000.0).clamp(-1.0, 1.0)); // position y
-        features.push((obs.self_state.velocity.x / 500.0).clamp(-1.0, 1.0));  // velocity x
-        features.push((obs.self_state.velocity.y / 500.0).clamp(-1.0, 1.0));  // velocity y
+        features.push((obs.self_state.velocity.x / 500.0).clamp(-1.0, 1.0)); // velocity x
+        features.push((obs.self_state.velocity.y / 500.0).clamp(-1.0, 1.0)); // velocity y
         features.push((obs.self_state.rotation / std::f32::consts::PI).clamp(-1.0, 1.0)); // rotation
         let health_ratio = match (obs.self_state.health, obs.self_state.max_health) {
             (Some(h), Some(m)) if m > 0.0 => (h / m).clamp(0.0, 1.0),
@@ -407,6 +419,7 @@ mod tests {
                 max_health: Some(100.0),
                 team: Team::Team(1),
                 cooldowns: vec![],
+                ..Default::default()
             },
             visible_entities: vec![VisibleEntity {
                 entity_id: pod_core::id::EntityId(2),
@@ -417,6 +430,7 @@ mod tests {
                 distance: 100.0,
                 relationship: Relationship::Hostile,
                 health_fraction: Some(0.5),
+                ..Default::default()
             }],
             audible_events: vec![],
             messages: vec![],

--- a/crates/pod-agents/src/prompt_template.rs
+++ b/crates/pod-agents/src/prompt_template.rs
@@ -230,7 +230,9 @@ pub struct TacticalTemplate {
 
 impl Default for TacticalTemplate {
     fn default() -> Self {
-        Self { threat_range: 300.0 }
+        Self {
+            threat_range: 300.0,
+        }
     }
 }
 
@@ -414,12 +416,7 @@ impl PromptTemplate for ToonTemplate {
             .self_state
             .cooldowns
             .iter()
-            .map(|cd| {
-                format!(
-                    "{} rem={}/{}",
-                    cd.name, cd.remaining_ticks, cd.total_ticks
-                )
-            })
+            .map(|cd| format!("{} rem={}/{}", cd.name, cd.remaining_ticks, cd.total_ticks))
             .collect();
 
         let visible_rows: Vec<String> = obs
@@ -481,7 +478,12 @@ impl PromptTemplate for ToonTemplate {
         let audio_rows: Vec<String> = obs
             .audible_events
             .iter()
-            .map(|event| format!("{} at {:.0} ({:.0})", event.event_type, event.distance, event.intensity))
+            .map(|event| {
+                format!(
+                    "{} at {:.0} ({:.0})",
+                    event.event_type, event.distance, event.intensity
+                )
+            })
             .collect();
 
         Self::push_section(&mut out, "self", &self_rows);
@@ -578,8 +580,8 @@ impl Default for TemplateRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pod_core::observation::*;
     use glam::Vec2;
+    use pod_core::observation::*;
 
     fn test_observation() -> Observation {
         Observation {
@@ -602,6 +604,7 @@ mod tests {
                     distance: 55.0,
                     relationship: Relationship::Hostile,
                     health_fraction: Some(0.6),
+                    ..Default::default()
                 },
                 VisibleEntity {
                     entity_id: pod_core::id::EntityId(2),
@@ -612,6 +615,7 @@ mod tests {
                     distance: 25.0,
                     relationship: Relationship::Friendly,
                     health_fraction: Some(0.9),
+                    ..Default::default()
                 },
             ],
             audible_events: vec![AudibleEvent {

--- a/crates/pod-agents/src/scripted_agent.rs
+++ b/crates/pod-agents/src/scripted_agent.rs
@@ -7,14 +7,14 @@
 //! - Finite State Machine (FSM) as alternative to behavior trees
 //! - Full action generation and state management
 
+use glam::Vec2;
+use log::{debug, warn};
 use pod_core::action::{Action, AgentConstraints};
 use pod_core::agent::{Agent, AgentType};
 use pod_core::id::AgentId;
 use pod_core::observation::{Observation, Relationship};
-use glam::Vec2;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use log::{debug, warn};
 
 /// Behavior tree status
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -119,11 +119,17 @@ impl Blackboard {
     }
 
     pub fn get_f32(&self, key: &str) -> Option<f32> {
-        self.data.get(key).and_then(|v| v.as_f64()).map(|f| f as f32)
+        self.data
+            .get(key)
+            .and_then(|v| v.as_f64())
+            .map(|f| f as f32)
     }
 
     pub fn get_string(&self, key: &str) -> Option<String> {
-        self.data.get(key).and_then(|v| v.as_str()).map(|s| s.to_string())
+        self.data
+            .get(key)
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
     }
 
     pub fn clear(&mut self) {
@@ -268,7 +274,10 @@ impl BehaviorTree {
         observation: &Observation,
     ) -> BehaviorStatus {
         match node {
-            BehaviorNode::Sequence { children, current_child_index } => {
+            BehaviorNode::Sequence {
+                children,
+                current_child_index,
+            } => {
                 // Sequence: run until one fails
                 for i in *current_child_index..children.len() {
                     match Self::tick_node(&mut children[i], actions, observation) {
@@ -287,7 +296,10 @@ impl BehaviorTree {
                 BehaviorStatus::Success
             }
 
-            BehaviorNode::Selector { children, current_child_index } => {
+            BehaviorNode::Selector {
+                children,
+                current_child_index,
+            } => {
                 // Selector: run until one succeeds
                 for i in *current_child_index..children.len() {
                     match Self::tick_node(&mut children[i], actions, observation) {
@@ -377,7 +389,11 @@ impl BehaviorTree {
                 }
             }
 
-            BehaviorNode::Repeat { child, count, current } => {
+            BehaviorNode::Repeat {
+                child,
+                count,
+                current,
+            } => {
                 if *current >= *count {
                     *current = 0;
                     return BehaviorStatus::Success;
@@ -406,7 +422,6 @@ impl BehaviorTree {
             BehaviorNode::Failure => BehaviorStatus::Failure,
 
             // ── Sensory / Conditional leaves (Task 2.8) ────────────────────
-
             BehaviorNode::HealthBelow { threshold } => {
                 let frac = health_fraction(observation);
                 if frac < *threshold {
@@ -473,7 +488,6 @@ impl BehaviorTree {
             }
 
             // ── Action leaves (Task 2.8) ───────────────────────────────────
-
             BehaviorNode::MoveToNearest { relationship } => {
                 let rel = *relationship;
                 if let Some(pos) = nearest_of_relationship(observation, rel) {
@@ -648,7 +662,10 @@ impl FiniteStateMachine {
                 let frac = health_fraction(obs);
                 return frac < threshold_pct / 100.0;
             }
-            warn!("FSM: could not parse threshold from condition '{}'", condition);
+            warn!(
+                "FSM: could not parse threshold from condition '{}'",
+                condition
+            );
             return false;
         }
 
@@ -658,7 +675,10 @@ impl FiniteStateMachine {
                 let frac = health_fraction(obs);
                 return frac > threshold_pct / 100.0;
             }
-            warn!("FSM: could not parse threshold from condition '{}'", condition);
+            warn!(
+                "FSM: could not parse threshold from condition '{}'",
+                condition
+            );
             return false;
         }
 
@@ -689,7 +709,11 @@ fn nearest_hostile_position(obs: &Observation) -> Option<Vec2> {
     obs.visible_entities
         .iter()
         .filter(|e| matches!(e.relationship, Relationship::Hostile))
-        .min_by(|a, b| a.distance.partial_cmp(&b.distance).unwrap_or(std::cmp::Ordering::Equal))
+        .min_by(|a, b| {
+            a.distance
+                .partial_cmp(&b.distance)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
         .map(|e| e.position)
 }
 
@@ -698,7 +722,11 @@ fn nearest_of_relationship(obs: &Observation, rel: Relationship) -> Option<Vec2>
     obs.visible_entities
         .iter()
         .filter(|e| relationship_matches(e.relationship, rel))
-        .min_by(|a, b| a.distance.partial_cmp(&b.distance).unwrap_or(std::cmp::Ordering::Equal))
+        .min_by(|a, b| {
+            a.distance
+                .partial_cmp(&b.distance)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
         .map(|e| e.position)
 }
 
@@ -848,7 +876,9 @@ pub fn chase_nearest_hostile() -> BehaviorNode {
 /// Chase a specific target position
 pub fn chase_target(target_position: Vec2) -> BehaviorNode {
     BehaviorNode::sequence(vec![
-        BehaviorNode::action(Action::LookAt { target: target_position }),
+        BehaviorNode::action(Action::LookAt {
+            target: target_position,
+        }),
         BehaviorNode::action(Action::Move {
             direction: target_position.normalize(),
         }),
@@ -867,7 +897,9 @@ pub fn attack_nearest() -> BehaviorNode {
 pub fn flee_from(danger_position: Vec2) -> BehaviorNode {
     let flee_direction = -danger_position.normalize();
     BehaviorNode::sequence(vec![
-        BehaviorNode::action(Action::Move { direction: flee_direction }),
+        BehaviorNode::action(Action::Move {
+            direction: flee_direction,
+        }),
         BehaviorNode::wait(60),
     ])
 }
@@ -1062,9 +1094,12 @@ pub fn combat_fsm() -> FiniteStateMachine {
 ///   Attacking  → Chasing   : no_enemies (enemy fled but recheck)
 ///   Chasing    → Patrolling : no_enemies + timer_120
 pub fn patrol_fsm() -> FiniteStateMachine {
-    let mut fsm = FiniteStateMachine::new(FsmState::Patrolling, Action::Move {
-        direction: Vec2::new(1.0, 0.0),
-    });
+    let mut fsm = FiniteStateMachine::new(
+        FsmState::Patrolling,
+        Action::Move {
+            direction: Vec2::new(1.0, 0.0),
+        },
+    );
 
     fsm.add_transition(FsmTransition {
         from: FsmState::Patrolling,
@@ -1087,12 +1122,18 @@ pub fn patrol_fsm() -> FiniteStateMachine {
         condition: "no_enemies".into(),
     });
 
-    fsm.set_state_action(FsmState::Patrolling, Action::Move {
-        direction: Vec2::new(1.0, 0.0),
-    });
-    fsm.set_state_action(FsmState::Chasing, Action::Move {
-        direction: Vec2::new(0.0, 1.0), // direction updated by runtime logic
-    });
+    fsm.set_state_action(
+        FsmState::Patrolling,
+        Action::Move {
+            direction: Vec2::new(1.0, 0.0),
+        },
+    );
+    fsm.set_state_action(
+        FsmState::Chasing,
+        Action::Move {
+            direction: Vec2::new(0.0, 1.0), // direction updated by runtime logic
+        },
+    );
     fsm.set_state_action(FsmState::Attacking, Action::Attack);
 
     fsm
@@ -1152,9 +1193,12 @@ pub fn coward_fsm() -> FiniteStateMachine {
     });
 
     fsm.set_state_action(FsmState::Idle, Action::Idle);
-    fsm.set_state_action(FsmState::Fleeing, Action::Move {
-        direction: Vec2::new(-1.0, 0.0), // away; runtime should override
-    });
+    fsm.set_state_action(
+        FsmState::Fleeing,
+        Action::Move {
+            direction: Vec2::new(-1.0, 0.0), // away; runtime should override
+        },
+    );
 
     fsm
 }
@@ -1166,10 +1210,7 @@ mod tests {
     #[test]
     fn test_behavior_sequence() {
         let mut tree = BehaviorTree::new(BehaviorNode::Sequence {
-            children: vec![
-                BehaviorNode::Success,
-                BehaviorNode::Success,
-            ],
+            children: vec![BehaviorNode::Success, BehaviorNode::Success],
             current_child_index: 0,
         });
 
@@ -1191,10 +1232,7 @@ mod tests {
     #[test]
     fn test_behavior_selector() {
         let mut tree = BehaviorTree::new(BehaviorNode::Selector {
-            children: vec![
-                BehaviorNode::Failure,
-                BehaviorNode::Success,
-            ],
+            children: vec![BehaviorNode::Failure, BehaviorNode::Success],
             current_child_index: 0,
         });
 
@@ -1245,9 +1283,9 @@ mod tests {
     /// Build a minimal Observation that has one hostile at `distance` and
     /// self health set to `health` (out of 100).
     fn test_observation_with_hostile(distance: f32, health: f32) -> Observation {
-        use pod_core::observation::{SelfState, VisibleEntity};
-        use pod_core::id::EntityId;
         use pod_core::component::Team;
+        use pod_core::id::EntityId;
+        use pod_core::observation::{SelfState, VisibleEntity};
 
         Observation {
             tick: 100,
@@ -1268,6 +1306,7 @@ mod tests {
                 distance,
                 relationship: Relationship::Hostile,
                 health_fraction: Some(1.0),
+                ..Default::default()
             }],
             audible_events: vec![],
             messages: vec![],
@@ -1348,7 +1387,10 @@ mod tests {
         let obs_close = test_observation_with_hostile(50.0, 100.0);
         let mut tree = BehaviorTree::new(aggressive_combat(Vec2::ZERO, 200.0));
         let (actions, status) = tree.tick(&obs_close);
-        assert!(matches!(status, BehaviorStatus::Success | BehaviorStatus::Running));
+        assert!(matches!(
+            status,
+            BehaviorStatus::Success | BehaviorStatus::Running
+        ));
         // Should produce at least a LookAt and Attack
         assert!(
             actions.iter().any(|a| matches!(a, Action::Attack)),
@@ -1360,7 +1402,10 @@ mod tests {
         let obs_empty = test_observation_empty();
         let mut tree2 = BehaviorTree::new(aggressive_combat(Vec2::ZERO, 200.0));
         let (actions2, status2) = tree2.tick(&obs_empty);
-        assert!(matches!(status2, BehaviorStatus::Success | BehaviorStatus::Running));
+        assert!(matches!(
+            status2,
+            BehaviorStatus::Success | BehaviorStatus::Running
+        ));
         assert!(
             actions2.iter().any(|a| matches!(a, Action::Move { .. })),
             "expected Move in wander fallback: {:?}",

--- a/crates/pod-agents/src/utility_ai.rs
+++ b/crates/pod-agents/src/utility_ai.rs
@@ -36,14 +36,13 @@
 //! agent.add_scorer(Box::new(AttackNearestHostileScorer::default()));
 //! ```
 
-use std::collections::VecDeque;
 use glam::Vec2;
-use pod_core::{
-    Action, AgentConstraints, AgentId, AgentIntrospection, AgentType, EntityId,
-    Observation,
-};
 use pod_core::agent::Agent;
 use pod_core::observation::Relationship;
+use pod_core::{
+    Action, AgentConstraints, AgentId, AgentIntrospection, AgentType, EntityId, Observation,
+};
+use std::collections::VecDeque;
 
 // ============================================================
 // ACTION SCORER TRAIT
@@ -85,13 +84,20 @@ fn nearest_hostile(observation: &Observation) -> Option<&pod_core::observation::
         .visible_entities
         .iter()
         .filter(|e| matches!(e.relationship, Relationship::Hostile))
-        .min_by(|a, b| a.distance.partial_cmp(&b.distance).unwrap_or(std::cmp::Ordering::Equal))
+        .min_by(|a, b| {
+            a.distance
+                .partial_cmp(&b.distance)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
 }
 
 /// Returns the agent's health fraction in `[0.0, 1.0]`, defaulting to `1.0`
 /// when health information is unavailable.
 fn health_fraction(observation: &Observation) -> f32 {
-    match (observation.self_state.health, observation.self_state.max_health) {
+    match (
+        observation.self_state.health,
+        observation.self_state.max_health,
+    ) {
         (Some(hp), Some(max)) if max > 0.0 => (hp / max).clamp(0.0, 1.0),
         _ => 1.0,
     }
@@ -119,7 +125,9 @@ impl AttackNearestHostileScorer {
 
 impl Default for AttackNearestHostileScorer {
     fn default() -> Self {
-        Self { optimal_range: 80.0 }
+        Self {
+            optimal_range: 80.0,
+        }
     }
 }
 
@@ -145,12 +153,16 @@ impl ActionScorer for AttackNearestHostileScorer {
 
     fn action(&self, observation: &Observation) -> Action {
         match nearest_hostile(observation) {
-            Some(hostile) => Action::AttackTarget { target: hostile.entity_id },
+            Some(hostile) => Action::AttackTarget {
+                target: hostile.entity_id,
+            },
             None => Action::Idle,
         }
     }
 
-    fn name(&self) -> &str { "AttackNearestHostile" }
+    fn name(&self) -> &str {
+        "AttackNearestHostile"
+    }
 }
 
 // ── FleeScorer ────────────────────────────────────────────────
@@ -167,7 +179,9 @@ pub struct FleeScorer {
 
 impl Default for FleeScorer {
     fn default() -> Self {
-        Self { flee_threshold: 0.4 }
+        Self {
+            flee_threshold: 0.4,
+        }
     }
 }
 
@@ -208,7 +222,9 @@ impl ActionScorer for FleeScorer {
         Action::Move { direction: away }
     }
 
-    fn name(&self) -> &str { "Flee" }
+    fn name(&self) -> &str {
+        "Flee"
+    }
 }
 
 // ── HealScorer ────────────────────────────────────────────────
@@ -235,7 +251,9 @@ impl ActionScorer for HealScorer {
         Action::UseItem { slot: 0 }
     }
 
-    fn name(&self) -> &str { "Heal" }
+    fn name(&self) -> &str {
+        "Heal"
+    }
 }
 
 // ── ExploreScorer ─────────────────────────────────────────────
@@ -263,7 +281,9 @@ impl ActionScorer for ExploreScorer {
         Action::Move { direction }
     }
 
-    fn name(&self) -> &str { "Explore" }
+    fn name(&self) -> &str {
+        "Explore"
+    }
 }
 
 // ── IdleScorer ────────────────────────────────────────────────
@@ -284,7 +304,9 @@ impl ActionScorer for IdleScorer {
         Action::Idle
     }
 
-    fn name(&self) -> &str { "Idle" }
+    fn name(&self) -> &str {
+        "Idle"
+    }
 }
 
 // ── ChaseScorer ───────────────────────────────────────────────
@@ -302,7 +324,9 @@ pub struct ChaseScorer {
 
 impl Default for ChaseScorer {
     fn default() -> Self {
-        Self { engage_range: 120.0 }
+        Self {
+            engage_range: 120.0,
+        }
     }
 }
 
@@ -345,7 +369,9 @@ impl ActionScorer for ChaseScorer {
         }
     }
 
-    fn name(&self) -> &str { "Chase" }
+    fn name(&self) -> &str {
+        "Chase"
+    }
 }
 
 // ── GuardScorer ───────────────────────────────────────────────
@@ -387,7 +413,10 @@ impl GuardScorer {
 
 impl ActionScorer for GuardScorer {
     fn score(&self, observation: &Observation) -> f32 {
-        let dist = observation.self_state.position.distance(self.guard_position);
+        let dist = observation
+            .self_state
+            .position
+            .distance(self.guard_position);
         if dist <= self.tolerance {
             return 0.0;
         }
@@ -405,7 +434,9 @@ impl ActionScorer for GuardScorer {
         Action::Move { direction }
     }
 
-    fn name(&self) -> &str { "Guard" }
+    fn name(&self) -> &str {
+        "Guard"
+    }
 }
 
 // ============================================================
@@ -449,7 +480,10 @@ impl UtilityAgent {
     /// Panics if `scorers` is empty (at least one scorer is required to
     /// guarantee `decide()` always returns an action).
     pub fn with_scorers(scorers: Vec<Box<dyn ActionScorer>>) -> Self {
-        assert!(!scorers.is_empty(), "UtilityAgent requires at least one scorer");
+        assert!(
+            !scorers.is_empty(),
+            "UtilityAgent requires at least one scorer"
+        );
         Self {
             id: AgentId::new(),
             scorers,
@@ -576,10 +610,7 @@ impl Agent for UtilityAgent {
             "scorers={} winner={} tick={} history_len={}",
             self.scorers.len(),
             winner,
-            self.last_observation
-                .as_ref()
-                .map(|o| o.tick)
-                .unwrap_or(0),
+            self.last_observation.as_ref().map(|o| o.tick).unwrap_or(0),
             self.score_history.len(),
         );
 
@@ -673,7 +704,7 @@ impl UtilityProfile {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pod_core::observation::{SelfState, VisibleEntity, Relationship};
+    use pod_core::observation::{Relationship, SelfState, VisibleEntity};
 
     // ── Observation builders ──────────────────────────────────
 
@@ -688,7 +719,12 @@ mod tests {
         }
     }
 
-    fn hostile_entity(entity_id: EntityId, position: Vec2, distance: f32, health_fraction: f32) -> VisibleEntity {
+    fn hostile_entity(
+        entity_id: EntityId,
+        position: Vec2,
+        distance: f32,
+        health_fraction: f32,
+    ) -> VisibleEntity {
         VisibleEntity {
             entity_id,
             entity_type: "enemy".to_string(),
@@ -698,6 +734,7 @@ mod tests {
             distance,
             relationship: Relationship::Hostile,
             health_fraction: Some(health_fraction),
+            ..Default::default()
         }
     }
 
@@ -718,12 +755,8 @@ mod tests {
         let hp = max * hp_fraction;
         let mut obs = obs_with_health(hp, max);
         obs.self_state.position = Vec2::ZERO;
-        obs.visible_entities.push(hostile_entity(
-            EntityId(1),
-            Vec2::new(50.0, 0.0),
-            50.0,
-            1.0,
-        ));
+        obs.visible_entities
+            .push(hostile_entity(EntityId(1), Vec2::new(50.0, 0.0), 50.0, 1.0));
         obs
     }
 
@@ -742,8 +775,14 @@ mod tests {
         let s2 = scorer.score(&obs_hostile);
         let s3 = scorer.score(&obs_dying);
 
-        assert_eq!(s1, 0.05, "IdleScorer must return 0.05 for empty observation");
-        assert_eq!(s2, 0.05, "IdleScorer must return 0.05 with hostiles present");
+        assert_eq!(
+            s1, 0.05,
+            "IdleScorer must return 0.05 for empty observation"
+        );
+        assert_eq!(
+            s2, 0.05,
+            "IdleScorer must return 0.05 with hostiles present"
+        );
         assert_eq!(s3, 0.05, "IdleScorer must return 0.05 even when dying");
 
         // Action is always Idle
@@ -758,7 +797,10 @@ mod tests {
         let obs = obs_with_health(100.0, 100.0); // no visible entities
 
         let score = scorer.score(&obs);
-        assert_eq!(score, 0.0, "AttackScorer must score 0.0 when no hostiles visible");
+        assert_eq!(
+            score, 0.0,
+            "AttackScorer must score 0.0 when no hostiles visible"
+        );
     }
 
     // ── Test 3: AttackScorer scores high with a nearby hostile ─
@@ -844,7 +886,11 @@ mod tests {
         agent.observe(obs.clone());
         let actions = agent.decide();
 
-        assert_eq!(actions.len(), 1, "UtilityAgent must return exactly 1 action");
+        assert_eq!(
+            actions.len(),
+            1,
+            "UtilityAgent must return exactly 1 action"
+        );
 
         match &actions[0] {
             Action::AttackTarget { target } => {
@@ -859,7 +905,10 @@ mod tests {
 
         // last_scores should be populated after decide()
         let scores = agent.last_scores();
-        assert!(!scores.is_empty(), "last_scores should be populated after decide()");
+        assert!(
+            !scores.is_empty(),
+            "last_scores should be populated after decide()"
+        );
 
         // The winning scorer should be first (highest score)
         let best_score = scores[0].1;
@@ -881,19 +930,38 @@ mod tests {
         let balanced = UtilityProfile::balanced();
 
         // Check expected scorer counts
-        assert_eq!(aggressive.len(), 3, "Aggressive profile should have 3 scorers");
-        assert_eq!(defensive.len(), 4, "Defensive profile should have 4 scorers");
+        assert_eq!(
+            aggressive.len(),
+            3,
+            "Aggressive profile should have 3 scorers"
+        );
+        assert_eq!(
+            defensive.len(),
+            4,
+            "Defensive profile should have 4 scorers"
+        );
         assert_eq!(explorer.len(), 3, "Explorer profile should have 3 scorers");
         assert_eq!(balanced.len(), 5, "Balanced profile should have 5 scorers");
 
         // Each profile must contain at least an Idle scorer as safety net
-        let has_idle = |scorers: &[Box<dyn ActionScorer>]| {
-            scorers.iter().any(|s| s.name() == "Idle")
-        };
-        assert!(has_idle(&aggressive), "Aggressive profile must include Idle scorer");
-        assert!(has_idle(&defensive), "Defensive profile must include Idle scorer");
-        assert!(has_idle(&explorer), "Explorer profile must include Idle scorer");
-        assert!(has_idle(&balanced), "Balanced profile must include Idle scorer");
+        let has_idle =
+            |scorers: &[Box<dyn ActionScorer>]| scorers.iter().any(|s| s.name() == "Idle");
+        assert!(
+            has_idle(&aggressive),
+            "Aggressive profile must include Idle scorer"
+        );
+        assert!(
+            has_idle(&defensive),
+            "Defensive profile must include Idle scorer"
+        );
+        assert!(
+            has_idle(&explorer),
+            "Explorer profile must include Idle scorer"
+        );
+        assert!(
+            has_idle(&balanced),
+            "Balanced profile must include Idle scorer"
+        );
 
         // Each profile must produce valid UtilityAgents
         let _a = UtilityAgent::with_scorers(UtilityProfile::aggressive());
@@ -929,17 +997,25 @@ mod tests {
 
         let full_hp = obs_with_health(100.0, 100.0);
         let half_hp = obs_with_health(50.0, 100.0);
-        let low_hp  = obs_with_health(10.0, 100.0);
+        let low_hp = obs_with_health(10.0, 100.0);
 
         let s_full = scorer.score(&full_hp);
         let s_half = scorer.score(&half_hp);
-        let s_low  = scorer.score(&low_hp);
+        let s_low = scorer.score(&low_hp);
 
         assert_eq!(s_full, 0.0, "HealScorer must be 0 at full health");
-        assert!(s_half > 0.0,   "HealScorer must be > 0 at half health");
-        assert!(s_low  > s_half, "HealScorer must be higher at lower health (low={:.3}, half={:.3})", s_low, s_half);
-        assert!(s_low  <= 0.85,  "HealScorer must not exceed 0.85");
+        assert!(s_half > 0.0, "HealScorer must be > 0 at half health");
+        assert!(
+            s_low > s_half,
+            "HealScorer must be higher at lower health (low={:.3}, half={:.3})",
+            s_low,
+            s_half
+        );
+        assert!(s_low <= 0.85, "HealScorer must not exceed 0.85");
 
-        assert!(matches!(scorer.action(&half_hp), Action::UseItem { slot: 0 }));
+        assert!(matches!(
+            scorer.action(&half_hp),
+            Action::UseItem { slot: 0 }
+        ));
     }
 }

--- a/crates/pod-core/src/action.rs
+++ b/crates/pod-core/src/action.rs
@@ -1,6 +1,7 @@
+use crate::component::SkillKind;
+use crate::id::{AgentId, EntityId};
 use glam::Vec2;
 use serde::{Deserialize, Serialize};
-use crate::id::{AgentId, EntityId};
 
 /// Every action an agent can take in the game.
 /// This is the SAME action space for human and AI agents.
@@ -30,7 +31,23 @@ pub enum Action {
     /// Attack a specific entity
     AttackTarget { target: EntityId },
     /// Use ability by slot index
-    UseAbility { slot: u8, target: Option<AbilityTarget> },
+    UseAbility {
+        slot: u8,
+        target: Option<AbilityTarget>,
+    },
+    /// Capture a weakened wild creature into the companion roster.
+    CaptureCreature {
+        target: EntityId,
+        tool_slot: Option<u8>,
+    },
+    /// Summon a companion from the roster into the active slot.
+    SummonCompanion { slot: u8 },
+    /// Issue a direct order to a companion in the roster.
+    CommandCompanion {
+        slot: u8,
+        command: CompanionCommand,
+        target: Option<EntityId>,
+    },
 
     // === INTERACTION ===
     /// Interact with nearest interactable
@@ -43,18 +60,35 @@ pub enum Action {
     Drop { slot: u8 },
     /// Use an item from inventory
     UseItem { slot: u8 },
+    /// Gather from a resource node using the specified skill.
+    GatherResource { target: EntityId, skill: SkillKind },
+    /// Claim a loot container or dropped bundle.
+    Loot { target: EntityId },
 
     // === COMMUNICATION ===
     /// Send a message (visible to agents in hearing range)
-    Speak { message: String, volume: SpeakVolume },
+    Speak {
+        message: String,
+        volume: SpeakVolume,
+    },
     /// Send a signal (game-specific, e.g. ping, emote)
     Signal { signal_type: String, data: String },
+    /// Toggle RuneScape-style auto retaliation on or off.
+    SetAutoRetaliate { enabled: bool },
 
     // === META ===
     /// Do nothing this tick (explicit no-op)
     Idle,
     /// Spawn request (only valid for system agents)
     Spawn { prefab: String, position: Vec2 },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CompanionCommand {
+    Attack,
+    Follow,
+    Guard,
+    Recall,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -66,9 +100,9 @@ pub enum AbilityTarget {
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum SpeakVolume {
-    Whisper,  // short range
-    Normal,   // medium range
-    Shout,    // long range
+    Whisper, // short range
+    Normal,  // medium range
+    Shout,   // long range
 }
 
 impl SpeakVolume {
@@ -195,9 +229,43 @@ fn validate_action_payload(action: &Action) -> Option<String> {
             }
             None
         }
+        Action::SummonCompanion { slot } => {
+            if *slot >= 6 {
+                return Some("Companion slot out of range".into());
+            }
+            None
+        }
+        Action::CommandCompanion { slot, target, .. } => {
+            if *slot >= 6 {
+                return Some("Companion slot out of range".into());
+            }
+            if let Some(target) = target {
+                if target.0 == 0 {
+                    return Some("Companion target entity id must be non-zero".into());
+                }
+            }
+            None
+        }
         Action::Drop { slot } | Action::UseItem { slot } => {
             if *slot >= 8 {
                 return Some("Inventory slot out of range".into());
+            }
+            None
+        }
+        Action::CaptureCreature { target, tool_slot } => {
+            if target.0 == 0 {
+                return Some("Capture target entity id must be non-zero".into());
+            }
+            if let Some(slot) = tool_slot {
+                if *slot >= 28 {
+                    return Some("Capture tool slot out of range".into());
+                }
+            }
+            None
+        }
+        Action::GatherResource { target, .. } | Action::Loot { target } => {
+            if target.0 == 0 {
+                return Some("Target entity id must be non-zero".into());
             }
             None
         }
@@ -209,13 +277,17 @@ fn validate_action_payload(action: &Action) -> Option<String> {
             }
             None
         }
-        Action::Stop | Action::Attack | Action::Interact | Action::Idle => None,
+        Action::Stop
+        | Action::Attack
+        | Action::Interact
+        | Action::Idle
+        | Action::SetAutoRetaliate { .. } => None,
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{validate_action, AgentAction, Action, AgentConstraints};
+    use super::{validate_action, Action, AgentAction, AgentConstraints};
     use crate::id::AgentId;
 
     fn action(agent_id: u64, action: Action) -> AgentAction {
@@ -244,10 +316,13 @@ mod tests {
     #[test]
     fn validate_action_rejects_too_fast_speak() {
         let constraints = AgentConstraints::default();
-        let invalid = action(1, Action::Speak {
-            message: "x".repeat(1024),
-            volume: crate::action::SpeakVolume::Normal,
-        });
+        let invalid = action(
+            1,
+            Action::Speak {
+                message: "x".repeat(1024),
+                volume: crate::action::SpeakVolume::Normal,
+            },
+        );
         assert!(matches!(
             validate_action(&invalid, &constraints, 1),
             super::ActionResult::Rejected(_)
@@ -257,10 +332,13 @@ mod tests {
     #[test]
     fn validate_action_rejects_empty_signal_type() {
         let constraints = AgentConstraints::default();
-        let invalid = action(1, Action::Signal {
-            signal_type: String::new(),
-            data: String::from("ok"),
-        });
+        let invalid = action(
+            1,
+            Action::Signal {
+                signal_type: String::new(),
+                data: String::from("ok"),
+            },
+        );
         assert!(matches!(
             validate_action(&invalid, &constraints, 1),
             super::ActionResult::Rejected(_)
@@ -284,6 +362,32 @@ mod tests {
             1,
             Action::AttackTarget {
                 target: crate::id::EntityId(0),
+            },
+        );
+        assert!(matches!(
+            validate_action(&invalid, &constraints, 1),
+            super::ActionResult::Rejected(_)
+        ));
+    }
+
+    #[test]
+    fn validate_action_rejects_invalid_companion_slot() {
+        let constraints = AgentConstraints::default();
+        let invalid = action(1, Action::SummonCompanion { slot: 9 });
+        assert!(matches!(
+            validate_action(&invalid, &constraints, 1),
+            super::ActionResult::Rejected(_)
+        ));
+    }
+
+    #[test]
+    fn validate_action_rejects_invalid_capture_tool_slot() {
+        let constraints = AgentConstraints::default();
+        let invalid = action(
+            1,
+            Action::CaptureCreature {
+                target: crate::id::EntityId(4),
+                tool_slot: Some(30),
             },
         );
         assert!(matches!(

--- a/crates/pod-core/src/app.rs
+++ b/crates/pod-core/src/app.rs
@@ -4,8 +4,8 @@ use std::collections::HashMap;
 use crate::action::AgentAction;
 use crate::component::{
     AgentControlled, ColorRect, CombatLoadout, CompanionRoster, CreatureIdentity, EncounterState,
-    Health, Inventory, Label, Movement, Perception, Script, SkillBook, Sprite, Transform,
-    Transform3D, Velocity,
+    Health, Inventory, Label, LootContainer, Movement, Perception, ResourceNode, Script, SkillBook,
+    Sprite, Transform, Transform3D, Velocity,
 };
 use crate::contract::{VersionedAgentAction, VersionedObservation};
 use crate::observation::Observation;
@@ -294,6 +294,10 @@ impl App {
             .register_component::<CreatureIdentity>("CreatureIdentity");
         self.types
             .register_component::<EncounterState>("EncounterState");
+        self.types
+            .register_component::<ResourceNode>("ResourceNode");
+        self.types
+            .register_component::<LootContainer>("LootContainer");
         self.types.register_contract::<Observation>("Observation");
         self.types.register_contract::<AgentAction>("AgentAction");
         self.types

--- a/crates/pod-core/src/component.rs
+++ b/crates/pod-core/src/component.rs
@@ -621,6 +621,53 @@ impl Default for Inventory {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ResourceNode {
+    pub skill: SkillKind,
+    pub tier: u8,
+    pub remaining_uses: u32,
+    pub respawn_ticks: u32,
+    pub experience: u32,
+    pub yield_item: ItemStack,
+}
+
+impl Default for ResourceNode {
+    fn default() -> Self {
+        Self {
+            skill: SkillKind::Mining,
+            tier: 1,
+            remaining_uses: 1,
+            respawn_ticks: 300,
+            experience: 25,
+            yield_item: ItemStack {
+                item_id: "copper-ore".to_string(),
+                display_name: "Copper Ore".to_string(),
+                quantity: 1,
+                stackable: true,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LootContainer {
+    pub coins: u64,
+    pub items: Vec<ItemStack>,
+    pub owner: Option<EntityId>,
+    pub claimed: bool,
+}
+
+impl Default for LootContainer {
+    fn default() -> Self {
+        Self {
+            coins: 0,
+            items: Vec::new(),
+            owner: None,
+            claimed: false,
+        }
+    }
+}
+
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum CreatureTemperament {
     Aggressive,

--- a/crates/pod-core/src/event.rs
+++ b/crates/pod-core/src/event.rs
@@ -52,6 +52,12 @@ pub enum Event {
         agent_id: AgentId,
         species_id: String,
     },
+    CompanionCommandIssued {
+        agent_id: AgentId,
+        slot: u8,
+        command: String,
+        target: Option<EntityId>,
+    },
     EncounterStarted {
         encounter_id: u64,
         kind: String,
@@ -59,6 +65,23 @@ pub enum Event {
     EncounterEnded {
         encounter_id: u64,
         victory: bool,
+    },
+    ResourceGathered {
+        entity: EntityId,
+        resource: EntityId,
+        skill: String,
+        item_id: String,
+        quantity: u32,
+    },
+    LootClaimed {
+        entity: EntityId,
+        source: EntityId,
+        coins: u64,
+        item_count: usize,
+    },
+    AutoRetaliateSet {
+        entity: EntityId,
+        enabled: bool,
     },
 
     // === PHYSICS ===

--- a/crates/pod-core/src/tick.rs
+++ b/crates/pod-core/src/tick.rs
@@ -1,4 +1,4 @@
-use crate::action::{validate_action, Action, ActionResult, AgentAction};
+use crate::action::{validate_action, Action, ActionResult, AgentAction, CompanionCommand};
 use crate::agent::AgentSlot;
 use crate::component::*;
 use crate::event::{Event, EventBus};
@@ -314,12 +314,18 @@ fn build_observations(
                 "LookAt",
                 "Attack",
                 "UseAbility",
+                "CaptureCreature",
+                "SummonCompanion",
+                "CommandCompanion",
                 "Interact",
                 "Pickup",
                 "Drop",
                 "UseItem",
+                "GatherResource",
+                "Loot",
                 "Speak",
                 "Signal",
+                "SetAutoRetaliate",
                 "Idle",
             ]
             .into_iter()
@@ -437,6 +443,7 @@ fn execute_action(
     };
 
     let mut set_attack_cooldown = false;
+    let attack_range = attack_range_for(ecs, entity);
 
     match &agent_action.action {
         Action::Move { direction } => {
@@ -466,7 +473,7 @@ fn execute_action(
                 return;
             }
 
-            if let Some(target_entity) = select_attack_target(ecs, entity, None) {
+            if let Some(target_entity) = select_attack_target(ecs, entity, None, attack_range) {
                 let applied = apply_attack(
                     ecs,
                     agents,
@@ -486,7 +493,7 @@ fn execute_action(
             }
 
             if let Some(target_entity) = find_entity_by_id(ecs, target.0) {
-                if target_entity != entity && in_range(ecs, entity, target_entity, ATTACK_RANGE) {
+                if target_entity != entity && in_range(ecs, entity, target_entity, attack_range) {
                     let applied = apply_attack(
                         ecs,
                         agents,
@@ -500,6 +507,37 @@ fn execute_action(
                     }
                 }
             }
+        }
+        Action::CaptureCreature { target, tool_slot } => {
+            if let Some(target_entity) = find_entity_by_id(ecs, target.0) {
+                let _ = capture_creature(
+                    ecs,
+                    events,
+                    entity,
+                    target_entity,
+                    agent_action.agent_id,
+                    *tool_slot,
+                );
+            }
+        }
+        Action::SummonCompanion { slot } => {
+            summon_companion(ecs, events, entity, agent_action.agent_id, *slot);
+        }
+        Action::CommandCompanion {
+            slot,
+            command,
+            target,
+        } => {
+            command_companion(
+                ecs,
+                agents,
+                events,
+                entity,
+                agent_action.agent_id,
+                *slot,
+                *command,
+                *target,
+            );
         }
         Action::Speak { message, volume } => {
             if let Ok(transform) = ecs.get::<&Transform>(entity) {
@@ -548,6 +586,30 @@ fn execute_action(
                 }
             }
         }
+        Action::GatherResource { target, skill } => {
+            if let Some(target_entity) = find_entity_by_id(ecs, target.0) {
+                let _ = gather_resource(ecs, events, entity, target_entity, *skill);
+            }
+        }
+        Action::Loot { target } => {
+            if let Some(target_entity) = find_entity_by_id(ecs, target.0) {
+                let _ = loot_container(ecs, events, entity, target_entity);
+            }
+        }
+        Action::SetAutoRetaliate { enabled } => {
+            if let Ok(mut loadout) = ecs.get::<&mut CombatLoadout>(entity) {
+                loadout.auto_retaliate = *enabled;
+                if let Ok(transform) = ecs.get::<&Transform>(entity) {
+                    events.emit(
+                        transform.position,
+                        Event::AutoRetaliateSet {
+                            entity: EntityId(entity.id() as u64),
+                            enabled: *enabled,
+                        },
+                    );
+                }
+            }
+        }
         Action::Idle => {}
         _ => {
             log::debug!("Unhandled action: {:?}", agent_action.action);
@@ -555,19 +617,44 @@ fn execute_action(
     }
 
     if set_attack_cooldown {
-        let duration = agents[actor_slot_index].agent.constraints().attack_cooldown;
+        let duration = attack_cooldown_for(
+            ecs,
+            entity,
+            agents[actor_slot_index].agent.constraints().attack_cooldown,
+        );
         agents[actor_slot_index].attack_cooldown_remaining = duration;
     }
 }
 
 const ATTACK_RANGE: f32 = 80.0;
 const INTERACT_RANGE: f32 = 50.0;
+const CAPTURE_RANGE: f32 = 60.0;
+const COMPANION_COMMAND_RANGE: f32 = 160.0;
+const CAPTURE_HEALTH_THRESHOLD: f32 = 0.35;
 const BASE_ATTACK_DAMAGE: f32 = 10.0;
 
 fn find_entity_by_id(ecs: &hecs::World, target_id: u64) -> Option<hecs::Entity> {
     ecs.query::<()>()
         .iter()
         .find_map(|(entity, _)| (entity.id() as u64 == target_id).then_some(entity))
+}
+
+fn attack_range_for(ecs: &hecs::World, entity: hecs::Entity) -> f32 {
+    ecs.get::<&CombatLoadout>(entity)
+        .map(|loadout| loadout.attack_range.max(1.0))
+        .unwrap_or(ATTACK_RANGE)
+}
+
+fn attack_cooldown_for(ecs: &hecs::World, entity: hecs::Entity, fallback: u32) -> u32 {
+    ecs.get::<&CombatLoadout>(entity)
+        .map(|loadout| loadout.attack_speed_ticks.max(1))
+        .unwrap_or(fallback.max(1))
+}
+
+fn attack_damage_for(ecs: &hecs::World, entity: hecs::Entity) -> f32 {
+    ecs.get::<&CombatLoadout>(entity)
+        .map(|loadout| loadout.max_hit.max(1.0))
+        .unwrap_or(BASE_ATTACK_DAMAGE)
 }
 
 fn in_range(ecs: &hecs::World, source: hecs::Entity, target: hecs::Entity, range: f32) -> bool {
@@ -603,10 +690,11 @@ fn select_attack_target(
     ecs: &hecs::World,
     source: hecs::Entity,
     explicit_target: Option<hecs::Entity>,
+    attack_range: f32,
 ) -> Option<hecs::Entity> {
     if let Some(target) = explicit_target {
         if target != source
-            && in_range(ecs, source, target, ATTACK_RANGE)
+            && in_range(ecs, source, target, attack_range)
             && is_hostile_target(ecs, source, target)
         {
             return Some(target);
@@ -623,7 +711,7 @@ fn select_attack_target(
                 return None;
             }
             let distance = source_pos.distance(transform.position);
-            if distance > ATTACK_RANGE || !is_hostile_target(ecs, source, entity) {
+            if distance > attack_range || !is_hostile_target(ecs, source, entity) {
                 return None;
             }
             Some((entity, distance))
@@ -638,6 +726,99 @@ fn select_attack_target(
     });
 
     candidates.first().map(|(entity, _)| *entity)
+}
+
+fn add_item_to_inventory(inventory: &mut Inventory, item: ItemStack) -> bool {
+    if item.stackable {
+        if let Some(existing) = inventory
+            .items
+            .iter_mut()
+            .find(|existing| existing.item_id == item.item_id)
+        {
+            existing.quantity = existing.quantity.saturating_add(item.quantity);
+            return true;
+        }
+    }
+
+    if inventory.items.len() >= inventory.capacity as usize {
+        return false;
+    }
+
+    inventory.items.push(item);
+    true
+}
+
+fn consume_inventory_slot(inventory: &mut Inventory, slot: u8) -> bool {
+    let index = slot as usize;
+    if index >= inventory.items.len() {
+        return false;
+    }
+
+    let item = &mut inventory.items[index];
+    if item.quantity == 0 {
+        return false;
+    }
+
+    if item.stackable && item.quantity > 1 {
+        item.quantity -= 1;
+    } else {
+        inventory.items.remove(index);
+    }
+
+    true
+}
+
+fn next_level_xp(level: u16) -> u32 {
+    83 + u32::from(level.saturating_sub(1)) * 97
+}
+
+fn recompute_skillbook_totals(skill_book: &mut SkillBook) {
+    skill_book.total_level = skill_book.skills.iter().map(|skill| skill.level).sum();
+
+    let combat_skills = [
+        SkillKind::Attack,
+        SkillKind::Strength,
+        SkillKind::Defence,
+        SkillKind::Ranged,
+        SkillKind::Magic,
+        SkillKind::Constitution,
+    ];
+    let combat_sum: u32 = skill_book
+        .skills
+        .iter()
+        .filter(|skill| combat_skills.contains(&skill.kind))
+        .map(|skill| u32::from(skill.level))
+        .sum();
+    skill_book.combat_level = (combat_sum / combat_skills.len() as u32).max(3) as u16;
+}
+
+fn award_skill_experience(
+    skill_book: &mut SkillBook,
+    skill: SkillKind,
+    amount: u32,
+) -> Option<u16> {
+    let progress_index = skill_book
+        .skills
+        .iter()
+        .position(|entry| entry.kind == skill)?;
+    let mut level_changed = false;
+
+    let new_level = {
+        let progress = &mut skill_book.skills[progress_index];
+        progress.experience = progress.experience.saturating_add(amount);
+
+        while progress.experience >= progress.xp_to_next_level {
+            progress.experience -= progress.xp_to_next_level;
+            progress.level = progress.level.saturating_add(1);
+            progress.xp_to_next_level = next_level_xp(progress.level);
+            level_changed = true;
+        }
+
+        level_changed.then_some(progress.level)
+    };
+
+    recompute_skillbook_totals(skill_book);
+    new_level
 }
 
 fn select_interaction_target(
@@ -671,6 +852,376 @@ fn select_interaction_target(
     candidates.first().map(|(entity, _)| *entity)
 }
 
+fn summon_companion(
+    ecs: &mut hecs::World,
+    events: &mut EventBus,
+    entity: hecs::Entity,
+    agent_id: crate::id::AgentId,
+    slot: u8,
+) -> bool {
+    let Some(companion) = ecs
+        .get::<&CompanionRoster>(entity)
+        .ok()
+        .and_then(|roster| roster.creatures.get(slot as usize).cloned())
+    else {
+        return false;
+    };
+
+    if let Ok(mut roster) = ecs.get::<&mut CompanionRoster>(entity) {
+        roster.active_slot = Some(slot);
+    } else {
+        return false;
+    }
+
+    if let Ok(transform) = ecs.get::<&Transform>(entity) {
+        events.emit(
+            transform.position,
+            Event::CompanionSummoned {
+                agent_id,
+                species_id: companion.creature.species_id,
+            },
+        );
+    }
+
+    true
+}
+
+fn command_companion(
+    ecs: &mut hecs::World,
+    agents: &mut [AgentSlot],
+    events: &mut EventBus,
+    entity: hecs::Entity,
+    agent_id: crate::id::AgentId,
+    slot: u8,
+    command: CompanionCommand,
+    target: Option<EntityId>,
+) -> bool {
+    let Some(companion) = ecs
+        .get::<&CompanionRoster>(entity)
+        .ok()
+        .and_then(|roster| roster.creatures.get(slot as usize).cloned())
+    else {
+        return false;
+    };
+
+    if let Ok(mut roster) = ecs.get::<&mut CompanionRoster>(entity) {
+        roster.active_slot = match command {
+            CompanionCommand::Recall => None,
+            _ => Some(slot),
+        };
+    } else {
+        return false;
+    }
+
+    let entity_id = EntityId(entity.id() as u64);
+    let origin = ecs
+        .get::<&Transform>(entity)
+        .map(|transform| transform.position)
+        .unwrap_or(Vec2::ZERO);
+    events.emit(
+        origin,
+        Event::CompanionCommandIssued {
+            agent_id,
+            slot,
+            command: format!("{command:?}"),
+            target,
+        },
+    );
+
+    if matches!(command, CompanionCommand::Attack) {
+        let Some(target_id) = target else {
+            return true;
+        };
+        let Some(target_entity) = find_entity_by_id(ecs, target_id.0) else {
+            return false;
+        };
+        if !in_range(ecs, entity, target_entity, COMPANION_COMMAND_RANGE) {
+            return false;
+        }
+
+        let companion_damage = f32::from(companion.creature.level).max(4.0);
+        let _ = apply_damage_from_source(
+            ecs,
+            agents,
+            events,
+            entity,
+            target_entity,
+            agent_id,
+            companion_damage,
+            "companion_attack",
+        );
+    } else if matches!(command, CompanionCommand::Recall) {
+        events.emit(
+            origin,
+            Event::EncounterEnded {
+                encounter_id: 0,
+                victory: false,
+            },
+        );
+    }
+
+    let _ = entity_id;
+    true
+}
+
+fn capture_creature(
+    ecs: &mut hecs::World,
+    events: &mut EventBus,
+    entity: hecs::Entity,
+    target_entity: hecs::Entity,
+    agent_id: crate::id::AgentId,
+    tool_slot: Option<u8>,
+) -> bool {
+    if !in_range(ecs, entity, target_entity, CAPTURE_RANGE) {
+        return false;
+    }
+
+    let Some(creature) = ecs
+        .get::<&CreatureIdentity>(target_entity)
+        .ok()
+        .map(|creature| (*creature).clone())
+    else {
+        return false;
+    };
+    if !creature.is_wild {
+        return false;
+    }
+
+    let target_health_fraction = ecs
+        .get::<&Health>(target_entity)
+        .map(|health| health.current / health.max.max(1.0))
+        .unwrap_or(1.0);
+    if target_health_fraction > CAPTURE_HEALTH_THRESHOLD {
+        return false;
+    }
+
+    let capture_allowed = ecs
+        .get::<&EncounterState>(entity)
+        .map(|encounter| encounter.capture_allowed)
+        .unwrap_or(true);
+    if !capture_allowed {
+        return false;
+    }
+
+    if let Some(slot) = tool_slot {
+        let Ok(mut inventory) = ecs.get::<&mut Inventory>(entity) else {
+            return false;
+        };
+        if !consume_inventory_slot(&mut inventory, slot) {
+            return false;
+        }
+    }
+
+    let current_max_health = ecs
+        .get::<&Health>(target_entity)
+        .map(|health| health.max)
+        .unwrap_or(10.0);
+    let current_health = ecs
+        .get::<&Health>(target_entity)
+        .map(|health| health.current.max(1.0))
+        .unwrap_or(current_max_health);
+    let combat_style = ecs
+        .get::<&CombatLoadout>(target_entity)
+        .map(|loadout| loadout.style)
+        .unwrap_or(CombatStyle::Summoning);
+    let captured = CompanionCreature {
+        creature: creature.clone(),
+        nickname: None,
+        current_health,
+        max_health: current_max_health,
+        combat_style,
+        mood: 1.0,
+    };
+
+    let next_slot = {
+        let Ok(mut roster) = ecs.get::<&mut CompanionRoster>(entity) else {
+            return false;
+        };
+        if roster.creatures.len() >= roster.party_capacity as usize {
+            return false;
+        }
+        let slot = roster.creatures.len() as u8;
+        roster.creatures.push(captured);
+        roster.active_slot.get_or_insert(slot);
+        slot
+    };
+
+    if let Ok(mut encounter) = ecs.get::<&mut EncounterState>(entity) {
+        encounter.capture_allowed = false;
+        encounter.in_combat = false;
+    }
+
+    let origin = ecs
+        .get::<&Transform>(entity)
+        .map(|transform| transform.position)
+        .unwrap_or(Vec2::ZERO);
+    let encounter_id = ecs
+        .get::<&EncounterState>(entity)
+        .map(|encounter| encounter.encounter_id)
+        .unwrap_or(0);
+    let species_id = creature.species_id.clone();
+    events.emit(
+        origin,
+        Event::CreatureCaptured {
+            agent_id,
+            species_id: species_id.clone(),
+            nickname: None,
+        },
+    );
+    events.emit(
+        origin,
+        Event::CompanionSummoned {
+            agent_id,
+            species_id: species_id.clone(),
+        },
+    );
+    if encounter_id != 0 {
+        events.emit(
+            origin,
+            Event::EncounterEnded {
+                encounter_id,
+                victory: true,
+            },
+        );
+    }
+
+    let _ = next_slot;
+    ecs.despawn(target_entity).is_ok()
+}
+
+fn gather_resource(
+    ecs: &mut hecs::World,
+    events: &mut EventBus,
+    entity: hecs::Entity,
+    target_entity: hecs::Entity,
+    skill: SkillKind,
+) -> bool {
+    if !in_range(ecs, entity, target_entity, INTERACT_RANGE) {
+        return false;
+    }
+
+    let Some(resource) = ecs
+        .get::<&ResourceNode>(target_entity)
+        .ok()
+        .map(|resource| (*resource).clone())
+    else {
+        return false;
+    };
+    if resource.skill != skill || resource.remaining_uses == 0 {
+        return false;
+    }
+
+    let Ok(mut inventory) = ecs.get::<&mut Inventory>(entity) else {
+        return false;
+    };
+    if !add_item_to_inventory(&mut inventory, resource.yield_item.clone()) {
+        return false;
+    }
+
+    if let Ok(mut node) = ecs.get::<&mut ResourceNode>(target_entity) {
+        node.remaining_uses = node.remaining_uses.saturating_sub(1);
+    }
+
+    let new_level = if let Ok(mut skill_book) = ecs.get::<&mut SkillBook>(entity) {
+        let level = award_skill_experience(&mut skill_book, skill, resource.experience)
+            .or_else(|| {
+                skill_book
+                    .skills
+                    .iter()
+                    .find(|entry| entry.kind == skill)
+                    .map(|entry| entry.level)
+            })
+            .unwrap_or(1);
+        Some(level)
+    } else {
+        None
+    };
+
+    let origin = ecs
+        .get::<&Transform>(entity)
+        .map(|transform| transform.position)
+        .unwrap_or(Vec2::ZERO);
+    events.emit(
+        origin,
+        Event::ResourceGathered {
+            entity: EntityId(entity.id() as u64),
+            resource: EntityId(target_entity.id() as u64),
+            skill: format!("{skill:?}"),
+            item_id: resource.yield_item.item_id.clone(),
+            quantity: resource.yield_item.quantity,
+        },
+    );
+    if let Some(level) = new_level {
+        events.emit(
+            origin,
+            Event::SkillXpGained {
+                entity: EntityId(entity.id() as u64),
+                skill: format!("{skill:?}"),
+                amount: resource.experience,
+                new_level: level,
+            },
+        );
+    }
+
+    true
+}
+
+fn loot_container(
+    ecs: &mut hecs::World,
+    events: &mut EventBus,
+    entity: hecs::Entity,
+    target_entity: hecs::Entity,
+) -> bool {
+    if !in_range(ecs, entity, target_entity, INTERACT_RANGE) {
+        return false;
+    }
+
+    let Some(loot) = ecs
+        .get::<&LootContainer>(target_entity)
+        .ok()
+        .map(|loot| (*loot).clone())
+    else {
+        return false;
+    };
+    if loot.claimed {
+        return false;
+    }
+
+    let Ok(mut inventory) = ecs.get::<&mut Inventory>(entity) else {
+        return false;
+    };
+    let mut preview = (*inventory).clone();
+    for item in loot.items.iter().cloned() {
+        if !add_item_to_inventory(&mut preview, item) {
+            return false;
+        }
+    }
+    preview.coins = preview.coins.saturating_add(loot.coins);
+    *inventory = preview;
+
+    if let Ok(mut loot_container) = ecs.get::<&mut LootContainer>(target_entity) {
+        loot_container.claimed = true;
+        loot_container.items.clear();
+        loot_container.coins = 0;
+    }
+
+    let origin = ecs
+        .get::<&Transform>(entity)
+        .map(|transform| transform.position)
+        .unwrap_or(Vec2::ZERO);
+    events.emit(
+        origin,
+        Event::LootClaimed {
+            entity: EntityId(entity.id() as u64),
+            source: EntityId(target_entity.id() as u64),
+            coins: loot.coins,
+            item_count: loot.items.len(),
+        },
+    );
+
+    true
+}
+
 fn apply_attack(
     ecs: &mut hecs::World,
     agents: &mut [AgentSlot],
@@ -678,6 +1229,29 @@ fn apply_attack(
     attacker_entity: hecs::Entity,
     target_entity: hecs::Entity,
     attacker_agent_id: crate::id::AgentId,
+) -> f32 {
+    let damage = attack_damage_for(ecs, attacker_entity);
+    apply_damage_from_source(
+        ecs,
+        agents,
+        events,
+        attacker_entity,
+        target_entity,
+        attacker_agent_id,
+        damage,
+        "attack",
+    )
+}
+
+fn apply_damage_from_source(
+    ecs: &mut hecs::World,
+    agents: &mut [AgentSlot],
+    events: &mut EventBus,
+    attacker_entity: hecs::Entity,
+    target_entity: hecs::Entity,
+    attacker_agent_id: crate::id::AgentId,
+    damage: f32,
+    sound_name: &str,
 ) -> f32 {
     let attacker_pos = ecs
         .get::<&Transform>(attacker_entity)
@@ -689,7 +1263,7 @@ fn apply_attack(
     events.emit(
         attacker_pos,
         Event::Sound {
-            name: "attack".into(),
+            name: sound_name.into(),
             intensity: 1.0,
         },
     );
@@ -703,7 +1277,7 @@ fn apply_attack(
     let mut target_dead = false;
 
     if let Ok(mut health) = ecs.get::<&mut Health>(target_entity) {
-        applied_damage = health.damage(BASE_ATTACK_DAMAGE);
+        applied_damage = health.damage(damage);
         target_dead = health.is_dead();
     }
 
@@ -1334,5 +1908,530 @@ mod tests {
                 .species_name,
             "Moss Turtle"
         );
+    }
+
+    #[test]
+    fn attack_target_uses_combat_loadout_damage_range_and_cooldown() {
+        let mut ecs = hecs::World::new();
+        let attacker_entity = spawn_actor(
+            &mut ecs,
+            Vec2::new(0.0, 0.0),
+            Team::Team(1),
+            Health::new(100.0),
+        );
+        let target_entity = spawn_actor(
+            &mut ecs,
+            Vec2::new(140.0, 0.0),
+            Team::Team(2),
+            Health::new(100.0),
+        );
+        ecs.insert(
+            attacker_entity,
+            (CombatLoadout {
+                style: CombatStyle::Ranged,
+                attack_range: 180.0,
+                attack_speed_ticks: 42,
+                max_hit: 17.0,
+                auto_retaliate: true,
+                equipped_weapon: Some("oak-shortbow".to_string()),
+                offhand_item: None,
+                active_ability_bar: vec!["rapid-shot".to_string()],
+            },),
+        )
+        .unwrap();
+
+        let target_id = EntityId(target_entity.id() as u64);
+        let obs_store = Arc::new(Mutex::new(Vec::new()));
+        let (agent, agent_id) = RecordingAgent::new(vec![], obs_store);
+        let mut slot = AgentSlot::new(Box::new(agent));
+        slot.entity_id = Some(attacker_entity);
+        let mut agents = vec![slot];
+        let mut events = EventBus::new();
+        let mut next_entity_id = 1;
+
+        let result = execute_tick(
+            &mut ecs,
+            &mut agents,
+            &mut events,
+            1,
+            vec![AgentAction {
+                agent_id,
+                tick: 1,
+                action: Action::AttackTarget { target: target_id },
+            }],
+            &mut next_entity_id,
+        );
+
+        let target_health = ecs.get::<&Health>(target_entity).unwrap();
+        assert_eq!(target_health.current, 83.0);
+        assert_eq!(agents[0].attack_cooldown_remaining, 42);
+        assert!(result.events.iter().any(|event| matches!(
+            event.event,
+            Event::Damage {
+                target,
+                amount,
+                ..
+            } if target == target_id && (amount - 17.0).abs() < f32::EPSILON
+        )));
+    }
+
+    #[test]
+    fn capture_creature_consumes_tool_and_adds_companion() {
+        let mut ecs = hecs::World::new();
+        let player_entity = spawn_actor(
+            &mut ecs,
+            Vec2::new(0.0, 0.0),
+            Team::Team(1),
+            Health::new(100.0),
+        );
+        let wild_entity = spawn_actor(
+            &mut ecs,
+            Vec2::new(12.0, 0.0),
+            Team::None,
+            Health {
+                current: 6.0,
+                max: 30.0,
+                armor: 0.0,
+                invulnerable: false,
+            },
+        );
+        ecs.insert(
+            player_entity,
+            (
+                Inventory {
+                    capacity: 28,
+                    carried_weight: 0.0,
+                    coins: 0,
+                    items: vec![ItemStack {
+                        item_id: "capture-orb".to_string(),
+                        display_name: "Capture Orb".to_string(),
+                        quantity: 2,
+                        stackable: true,
+                    }],
+                },
+                CompanionRoster::default(),
+                EncounterState {
+                    encounter_id: 7,
+                    kind: EncounterKind::WildCreature,
+                    threat_level: 0.4,
+                    primary_target: Some(EntityId(wild_entity.id() as u64)),
+                    active_turn_owner: Some(EntityId(player_entity.id() as u64)),
+                    capture_allowed: true,
+                    in_combat: true,
+                },
+            ),
+        )
+        .unwrap();
+        ecs.insert(
+            wild_entity,
+            (
+                CreatureIdentity {
+                    species_id: "spark-mouse".to_string(),
+                    species_name: "Spark Mouse".to_string(),
+                    elemental_affinity: "storm".to_string(),
+                    level: 5,
+                    temperament: CreatureTemperament::Timid,
+                    capture_difficulty: 0.25,
+                    is_wild: true,
+                },
+                CombatLoadout {
+                    style: CombatStyle::Summoning,
+                    ..CombatLoadout::default()
+                },
+            ),
+        )
+        .unwrap();
+
+        let obs_store = Arc::new(Mutex::new(Vec::new()));
+        let (agent, agent_id) = RecordingAgent::new(vec![], obs_store);
+        let mut slot = AgentSlot::new(Box::new(agent));
+        slot.entity_id = Some(player_entity);
+        let mut agents = vec![slot];
+        let mut events = EventBus::new();
+        let mut next_entity_id = 1;
+
+        let result = execute_tick(
+            &mut ecs,
+            &mut agents,
+            &mut events,
+            1,
+            vec![AgentAction {
+                agent_id,
+                tick: 1,
+                action: Action::CaptureCreature {
+                    target: EntityId(wild_entity.id() as u64),
+                    tool_slot: Some(0),
+                },
+            }],
+            &mut next_entity_id,
+        );
+
+        let roster = ecs.get::<&CompanionRoster>(player_entity).unwrap();
+        assert_eq!(roster.active_slot, Some(0));
+        assert_eq!(roster.creatures.len(), 1);
+        assert_eq!(roster.creatures[0].creature.species_id, "spark-mouse");
+        let inventory = ecs.get::<&Inventory>(player_entity).unwrap();
+        assert_eq!(inventory.items[0].quantity, 1);
+        let encounter = ecs.get::<&EncounterState>(player_entity).unwrap();
+        assert!(!encounter.capture_allowed);
+        assert!(!encounter.in_combat);
+        assert!(ecs.get::<&Transform>(wild_entity).is_err());
+        assert!(result.events.iter().any(|event| matches!(
+            &event.event,
+            Event::CreatureCaptured { species_id, .. } if species_id == "spark-mouse"
+        )));
+    }
+
+    #[test]
+    fn summon_companion_sets_active_slot_and_emits_event() {
+        let mut ecs = hecs::World::new();
+        let player_entity = spawn_actor(
+            &mut ecs,
+            Vec2::new(0.0, 0.0),
+            Team::Team(1),
+            Health::new(100.0),
+        );
+        ecs.insert(
+            player_entity,
+            (CompanionRoster {
+                active_slot: None,
+                party_capacity: 6,
+                creatures: vec![CompanionCreature {
+                    creature: CreatureIdentity {
+                        species_id: "ember-fox".to_string(),
+                        species_name: "Ember Fox".to_string(),
+                        elemental_affinity: "fire".to_string(),
+                        level: 9,
+                        temperament: CreatureTemperament::Loyal,
+                        capture_difficulty: 0.2,
+                        is_wild: false,
+                    },
+                    nickname: Some("Cinder".to_string()),
+                    current_health: 20.0,
+                    max_health: 20.0,
+                    combat_style: CombatStyle::Summoning,
+                    mood: 1.0,
+                }],
+            },),
+        )
+        .unwrap();
+
+        let obs_store = Arc::new(Mutex::new(Vec::new()));
+        let (agent, agent_id) = RecordingAgent::new(vec![], obs_store);
+        let mut slot = AgentSlot::new(Box::new(agent));
+        slot.entity_id = Some(player_entity);
+        let mut agents = vec![slot];
+        let mut events = EventBus::new();
+        let mut next_entity_id = 1;
+
+        let result = execute_tick(
+            &mut ecs,
+            &mut agents,
+            &mut events,
+            1,
+            vec![AgentAction {
+                agent_id,
+                tick: 1,
+                action: Action::SummonCompanion { slot: 0 },
+            }],
+            &mut next_entity_id,
+        );
+
+        let roster = ecs.get::<&CompanionRoster>(player_entity).unwrap();
+        assert_eq!(roster.active_slot, Some(0));
+        assert!(result.events.iter().any(|event| matches!(
+            &event.event,
+            Event::CompanionSummoned { species_id, .. } if species_id == "ember-fox"
+        )));
+    }
+
+    #[test]
+    fn command_companion_attack_damages_hostile_target() {
+        let mut ecs = hecs::World::new();
+        let player_entity = spawn_actor(
+            &mut ecs,
+            Vec2::new(0.0, 0.0),
+            Team::Team(1),
+            Health::new(100.0),
+        );
+        let target_entity = spawn_actor(
+            &mut ecs,
+            Vec2::new(20.0, 0.0),
+            Team::Team(2),
+            Health::new(50.0),
+        );
+        ecs.insert(
+            player_entity,
+            (CompanionRoster {
+                active_slot: None,
+                party_capacity: 6,
+                creatures: vec![CompanionCreature {
+                    creature: CreatureIdentity {
+                        species_id: "river-drake".to_string(),
+                        species_name: "River Drake".to_string(),
+                        elemental_affinity: "water".to_string(),
+                        level: 11,
+                        temperament: CreatureTemperament::Loyal,
+                        capture_difficulty: 0.1,
+                        is_wild: false,
+                    },
+                    nickname: None,
+                    current_health: 28.0,
+                    max_health: 28.0,
+                    combat_style: CombatStyle::Summoning,
+                    mood: 1.0,
+                }],
+            },),
+        )
+        .unwrap();
+
+        let obs_store = Arc::new(Mutex::new(Vec::new()));
+        let (agent, agent_id) = RecordingAgent::new(vec![], obs_store);
+        let mut slot = AgentSlot::new(Box::new(agent));
+        slot.entity_id = Some(player_entity);
+        let mut agents = vec![slot];
+        let mut events = EventBus::new();
+        let mut next_entity_id = 1;
+
+        let result = execute_tick(
+            &mut ecs,
+            &mut agents,
+            &mut events,
+            1,
+            vec![AgentAction {
+                agent_id,
+                tick: 1,
+                action: Action::CommandCompanion {
+                    slot: 0,
+                    command: CompanionCommand::Attack,
+                    target: Some(EntityId(target_entity.id() as u64)),
+                },
+            }],
+            &mut next_entity_id,
+        );
+
+        let target_health = ecs.get::<&Health>(target_entity).unwrap();
+        assert_eq!(target_health.current, 39.0);
+        let roster = ecs.get::<&CompanionRoster>(player_entity).unwrap();
+        assert_eq!(roster.active_slot, Some(0));
+        assert!(result.events.iter().any(|event| matches!(
+            event.event,
+            Event::CompanionCommandIssued { slot, ref command, .. }
+                if slot == 0 && command == "Attack"
+        )));
+    }
+
+    #[test]
+    fn gather_resource_adds_item_and_awards_skill_xp() {
+        let mut ecs = hecs::World::new();
+        let player_entity = spawn_actor(
+            &mut ecs,
+            Vec2::new(0.0, 0.0),
+            Team::Team(1),
+            Health::new(100.0),
+        );
+        let resource_entity = ecs.spawn((
+            Transform {
+                position: Vec2::new(10.0, 0.0),
+                rotation: 0.0,
+                scale: Vec2::ONE,
+            },
+            ResourceNode {
+                skill: SkillKind::Mining,
+                tier: 1,
+                remaining_uses: 1,
+                respawn_ticks: 300,
+                experience: 10,
+                yield_item: ItemStack {
+                    item_id: "copper-ore".to_string(),
+                    display_name: "Copper Ore".to_string(),
+                    quantity: 2,
+                    stackable: true,
+                },
+            },
+        ));
+        ecs.insert(
+            player_entity,
+            (
+                Inventory::default(),
+                SkillBook {
+                    combat_level: 3,
+                    total_level: 17,
+                    skills: vec![
+                        SkillProgress::new(SkillKind::Attack, 1, 0, 83),
+                        SkillProgress::new(SkillKind::Strength, 1, 0, 83),
+                        SkillProgress::new(SkillKind::Defence, 1, 0, 83),
+                        SkillProgress::new(SkillKind::Ranged, 1, 0, 83),
+                        SkillProgress::new(SkillKind::Magic, 1, 0, 83),
+                        SkillProgress::new(SkillKind::Constitution, 10, 1_154, 1_358),
+                        SkillProgress::new(SkillKind::Mining, 1, 80, 83),
+                        SkillProgress::new(SkillKind::Taming, 1, 0, 83),
+                        SkillProgress::new(SkillKind::Bonding, 1, 0, 83),
+                    ],
+                },
+            ),
+        )
+        .unwrap();
+
+        let obs_store = Arc::new(Mutex::new(Vec::new()));
+        let (agent, agent_id) = RecordingAgent::new(vec![], obs_store);
+        let mut slot = AgentSlot::new(Box::new(agent));
+        slot.entity_id = Some(player_entity);
+        let mut agents = vec![slot];
+        let mut events = EventBus::new();
+        let mut next_entity_id = 1;
+
+        let result = execute_tick(
+            &mut ecs,
+            &mut agents,
+            &mut events,
+            1,
+            vec![AgentAction {
+                agent_id,
+                tick: 1,
+                action: Action::GatherResource {
+                    target: EntityId(resource_entity.id() as u64),
+                    skill: SkillKind::Mining,
+                },
+            }],
+            &mut next_entity_id,
+        );
+
+        let inventory = ecs.get::<&Inventory>(player_entity).unwrap();
+        assert_eq!(inventory.items.len(), 1);
+        assert_eq!(inventory.items[0].item_id, "copper-ore");
+        assert_eq!(inventory.items[0].quantity, 2);
+        let skill_book = ecs.get::<&SkillBook>(player_entity).unwrap();
+        let mining = skill_book
+            .skills
+            .iter()
+            .find(|progress| progress.kind == SkillKind::Mining)
+            .unwrap();
+        assert_eq!(mining.level, 2);
+        assert_eq!(mining.experience, 7);
+        let node = ecs.get::<&ResourceNode>(resource_entity).unwrap();
+        assert_eq!(node.remaining_uses, 0);
+        assert!(result.events.iter().any(|event| matches!(
+            &event.event,
+            Event::SkillXpGained { skill, amount, new_level, .. }
+                if skill == "Mining" && *amount == 10 && *new_level == 2
+        )));
+    }
+
+    #[test]
+    fn loot_claims_container_and_transfers_contents() {
+        let mut ecs = hecs::World::new();
+        let player_entity = spawn_actor(
+            &mut ecs,
+            Vec2::new(0.0, 0.0),
+            Team::Team(1),
+            Health::new(100.0),
+        );
+        let chest_entity = ecs.spawn((
+            Transform {
+                position: Vec2::new(8.0, 0.0),
+                rotation: 0.0,
+                scale: Vec2::ONE,
+            },
+            LootContainer {
+                coins: 125,
+                items: vec![ItemStack {
+                    item_id: "salmon".to_string(),
+                    display_name: "Salmon".to_string(),
+                    quantity: 3,
+                    stackable: true,
+                }],
+                owner: None,
+                claimed: false,
+            },
+        ));
+        ecs.insert(player_entity, (Inventory::default(),)).unwrap();
+
+        let obs_store = Arc::new(Mutex::new(Vec::new()));
+        let (agent, agent_id) = RecordingAgent::new(vec![], obs_store);
+        let mut slot = AgentSlot::new(Box::new(agent));
+        slot.entity_id = Some(player_entity);
+        let mut agents = vec![slot];
+        let mut events = EventBus::new();
+        let mut next_entity_id = 1;
+
+        let result = execute_tick(
+            &mut ecs,
+            &mut agents,
+            &mut events,
+            1,
+            vec![AgentAction {
+                agent_id,
+                tick: 1,
+                action: Action::Loot {
+                    target: EntityId(chest_entity.id() as u64),
+                },
+            }],
+            &mut next_entity_id,
+        );
+
+        let inventory = ecs.get::<&Inventory>(player_entity).unwrap();
+        assert_eq!(inventory.coins, 125);
+        assert_eq!(inventory.items.len(), 1);
+        assert_eq!(inventory.items[0].item_id, "salmon");
+        let loot = ecs.get::<&LootContainer>(chest_entity).unwrap();
+        assert!(loot.claimed);
+        assert_eq!(loot.coins, 0);
+        assert!(loot.items.is_empty());
+        assert!(result.events.iter().any(|event| matches!(
+            event.event,
+            Event::LootClaimed {
+                coins,
+                item_count,
+                ..
+            } if coins == 125 && item_count == 1
+        )));
+    }
+
+    #[test]
+    fn set_auto_retaliate_updates_combat_loadout() {
+        let mut ecs = hecs::World::new();
+        let player_entity = spawn_actor(
+            &mut ecs,
+            Vec2::new(0.0, 0.0),
+            Team::Team(1),
+            Health::new(100.0),
+        );
+        ecs.insert(
+            player_entity,
+            (CombatLoadout {
+                auto_retaliate: true,
+                ..CombatLoadout::default()
+            },),
+        )
+        .unwrap();
+
+        let obs_store = Arc::new(Mutex::new(Vec::new()));
+        let (agent, agent_id) = RecordingAgent::new(vec![], obs_store);
+        let mut slot = AgentSlot::new(Box::new(agent));
+        slot.entity_id = Some(player_entity);
+        let mut agents = vec![slot];
+        let mut events = EventBus::new();
+        let mut next_entity_id = 1;
+
+        let result = execute_tick(
+            &mut ecs,
+            &mut agents,
+            &mut events,
+            1,
+            vec![AgentAction {
+                agent_id,
+                tick: 1,
+                action: Action::SetAutoRetaliate { enabled: false },
+            }],
+            &mut next_entity_id,
+        );
+
+        let loadout = ecs.get::<&CombatLoadout>(player_entity).unwrap();
+        assert!(!loadout.auto_retaliate);
+        assert!(result.events.iter().any(|event| matches!(
+            event.event,
+            Event::AutoRetaliateSet { enabled, .. } if !enabled
+        )));
     }
 }

--- a/crates/pod-core/src/world.rs
+++ b/crates/pod-core/src/world.rs
@@ -190,6 +190,8 @@ enum ComponentToAdd {
     CreatureIdentity(CreatureIdentity),
     CompanionRoster(CompanionRoster),
     EncounterState(EncounterState),
+    ResourceNode(ResourceNode),
+    LootContainer(LootContainer),
 }
 
 impl<'w> EntityBuilder<'w> {
@@ -290,6 +292,16 @@ impl<'w> EntityBuilder<'w> {
         self
     }
 
+    pub fn with_resource_node(mut self, resource: ResourceNode) -> Self {
+        self.components.push(ComponentToAdd::ResourceNode(resource));
+        self
+    }
+
+    pub fn with_loot_container(mut self, loot: LootContainer) -> Self {
+        self.components.push(ComponentToAdd::LootContainer(loot));
+        self
+    }
+
     /// Finalize and spawn the entity
     pub fn build(self) -> hecs::Entity {
         let entity = self.world.ecs.spawn((self.transform, Velocity::default()));
@@ -343,6 +355,12 @@ impl<'w> EntityBuilder<'w> {
                 }
                 ComponentToAdd::EncounterState(encounter) => {
                     self.world.ecs.insert_one(entity, encounter).unwrap();
+                }
+                ComponentToAdd::ResourceNode(resource) => {
+                    self.world.ecs.insert_one(entity, resource).unwrap();
+                }
+                ComponentToAdd::LootContainer(loot) => {
+                    self.world.ecs.insert_one(entity, loot).unwrap();
                 }
             }
         }

--- a/crates/pod-net/src/client_stdb.rs
+++ b/crates/pod-net/src/client_stdb.rs
@@ -39,8 +39,8 @@
 //! }
 //! ```
 
-use std::fmt;
 use std::collections::HashSet;
+use std::fmt;
 
 use glam::Vec2;
 use uuid::Uuid;
@@ -137,7 +137,9 @@ impl SpacetimeSubscriptionManager {
         let queries = self.queries_for_profile();
 
         if self.active_queries != queries {
-            client.subscribe(queries.clone()).map_err(StdbClientError::from)?;
+            client
+                .subscribe(queries.clone())
+                .map_err(StdbClientError::from)?;
             self.active_queries = queries;
         }
 
@@ -155,11 +157,9 @@ impl SpacetimeSubscriptionManager {
                 .into_iter()
                 .map(ToString::to_string)
                 .collect(),
-            SubscriptionProfile::Player(entity_id) => {
-                Subscriptions::player_agent(*entity_id)
-                    .into_iter()
-                    .collect()
-            }
+            SubscriptionProfile::Player(entity_id) => Subscriptions::player_agent(*entity_id)
+                .into_iter()
+                .collect(),
             SubscriptionProfile::Custom(queries) => queries.clone(),
         }
     }
@@ -485,7 +485,10 @@ impl SpacetimeDBClient {
                 StdbEvent::Connected { .. } => {
                     self.client_id = Some(ClientId::new());
                     log::info!("[pod-net stdb] Connected to SpacetimeDB");
-                    if let Err(err) = self.subscriptions.ensure_subscriptions_applied(&mut self.inner) {
+                    if let Err(err) = self
+                        .subscriptions
+                        .ensure_subscriptions_applied(&mut self.inner)
+                    {
                         log::error!(
                             "[pod-net stdb] Failed to apply subscriptions after connect: {err}"
                         );
@@ -745,8 +748,13 @@ impl SpacetimeDBClient {
         radius: f32,
         partition_size: f32,
     ) -> Result<bool, StdbClientError> {
-        let queries =
-            build_player_partitioned_interest_queries(entity_id, center_x, center_y, radius, partition_size)?;
+        let queries = build_player_partitioned_interest_queries(
+            entity_id,
+            center_x,
+            center_y,
+            radius,
+            partition_size,
+        )?;
         self.subscriptions.set_custom(queries);
         self.subscriptions
             .ensure_subscriptions_applied(&mut self.inner)
@@ -839,10 +847,7 @@ fn entity_to_snapshot(cached: &CachedEntity) -> EntitySnapshot {
     EntitySnapshot {
         id: cached.entity_id,
         position: Vec2::new(px, py),
-        velocity: Vec2::new(
-            cached.vel_x.unwrap_or(0.0),
-            cached.vel_y.unwrap_or(0.0),
-        ),
+        velocity: Vec2::new(cached.vel_x.unwrap_or(0.0), cached.vel_y.unwrap_or(0.0)),
         rotation: cached.rotation.unwrap_or(0.0),
         health: cached.health,
         max_health: cached.max_health,
@@ -868,15 +873,21 @@ fn convert_action(entity_id: u64, action: &Action) -> SubmittedAction {
         Action::AttackTarget { target } => SubmittedAction::attack_target(entity_id, target.0),
         Action::UseAbility { slot, target } => {
             let (target_kind, tx, ty, te) = match target {
-                Some(AbilityTarget::Position(p)) => {
-                    (Some(AbilityTargetKind::Position), Some(p.x), Some(p.y), None)
-                }
+                Some(AbilityTarget::Position(p)) => (
+                    Some(AbilityTargetKind::Position),
+                    Some(p.x),
+                    Some(p.y),
+                    None,
+                ),
                 Some(AbilityTarget::Entity(eid)) => {
                     (Some(AbilityTargetKind::Entity), None, None, Some(eid.0))
                 }
-                Some(AbilityTarget::Direction(d)) => {
-                    (Some(AbilityTargetKind::Direction), Some(d.x), Some(d.y), None)
-                }
+                Some(AbilityTarget::Direction(d)) => (
+                    Some(AbilityTargetKind::Direction),
+                    Some(d.x),
+                    Some(d.y),
+                    None,
+                ),
                 None => (Some(AbilityTargetKind::None), None, None, None),
             };
             SubmittedAction {
@@ -889,6 +900,28 @@ fn convert_action(entity_id: u64, action: &Action) -> SubmittedAction {
                 ..default_submitted(entity_id)
             }
         }
+        Action::CaptureCreature { target, tool_slot } => SubmittedAction {
+            action_kind: ActionKind::CaptureCreature,
+            target_entity_id: Some(target.0),
+            ability_slot: *tool_slot,
+            ..default_submitted(entity_id)
+        },
+        Action::SummonCompanion { slot } => SubmittedAction {
+            action_kind: ActionKind::SummonCompanion,
+            ability_slot: Some(*slot),
+            ..default_submitted(entity_id)
+        },
+        Action::CommandCompanion {
+            slot,
+            command,
+            target,
+        } => SubmittedAction {
+            action_kind: ActionKind::CommandCompanion,
+            ability_slot: Some(*slot),
+            target_entity_id: target.map(|target| target.0),
+            signal_type: Some(format!("{command:?}")),
+            ..default_submitted(entity_id)
+        },
         Action::Interact => SubmittedAction {
             action_kind: ActionKind::Interact,
             ..default_submitted(entity_id)
@@ -913,6 +946,17 @@ fn convert_action(entity_id: u64, action: &Action) -> SubmittedAction {
             ability_slot: Some(*slot),
             ..default_submitted(entity_id)
         },
+        Action::GatherResource { target, skill } => SubmittedAction {
+            action_kind: ActionKind::GatherResource,
+            target_entity_id: Some(target.0),
+            signal_type: Some(format!("{skill:?}")),
+            ..default_submitted(entity_id)
+        },
+        Action::Loot { target } => SubmittedAction {
+            action_kind: ActionKind::Loot,
+            target_entity_id: Some(target.0),
+            ..default_submitted(entity_id)
+        },
         Action::Speak { message, volume } => {
             SubmittedAction::speak(entity_id, message.clone(), convert_speak_volume(volume))
         }
@@ -920,6 +964,11 @@ fn convert_action(entity_id: u64, action: &Action) -> SubmittedAction {
             action_kind: ActionKind::Signal,
             signal_type: Some(signal_type.clone()),
             signal_data: Some(data.clone()),
+            ..default_submitted(entity_id)
+        },
+        Action::SetAutoRetaliate { enabled } => SubmittedAction {
+            action_kind: ActionKind::SetAutoRetaliate,
+            signal_data: Some(enabled.to_string()),
             ..default_submitted(entity_id)
         },
         Action::Idle => SubmittedAction::idle(entity_id),
@@ -1025,7 +1074,11 @@ fn convert_world_event(
         }
     };
 
-    Some(GameEvent { tick, origin, event })
+    Some(GameEvent {
+        tick,
+        origin,
+        event,
+    })
 }
 
 // ============================================================
@@ -1116,6 +1169,32 @@ mod tests {
     }
 
     #[test]
+    fn test_convert_action_capture_creature() {
+        let action = Action::CaptureCreature {
+            target: EntityId(12),
+            tool_slot: Some(3),
+        };
+        let submitted = convert_action(1, &action);
+        assert_eq!(submitted.action_kind, ActionKind::CaptureCreature);
+        assert_eq!(submitted.target_entity_id, Some(12));
+        assert_eq!(submitted.ability_slot, Some(3));
+    }
+
+    #[test]
+    fn test_convert_action_command_companion() {
+        let action = Action::CommandCompanion {
+            slot: 2,
+            command: pod_core::action::CompanionCommand::Attack,
+            target: Some(EntityId(44)),
+        };
+        let submitted = convert_action(1, &action);
+        assert_eq!(submitted.action_kind, ActionKind::CommandCompanion);
+        assert_eq!(submitted.ability_slot, Some(2));
+        assert_eq!(submitted.target_entity_id, Some(44));
+        assert_eq!(submitted.signal_type.as_deref(), Some("Attack"));
+    }
+
+    #[test]
     fn test_convert_action_idle() {
         let submitted = convert_action(1, &Action::Idle);
         assert_eq!(submitted.action_kind, ActionKind::Idle);
@@ -1169,7 +1248,10 @@ mod tests {
         let ge = event.unwrap();
         assert_eq!(ge.tick, 10);
         match ge.event {
-            Event::EntitySpawned { entity, entity_type } => {
+            Event::EntitySpawned {
+                entity,
+                entity_type,
+            } => {
                 assert_eq!(entity, EntityId(5));
                 assert_eq!(entity_type, "npc");
             }
@@ -1199,14 +1281,7 @@ mod tests {
 
     #[test]
     fn test_convert_world_event_tick_advanced_returns_none() {
-        let event = convert_world_event(
-            30,
-            Vec2::ZERO,
-            &WorldEventKind::TickAdvanced,
-            0,
-            None,
-            "",
-        );
+        let event = convert_world_event(30, Vec2::ZERO, &WorldEventKind::TickAdvanced, 0, None, "");
         assert!(event.is_none());
     }
 
@@ -1282,7 +1357,9 @@ mod tests {
         let client = SpacetimeDBClient::new(SpacetimeDBClientConfig::default());
         let queries = client.subscriptions.queries_for_profile();
 
-        assert!(queries.iter().any(|query| query.contains("FROM world_state")));
+        assert!(queries
+            .iter()
+            .any(|query| query.contains("FROM world_state")));
         assert!(queries.iter().any(|query| query.contains("FROM entity")));
         assert!(queries.iter().any(|query| query.contains("combat_event")));
         assert!(client.subscriptions.active_queries().is_empty());

--- a/crates/pod-stdb/src/client.rs
+++ b/crates/pod-stdb/src/client.rs
@@ -73,8 +73,8 @@
 //! Until bindings are generated, this module provides the typed API surface
 //! with stub implementations. See [`StdbClient::connect`] for details.
 
-use std::collections::{HashMap, VecDeque};
 use crate::types::*;
+use std::collections::{HashMap, VecDeque};
 
 // ============================================================
 // CONFIGURATION
@@ -169,18 +169,11 @@ pub enum ConnectionState {
 pub enum StdbEvent {
     // ── Connection lifecycle ──
     /// Successfully connected to SpacetimeDB.
-    Connected {
-        identity: Vec<u8>,
-        token: String,
-    },
+    Connected { identity: Vec<u8>, token: String },
     /// Disconnected from SpacetimeDB.
-    Disconnected {
-        reason: String,
-    },
+    Disconnected { reason: String },
     /// Connection attempt failed.
-    ConnectError {
-        message: String,
-    },
+    ConnectError { message: String },
     /// Initial subscription data has been received and cached.
     SubscriptionApplied,
 
@@ -193,24 +186,15 @@ pub enum StdbEvent {
         world_height: f32,
     },
     /// Tick counter advanced (extracted from world_state updates).
-    TickAdvanced {
-        old_tick: u64,
-        new_tick: u64,
-    },
+    TickAdvanced { old_tick: u64, new_tick: u64 },
 
     // ── Entity lifecycle ──
     /// A new entity appeared in the subscription.
-    EntityInserted {
-        entity_id: u64,
-    },
+    EntityInserted { entity_id: u64 },
     /// An entity was updated (any component changed).
-    EntityUpdated {
-        entity_id: u64,
-    },
+    EntityUpdated { entity_id: u64 },
     /// An entity was removed from the subscription (destroyed or out of range).
-    EntityDeleted {
-        entity_id: u64,
-    },
+    EntityDeleted { entity_id: u64 },
 
     // ── Agent-specific ──
     /// Observation data received for a controlled entity.
@@ -245,14 +229,9 @@ pub enum StdbEvent {
 
     // ── Reducer acknowledgments ──
     /// A reducer call was acknowledged by the server.
-    ReducerCallSuccess {
-        reducer_name: String,
-    },
+    ReducerCallSuccess { reducer_name: String },
     /// A reducer call failed.
-    ReducerCallError {
-        reducer_name: String,
-        error: String,
-    },
+    ReducerCallError { reducer_name: String, error: String },
 }
 
 // ============================================================
@@ -665,10 +644,7 @@ impl Subscriptions {
 
     /// Subscribe to lobby tables only.
     pub fn lobby_system() -> Vec<&'static str> {
-        vec![
-            "SELECT * FROM lobby",
-            "SELECT * FROM lobby_member",
-        ]
+        vec!["SELECT * FROM lobby", "SELECT * FROM lobby_member"]
     }
 
     /// Subscribe to matchmaking tables only.
@@ -778,7 +754,9 @@ impl StdbClient {
                 return Err(StdbError::InvalidState("Already connected".into()));
             }
             ConnectionState::Connecting => {
-                return Err(StdbError::InvalidState("Connection already in progress".into()));
+                return Err(StdbError::InvalidState(
+                    "Connection already in progress".into(),
+                ));
             }
             _ => {}
         }
@@ -828,11 +806,12 @@ impl StdbClient {
     pub fn frame_tick(&mut self) {
         self.frames_processed += 1;
         if let ConnectionState::Connecting = &self.state {
-            let token = self
-                .config
-                .auth_token
-                .clone()
-                .unwrap_or_else(|| format!("pod-local-{}-{}", self.config.db_name, self.frames_processed));
+            let token = self.config.auth_token.clone().unwrap_or_else(|| {
+                format!(
+                    "pod-local-{}-{}",
+                    self.config.db_name, self.frames_processed
+                )
+            });
             let mut identity = vec![0u8; 16];
             for (idx, byte) in self
                 .config
@@ -848,7 +827,8 @@ impl StdbClient {
                 identity: identity.clone(),
                 token: token.clone(),
             };
-            self.events.push_back(StdbEvent::Connected { identity, token });
+            self.events
+                .push_back(StdbEvent::Connected { identity, token });
 
             if self.world_state.is_none() {
                 self.update_world_state(CachedWorldState {
@@ -941,7 +921,9 @@ impl StdbClient {
             ));
         }
         self.reducers_called += 1;
-        log::debug!("[pod-stdb client] Calling create_world(seed={seed}, {width}x{height}, tps={tps})");
+        log::debug!(
+            "[pod-stdb client] Calling create_world(seed={seed}, {width}x{height}, tps={tps})"
+        );
         self.update_world_state(CachedWorldState {
             tick: 0,
             rng_seed: seed,
@@ -1098,17 +1080,15 @@ impl StdbClient {
     }
 
     /// Mark this player as ready or not ready in a lobby.
-    pub fn call_set_lobby_ready(
-        &mut self,
-        lobby_id: u64,
-        is_ready: bool,
-    ) -> Result<(), StdbError> {
+    pub fn call_set_lobby_ready(&mut self, lobby_id: u64, is_ready: bool) -> Result<(), StdbError> {
         self.require_connected()?;
         if lobby_id == 0 {
             return Err(StdbError::ReducerError("Lobby id must be non-zero".into()));
         }
         self.reducers_called += 1;
-        log::info!("[pod-stdb client] Calling set_lobby_ready(lobby_id={lobby_id}, is_ready={is_ready})");
+        log::info!(
+            "[pod-stdb client] Calling set_lobby_ready(lobby_id={lobby_id}, is_ready={is_ready})"
+        );
         let _ = is_ready;
         self.record_reducer_success("set_lobby_ready");
         Ok(())
@@ -1161,7 +1141,10 @@ impl StdbClient {
     }
 
     /// Create a match from the matchmaking queue.
-    pub fn call_create_match_from_queue(&mut self, desired_party_size: u32) -> Result<(), StdbError> {
+    pub fn call_create_match_from_queue(
+        &mut self,
+        desired_party_size: u32,
+    ) -> Result<(), StdbError> {
         self.require_connected()?;
         if desired_party_size == 0 {
             return Err(StdbError::ReducerError(
@@ -1336,9 +1319,9 @@ impl StdbClient {
             .entities
             .get(&source_id)
             .ok_or_else(|| StdbError::ReducerError(format!("Entity {source_id} missing")))?;
-        let source_pos = source
-            .position()
-            .ok_or_else(|| StdbError::ReducerError(format!("Entity {source_id} has no transform")))?;
+        let source_pos = source.position().ok_or_else(|| {
+            StdbError::ReducerError(format!("Entity {source_id} has no transform"))
+        })?;
         let source_team = source.team_id.unwrap_or(0);
 
         match action.action_kind {
@@ -1350,7 +1333,9 @@ impl StdbClient {
                             let speed = entity.max_speed.unwrap_or(200.0);
                             entity.vel_x = Some((dx / len) * speed);
                             entity.vel_y = Some((dy / len) * speed);
-                            self.events.push_back(StdbEvent::EntityUpdated { entity_id: source_id });
+                            self.events.push_back(StdbEvent::EntityUpdated {
+                                entity_id: source_id,
+                            });
                         }
                     }
                 }
@@ -1359,22 +1344,32 @@ impl StdbClient {
                 if let Some(entity) = self.entities.get_mut(&source_id) {
                     entity.vel_x = Some(0.0);
                     entity.vel_y = Some(0.0);
-                    self.events.push_back(StdbEvent::EntityUpdated { entity_id: source_id });
+                    self.events.push_back(StdbEvent::EntityUpdated {
+                        entity_id: source_id,
+                    });
                 }
             }
             ActionKind::Rotate => {
-                if let (Some(entity), Some(angle)) = (self.entities.get_mut(&source_id), action.angle) {
+                if let (Some(entity), Some(angle)) =
+                    (self.entities.get_mut(&source_id), action.angle)
+                {
                     entity.rotation = Some(angle);
-                    self.events.push_back(StdbEvent::EntityUpdated { entity_id: source_id });
+                    self.events.push_back(StdbEvent::EntityUpdated {
+                        entity_id: source_id,
+                    });
                 }
             }
             ActionKind::LookAt => {
-                if let (Some(entity), Some(tx), Some(ty)) =
-                    (self.entities.get_mut(&source_id), action.target_x, action.target_y)
-                {
+                if let (Some(entity), Some(tx), Some(ty)) = (
+                    self.entities.get_mut(&source_id),
+                    action.target_x,
+                    action.target_y,
+                ) {
                     if let Some((sx, sy)) = entity.position() {
                         entity.rotation = Some((ty - sy).atan2(tx - sx));
-                        self.events.push_back(StdbEvent::EntityUpdated { entity_id: source_id });
+                        self.events.push_back(StdbEvent::EntityUpdated {
+                            entity_id: source_id,
+                        });
                     }
                 }
             }
@@ -1392,7 +1387,8 @@ impl StdbClient {
                     let dy = ty - source_pos.1;
                     let distance = (dx * dx + dy * dy).sqrt();
                     let candidate_team = candidate.team_id.unwrap_or(0);
-                    let hostile = source_team == 0 || candidate_team == 0 || source_team != candidate_team;
+                    let hostile =
+                        source_team == 0 || candidate_team == 0 || source_team != candidate_team;
                     if hostile && distance <= ATTACK_RANGE && distance < best_distance {
                         target = Some(*candidate_id);
                         best_distance = distance;
@@ -1428,8 +1424,108 @@ impl StdbClient {
                     self.apply_damage(source_id, target_id, BASE_DAMAGE)?;
                 }
             }
+            ActionKind::CaptureCreature => {
+                let Some(target_id) = action.target_entity_id else {
+                    return Err(StdbError::ReducerError(
+                        "CaptureCreature requires target_entity_id".into(),
+                    ));
+                };
+                self.receive_world_event(
+                    self.current_tick_value(),
+                    WorldEventKind::AbilityUsed,
+                    source_id,
+                    Some(target_id),
+                    format!(
+                        r#"{{"type":"capture_creature","tool_slot":{}}}"#,
+                        action
+                            .ability_slot
+                            .map(|slot| slot.to_string())
+                            .unwrap_or_else(|| "null".to_string())
+                    ),
+                );
+            }
+            ActionKind::SummonCompanion => {
+                self.receive_world_event(
+                    self.current_tick_value(),
+                    WorldEventKind::AbilityUsed,
+                    source_id,
+                    None,
+                    format!(
+                        r#"{{"type":"summon_companion","slot":{}}}"#,
+                        action.ability_slot.unwrap_or(0)
+                    ),
+                );
+            }
+            ActionKind::CommandCompanion => {
+                let command = action
+                    .signal_type
+                    .clone()
+                    .unwrap_or_else(|| "follow".to_string())
+                    .replace('"', "\\\"");
+                let target_id = action
+                    .target_entity_id
+                    .map(|target| target.to_string())
+                    .unwrap_or_else(|| "null".to_string());
+                self.receive_world_event(
+                    self.current_tick_value(),
+                    WorldEventKind::AbilityUsed,
+                    source_id,
+                    action.target_entity_id,
+                    format!(
+                        r#"{{"type":"command_companion","slot":{},"command":"{}","target":{}}}"#,
+                        action.ability_slot.unwrap_or(0),
+                        command,
+                        target_id
+                    ),
+                );
+            }
+            ActionKind::GatherResource => {
+                let Some(target_id) = action.target_entity_id else {
+                    return Err(StdbError::ReducerError(
+                        "GatherResource requires target_entity_id".into(),
+                    ));
+                };
+                let skill = action
+                    .signal_type
+                    .clone()
+                    .unwrap_or_else(|| "gather".to_string())
+                    .replace('"', "\\\"");
+                self.receive_world_event(
+                    self.current_tick_value(),
+                    WorldEventKind::AbilityUsed,
+                    source_id,
+                    Some(target_id),
+                    format!(r#"{{"type":"gather_resource","skill":"{}"}}"#, skill),
+                );
+            }
+            ActionKind::Loot => {
+                let Some(target_id) = action.target_entity_id else {
+                    return Err(StdbError::ReducerError(
+                        "Loot requires target_entity_id".into(),
+                    ));
+                };
+                self.receive_world_event(
+                    self.current_tick_value(),
+                    WorldEventKind::ItemPickedUp,
+                    source_id,
+                    Some(target_id),
+                    r#"{"type":"loot"}"#.to_string(),
+                );
+            }
+            ActionKind::SetAutoRetaliate => {
+                let enabled = action.signal_data.as_deref() == Some("true");
+                self.receive_world_event(
+                    self.current_tick_value(),
+                    WorldEventKind::AbilityUsed,
+                    source_id,
+                    None,
+                    format!(r#"{{"type":"set_auto_retaliate","enabled":{enabled}}}"#),
+                );
+            }
             ActionKind::Speak => {
-                if let (Some(message), Some(volume)) = (action.message.clone(), action.volume.clone()) {
+                if let (Some(message), Some(volume)) =
+                    (action.message.clone(), action.volume.clone())
+                {
                     self.receive_speech_event(
                         self.current_tick_value(),
                         source_id,
@@ -1511,7 +1607,10 @@ impl StdbClient {
                     WorldEventKind::AbilityUsed,
                     source_id,
                     action.target_entity_id,
-                    action.signal_data.clone().unwrap_or_else(|| "{}".to_string()),
+                    action
+                        .signal_data
+                        .clone()
+                        .unwrap_or_else(|| "{}".to_string()),
                 );
             }
             ActionKind::Spawn => {
@@ -1561,7 +1660,9 @@ impl StdbClient {
         target.alive = remaining > 0.0;
 
         self.receive_combat_event(tick, attacker_id, target_id, damage, remaining <= 0.0);
-        self.events.push_back(StdbEvent::EntityUpdated { entity_id: target_id });
+        self.events.push_back(StdbEvent::EntityUpdated {
+            entity_id: target_id,
+        });
         if remaining <= 0.0 {
             self.receive_world_event(
                 tick,
@@ -1617,9 +1718,11 @@ impl StdbClient {
         self.entities.insert(eid, entity);
 
         if is_new {
-            self.events.push_back(StdbEvent::EntityInserted { entity_id: eid });
+            self.events
+                .push_back(StdbEvent::EntityInserted { entity_id: eid });
         } else {
-            self.events.push_back(StdbEvent::EntityUpdated { entity_id: eid });
+            self.events
+                .push_back(StdbEvent::EntityUpdated { entity_id: eid });
         }
         self.events_received += 1;
     }
@@ -1628,7 +1731,8 @@ impl StdbClient {
     pub fn remove_entity(&mut self, entity_id: u64) {
         self.entities.remove(&entity_id);
         self.observations.remove(&entity_id);
-        self.events.push_back(StdbEvent::EntityDeleted { entity_id });
+        self.events
+            .push_back(StdbEvent::EntityDeleted { entity_id });
         self.events_received += 1;
     }
 
@@ -1639,7 +1743,8 @@ impl StdbClient {
         observer_entity_id: u64,
         observation_json: String,
     ) {
-        self.observations.insert(observer_entity_id, observation_json.clone());
+        self.observations
+            .insert(observer_entity_id, observation_json.clone());
         self.events.push_back(StdbEvent::ObservationReceived {
             tick,
             observer_entity_id,
@@ -1741,10 +1846,16 @@ mod tests {
             connection_mode: StdbConnectionMode::Emulated,
             ..StdbClientConfig::default()
         });
-        assert!(matches!(client.connection_state(), ConnectionState::Disconnected));
+        assert!(matches!(
+            client.connection_state(),
+            ConnectionState::Disconnected
+        ));
 
         client.connect().unwrap();
-        assert!(matches!(client.connection_state(), ConnectionState::Connecting));
+        assert!(matches!(
+            client.connection_state(),
+            ConnectionState::Connecting
+        ));
 
         // Double connect should error
         assert!(client.connect().is_err());
@@ -1756,9 +1867,14 @@ mod tests {
             connection_mode: StdbConnectionMode::Generated,
             ..StdbClientConfig::default()
         });
-        let err = client.connect().expect_err("generated mode requires runtime wiring");
+        let err = client
+            .connect()
+            .expect_err("generated mode requires runtime wiring");
         assert!(matches!(err, StdbError::ConnectionFailed(_)));
-        assert!(matches!(client.connection_state(), ConnectionState::Error(_)));
+        assert!(matches!(
+            client.connection_state(),
+            ConnectionState::Error(_)
+        ));
     }
 
     #[test]
@@ -1798,10 +1914,7 @@ mod tests {
         assert!(!client.has_events());
 
         // Check observation is cached
-        assert_eq!(
-            client.latest_observation(42),
-            Some("{\"test\":true}")
-        );
+        assert_eq!(client.latest_observation(42), Some("{\"test\":true}"));
     }
 
     #[test]

--- a/crates/pod-stdb/src/reducers.rs
+++ b/crates/pod-stdb/src/reducers.rs
@@ -9,12 +9,12 @@
 //!   4. Physics/Movement (velocity integration)
 //!   5. Flush Events (broadcast to listeners)
 
+use crate::events::*;
+use crate::tables::*;
+use crate::types::*;
+use serde_json::json;
 use spacetimedb::{Identity, ReducerContext, Table};
 use std::collections::HashMap;
-use serde_json::json;
-use crate::tables::*;
-use crate::events::*;
-use crate::types::*;
 
 fn reject_reducer(ctx: &ReducerContext, reason: impl Into<String>) {
     let reason_text = reason.into();
@@ -78,8 +78,16 @@ pub fn client_disconnected(ctx: &ReducerContext) {
     }
 
     // Remove lobby membership, if any
-    for membership in ctx.db.lobby_member().iter().filter(|member| member.identity == identity) {
-        ctx.db.lobby_member().membership_id().delete(membership.membership_id);
+    for membership in ctx
+        .db
+        .lobby_member()
+        .iter()
+        .filter(|member| member.identity == identity)
+    {
+        ctx.db
+            .lobby_member()
+            .membership_id()
+            .delete(membership.membership_id);
     }
 }
 
@@ -89,13 +97,7 @@ pub fn client_disconnected(ctx: &ReducerContext) {
 
 /// Create or reset the game world with custom parameters.
 #[spacetimedb::reducer]
-pub fn create_world(
-    ctx: &ReducerContext,
-    seed: u64,
-    width: f32,
-    height: f32,
-    tps: u32,
-) {
+pub fn create_world(ctx: &ReducerContext, seed: u64, width: f32, height: f32, tps: u32) {
     if let Some(mut ws) = ctx.db.world_state().id().find(0) {
         ws.tick = 0;
         ws.rng_seed = seed;
@@ -137,13 +139,12 @@ pub fn set_paused(ctx: &ReducerContext, paused: bool) {
 /// Spawn a new entity with a transform at the given position.
 /// Optionally assign an agent type. Returns the entity via auto_inc.
 #[spacetimedb::reducer]
-pub fn spawn_entity(
-    ctx: &ReducerContext,
-    pos_x: f32,
-    pos_y: f32,
-    agent_type: Option<AgentType>,
-) {
-    let ws = ctx.db.world_state().id().find(0)
+pub fn spawn_entity(ctx: &ReducerContext, pos_x: f32, pos_y: f32, agent_type: Option<AgentType>) {
+    let ws = ctx
+        .db
+        .world_state()
+        .id()
+        .find(0)
         .expect("World not initialized — call create_world first");
 
     // Insert entity row (entity_id = 0 triggers auto_inc)
@@ -200,7 +201,11 @@ pub fn spawn_entity_full(
     vision_fov: f32,
     hearing_range: f32,
 ) {
-    let ws = ctx.db.world_state().id().find(0)
+    let ws = ctx
+        .db
+        .world_state()
+        .id()
+        .find(0)
         .expect("World not initialized");
 
     let entity = ctx.db.entity().insert(EntityRow {
@@ -325,10 +330,17 @@ pub fn connect_agent(
     let identity = ctx.sender;
 
     // Verify entity exists and is alive
-    let entity = ctx.db.entity().entity_id().find(entity_id)
+    let entity = ctx
+        .db
+        .entity()
+        .entity_id()
+        .find(entity_id)
         .expect("Entity not found");
     if !entity.alive {
-        reject_reducer(ctx, format!("connect_agent rejected: entity {entity_id} is dead"));
+        reject_reducer(
+            ctx,
+            format!("connect_agent rejected: entity {entity_id} is dead"),
+        );
         return;
     }
 
@@ -361,7 +373,12 @@ pub fn create_lobby(
 ) {
     let identity = ctx.sender;
 
-    let ws = ctx.db.world_state().id().find(0).expect("World not initialized");
+    let ws = ctx
+        .db
+        .world_state()
+        .id()
+        .find(0)
+        .expect("World not initialized");
     if max_players == 0 {
         reject_reducer(ctx, "create_lobby rejected: max_players must be at least 1");
         return;
@@ -387,25 +404,39 @@ pub fn create_lobby(
         is_ready: true,
     });
 
-    log::info!("[pod-stdb] Lobby {} created by {identity:?} as entity {host_entity_id}", lobby.lobby_id);
+    log::info!(
+        "[pod-stdb] Lobby {} created by {identity:?} as entity {host_entity_id}",
+        lobby.lobby_id
+    );
 }
 
 /// Join a lobby by ID.
 #[spacetimedb::reducer]
 pub fn join_lobby(ctx: &ReducerContext, lobby_id: u64, entity_id: u64) {
     let identity = ctx.sender;
-    let ws = ctx.db.world_state().id().find(0).expect("World not initialized");
+    let ws = ctx
+        .db
+        .world_state()
+        .id()
+        .find(0)
+        .expect("World not initialized");
 
     let lobby = match ctx.db.lobby().lobby_id().find(lobby_id) {
         Some(row) => row,
         None => {
-            reject_reducer(ctx, format!("join_lobby rejected: lobby {lobby_id} does not exist"));
+            reject_reducer(
+                ctx,
+                format!("join_lobby rejected: lobby {lobby_id} does not exist"),
+            );
             return;
         }
     };
 
     if lobby.started {
-        reject_reducer(ctx, format!("join_lobby rejected: lobby {lobby_id} already started"));
+        reject_reducer(
+            ctx,
+            format!("join_lobby rejected: lobby {lobby_id} already started"),
+        );
         return;
     }
 
@@ -423,7 +454,10 @@ pub fn join_lobby(ctx: &ReducerContext, lobby_id: u64, entity_id: u64) {
             .collect();
 
         if current_members.len() as u32 >= lobby.max_players {
-            reject_reducer(ctx, format!("join_lobby rejected: lobby {lobby_id} is full"));
+            reject_reducer(
+                ctx,
+                format!("join_lobby rejected: lobby {lobby_id} is full"),
+            );
             return;
         }
 
@@ -442,7 +476,12 @@ pub fn join_lobby(ctx: &ReducerContext, lobby_id: u64, entity_id: u64) {
 #[spacetimedb::reducer]
 pub fn leave_lobby(ctx: &ReducerContext) {
     let identity = ctx.sender;
-    for membership in ctx.db.lobby_member().iter().filter(|member| member.identity == identity) {
+    for membership in ctx
+        .db
+        .lobby_member()
+        .iter()
+        .filter(|member| member.identity == identity)
+    {
         ctx.db
             .lobby_member()
             .membership_id()
@@ -456,9 +495,12 @@ pub fn set_lobby_ready(ctx: &ReducerContext, lobby_id: u64, is_ready: bool) {
     let identity = ctx.sender;
     let mut updated = false;
 
-    if let Some(mut member) = ctx.db.lobby_member().iter().find(|member| {
-        member.identity == identity && member.lobby_id == lobby_id
-    }) {
+    if let Some(mut member) = ctx
+        .db
+        .lobby_member()
+        .iter()
+        .find(|member| member.identity == identity && member.lobby_id == lobby_id)
+    {
         member.is_ready = is_ready;
         ctx.db.lobby_member().membership_id().update(member);
         updated = true;
@@ -480,7 +522,10 @@ pub fn start_lobby(ctx: &ReducerContext, lobby_id: u64) {
     let mut lobby = match ctx.db.lobby().lobby_id().find(lobby_id) {
         Some(row) => row,
         None => {
-            reject_reducer(ctx, format!("start_lobby rejected: lobby {lobby_id} does not exist"));
+            reject_reducer(
+                ctx,
+                format!("start_lobby rejected: lobby {lobby_id} does not exist"),
+            );
             return;
         }
     };
@@ -513,10 +558,19 @@ pub fn join_match_queue(ctx: &ReducerContext, entity_id: u64, desired_party_size
     }
 
     let identity = ctx.sender;
-    let ws = ctx.db.world_state().id().find(0).expect("World not initialized");
+    let ws = ctx
+        .db
+        .world_state()
+        .id()
+        .find(0)
+        .expect("World not initialized");
 
     // Validate entity exists and is alive.
-    let entity = ctx.db.entity().entity_id().find(entity_id)
+    let entity = ctx
+        .db
+        .entity()
+        .entity_id()
+        .find(entity_id)
         .expect("Entity not found");
     if !entity.alive {
         reject_reducer(
@@ -527,9 +581,12 @@ pub fn join_match_queue(ctx: &ReducerContext, entity_id: u64, desired_party_size
     }
 
     // Prevent duplicate queue entries for same identity/entity pair.
-    if ctx.db.match_queue().iter().any(|row| {
-        row.identity == identity && row.entity_id == entity_id
-    }) {
+    if ctx
+        .db
+        .match_queue()
+        .iter()
+        .any(|row| row.identity == identity && row.entity_id == entity_id)
+    {
         reject_reducer(
             ctx,
             format!(
@@ -547,7 +604,9 @@ pub fn join_match_queue(ctx: &ReducerContext, entity_id: u64, desired_party_size
         queued_at_tick: ws.tick,
     });
 
-    log::info!("[pod-stdb] {identity:?} queued entity {entity_id} for party size {desired_party_size}");
+    log::info!(
+        "[pod-stdb] {identity:?} queued entity {entity_id} for party size {desired_party_size}"
+    );
 }
 
 /// Remove all queue entries for the calling identity.
@@ -594,7 +653,12 @@ pub fn create_match_from_queue(ctx: &ReducerContext, desired_party_size: u32) {
         return;
     }
 
-    let ws = ctx.db.world_state().id().find(0).expect("World not initialized");
+    let ws = ctx
+        .db
+        .world_state()
+        .id()
+        .find(0)
+        .expect("World not initialized");
 
     let mut candidates: Vec<(u64, Identity, u64)> = Vec::new();
     for row in ctx.db.match_queue().iter() {
@@ -675,7 +739,11 @@ pub fn submit_action(
     signal_data: Option<String>,
     prefab: Option<String>,
 ) {
-    let ws = ctx.db.world_state().id().find(0)
+    let ws = ctx
+        .db
+        .world_state()
+        .id()
+        .find(0)
         .expect("World not initialized");
 
     ctx.db.action_submission().insert(ActionSubmissionRow {
@@ -714,7 +782,11 @@ pub fn submit_action(
 ///   6. Advance tick counter
 #[spacetimedb::reducer]
 pub fn execute_tick(ctx: &ReducerContext) {
-    let mut ws = ctx.db.world_state().id().find(0)
+    let mut ws = ctx
+        .db
+        .world_state()
+        .id()
+        .find(0)
         .expect("World not initialized");
 
     if ws.paused {
@@ -859,6 +931,98 @@ pub fn execute_tick(ctx: &ReducerContext) {
                     }
                 }
             }
+            ActionKind::CaptureCreature => {
+                let Some(target_id) = submission.target_entity_id else {
+                    continue;
+                };
+                let tool_slot = submission
+                    .ability_slot
+                    .map(|slot| slot.to_string())
+                    .unwrap_or_else(|| "null".to_string());
+                ctx.db.world_event().insert(WorldEventRow {
+                    event_id: 0,
+                    tick: current_tick,
+                    event_kind: WorldEventKind::AbilityUsed,
+                    entity_id: eid,
+                    secondary_entity_id: Some(target_id),
+                    data_json: format!(r#"{{"type":"capture_creature","tool_slot":{tool_slot}}}"#),
+                });
+            }
+            ActionKind::SummonCompanion => {
+                let slot = submission.ability_slot.unwrap_or(0);
+                ctx.db.world_event().insert(WorldEventRow {
+                    event_id: 0,
+                    tick: current_tick,
+                    event_kind: WorldEventKind::AbilityUsed,
+                    entity_id: eid,
+                    secondary_entity_id: None,
+                    data_json: format!(r#"{{"type":"summon_companion","slot":{slot}}}"#),
+                });
+            }
+            ActionKind::CommandCompanion => {
+                let slot = submission.ability_slot.unwrap_or(0);
+                let command = submission
+                    .signal_type
+                    .clone()
+                    .unwrap_or_else(|| "follow".to_string())
+                    .replace('"', "\\\"");
+                let target_id = submission
+                    .target_entity_id
+                    .map(|target| target.to_string())
+                    .unwrap_or_else(|| "null".to_string());
+                ctx.db.world_event().insert(WorldEventRow {
+                    event_id: 0,
+                    tick: current_tick,
+                    event_kind: WorldEventKind::AbilityUsed,
+                    entity_id: eid,
+                    secondary_entity_id: submission.target_entity_id,
+                    data_json: format!(
+                        r#"{{"type":"command_companion","slot":{slot},"command":"{command}","target":{target_id}}}"#
+                    ),
+                });
+            }
+            ActionKind::GatherResource => {
+                let Some(target_id) = submission.target_entity_id else {
+                    continue;
+                };
+                let skill = submission
+                    .signal_type
+                    .clone()
+                    .unwrap_or_else(|| "gather".to_string())
+                    .replace('"', "\\\"");
+                ctx.db.world_event().insert(WorldEventRow {
+                    event_id: 0,
+                    tick: current_tick,
+                    event_kind: WorldEventKind::AbilityUsed,
+                    entity_id: eid,
+                    secondary_entity_id: Some(target_id),
+                    data_json: format!(r#"{{"type":"gather_resource","skill":"{skill}"}}"#),
+                });
+            }
+            ActionKind::Loot => {
+                let Some(target_id) = submission.target_entity_id else {
+                    continue;
+                };
+                ctx.db.world_event().insert(WorldEventRow {
+                    event_id: 0,
+                    tick: current_tick,
+                    event_kind: WorldEventKind::ItemPickedUp,
+                    entity_id: eid,
+                    secondary_entity_id: Some(target_id),
+                    data_json: r#"{"type":"loot"}"#.to_string(),
+                });
+            }
+            ActionKind::SetAutoRetaliate => {
+                let enabled = submission.signal_data.as_deref() == Some("true");
+                ctx.db.world_event().insert(WorldEventRow {
+                    event_id: 0,
+                    tick: current_tick,
+                    event_kind: WorldEventKind::AbilityUsed,
+                    entity_id: eid,
+                    secondary_entity_id: None,
+                    data_json: format!(r#"{{"type":"set_auto_retaliate","enabled":{enabled}}}"#),
+                });
+            }
             ActionKind::Interact => {
                 if let Some(target_id) = find_interaction_target(ctx, eid) {
                     ctx.db.world_event().insert(WorldEventRow {
@@ -932,7 +1096,9 @@ pub fn execute_tick(ctx: &ReducerContext) {
                 });
             }
             ActionKind::Speak => {
-                if let (Some(msg), Some(vol)) = (submission.message.clone(), submission.volume.clone()) {
+                if let (Some(msg), Some(vol)) =
+                    (submission.message.clone(), submission.volume.clone())
+                {
                     if let Some(tf) = ctx.db.transform().entity_id().find(eid) {
                         ctx.db.speech_event().insert(SpeechEventRow {
                             event_id: 0,
@@ -947,7 +1113,9 @@ pub fn execute_tick(ctx: &ReducerContext) {
                 }
             }
             ActionKind::Signal => {
-                let signal_type = submission.signal_type.unwrap_or_else(|| "signal".to_string());
+                let signal_type = submission
+                    .signal_type
+                    .unwrap_or_else(|| "signal".to_string());
                 let signal_data = submission.signal_data.unwrap_or_default();
                 let escaped_type = signal_type.replace('"', "\\\"");
                 let escaped_data = signal_data.replace('"', "\\\"");
@@ -959,15 +1127,16 @@ pub fn execute_tick(ctx: &ReducerContext) {
                     secondary_entity_id: None,
                     data_json: format!(
                         r#"{{"signal_type":"{}","signal_data":"{}"}}"#,
-                        escaped_type,
-                        escaped_data
+                        escaped_type, escaped_data
                     ),
                 });
             }
             ActionKind::Spawn => {
-                if let (Some(prefab), Some(x), Some(y)) =
-                    (submission.prefab.clone(), submission.target_x, submission.target_y)
-                {
+                if let (Some(prefab), Some(x), Some(y)) = (
+                    submission.prefab.clone(),
+                    submission.target_x,
+                    submission.target_y,
+                ) {
                     let created = ctx.db.entity().insert(EntityRow {
                         entity_id: 0,
                         agent_type: None,

--- a/crates/pod-stdb/src/types.rs
+++ b/crates/pod-stdb/src/types.rs
@@ -73,15 +73,21 @@ pub enum ActionKind {
     Attack,
     AttackTarget,
     UseAbility,
+    CaptureCreature,
+    SummonCompanion,
+    CommandCompanion,
     // Interaction
     Interact,
     InteractWith,
     Pickup,
     Drop,
     UseItem,
+    GatherResource,
+    Loot,
     // Communication
     Speak,
     Signal,
+    SetAutoRetaliate,
     // Meta
     Idle,
     Spawn,


### PR DESCRIPTION
## Summary
- add MMO gameplay verbs for capture, summon, companion commands, gathering, looting, and auto-retaliate
- execute those verbs in `pod-core` with deterministic tests for combat cadence, capture, summon, gathering, and loot flows
- mirror the new verbs through the parser, network transport, and SpacetimeDB client/reducer action surfaces

## Testing
- cargo check -p pod-core -p pod-agents -p pod-net -p pod-stdb
- cargo test -p pod-core --lib
- cargo test -p pod-agents --lib
- cargo test -p pod-net --lib
- cargo test -p pod-stdb --lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added creature capture mechanic with tool slot support
  * Introduced companion summoning and command system (attack, follow, guard, recall)
  * Implemented resource gathering with skill progression
  * Added loot container system with item and coin collection
  * Enabled auto-retaliate toggle for combat automation
  * Extended action parsing to support MMO verbs and new companion interactions

* **Documentation**
  * Updated iteration planning with Iteration 48 MMO gameplay parity focus

<!-- end of auto-generated comment: release notes by coderabbit.ai -->