### PR TITLE
Add shared simulation reconciliation foundation

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -389,5 +389,14 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cargo test -p pod-net --lib`
   - `cargo test -p pod-stdb --lib`
 
-**Last updated**: Iteration 48
-**Current focus**: Phase 1 MMO action validation and Phase 3 authority parity for the RuneScape-style MMO + companion-creature vertical slice
+### Iteration 49 — Shared Simulation Reconciliation Foundation
+
+- [x] Extended `pod-net` snapshots with deterministic authoritative digests, explicit full-snapshot recovery markers, and replayable predicted action batches so direct-connect clients can detect divergence and rebuild from a known-good baseline.
+- [x] Updated the direct-connect wire contract to include controlled-entity assignment on `Welcome` plus per-client acknowledged action ticks on authoritative state updates.
+- [x] Split native and web direct-connect clients into authoritative vs predicted snapshot tracking, preserving unacknowledged local action batches and replaying them after authoritative correction instead of patching deltas directly onto predicted state.
+- [x] Added deterministic `pod-net` tests for stable snapshot digests, predicted movement replay, and full-snapshot/baseline handling during authoritative update application.
+- [x] Validated touched crate:
+  - `cargo test -p pod-net --lib`
+
+**Last updated**: Iteration 49
+**Current focus**: Phase 3 authority parity and shared-simulation recovery for the RuneScape-style MMO + companion-creature vertical slice

--- a/crates/pod-net/src/client_native.rs
+++ b/crates/pod-net/src/client_native.rs
@@ -16,7 +16,9 @@ use pod_core::Action;
 use crate::protocol::{
     ClientConfig as ProtoClientConfig, ClientId, ClientMessage, ReconnectToken, ServerMessage,
 };
-use crate::snapshot::WorldSnapshot;
+use crate::snapshot::{
+    apply_authoritative_update, PredictedActionBatch, ReconciliationReport, WorldSnapshot,
+};
 
 // ============================================================
 // NATIVE CLIENT
@@ -35,16 +37,26 @@ pub struct NativeClient {
     reader_task: Option<tokio::task::JoinHandle<()>>,
     /// Buffered server updates
     pending_updates: Vec<ServerMessage>,
+    /// Authoritative world state as last confirmed by the server.
+    authoritative_snapshot: Option<WorldSnapshot>,
     /// Local prediction world state
     local_snapshot: Option<WorldSnapshot>,
+    /// Entity controlled by this client, if one has been assigned by the server.
+    controlled_entity: Option<u64>,
     /// Actions pending transmission
     pending_actions: Vec<Action>,
+    /// Sent but not yet acknowledged action batches.
+    prediction_history: Vec<PredictedActionBatch>,
     /// Highest server tick applied locally.
     last_server_tick: u64,
+    /// Highest action tick acknowledged by the server.
+    last_acknowledged_action_tick: Option<u64>,
     /// Highest event tick accepted from server.
     last_event_tick: u64,
     /// Reconnect token issued by server on first successful connect.
     reconnect_token: Option<ReconnectToken>,
+    /// Last authoritative reconciliation outcome.
+    last_reconciliation: Option<ReconciliationReport>,
 }
 
 impl NativeClient {
@@ -67,11 +79,14 @@ impl NativeClient {
         } else {
             let mut roots = rustls::RootCertStore::empty();
             if let Ok(path) = std::env::var("POD_TRUSTED_CERT_DER") {
-                let cert_der = std::fs::read(&path)
-                    .map_err(|e| ClientError::Config(format!("Failed reading POD_TRUSTED_CERT_DER: {e}")))?;
+                let cert_der = std::fs::read(&path).map_err(|e| {
+                    ClientError::Config(format!("Failed reading POD_TRUSTED_CERT_DER: {e}"))
+                })?;
                 roots
                     .add(rustls::pki_types::CertificateDer::from(cert_der))
-                    .map_err(|e| ClientError::Config(format!("Invalid trusted DER certificate: {e}")))?;
+                    .map_err(|e| {
+                        ClientError::Config(format!("Invalid trusted DER certificate: {e}"))
+                    })?;
             } else {
                 return Err(ClientError::Config(
                     "TLS verification requires POD_TRUSTED_CERT_DER to point to a trusted server certificate (DER).".into(),
@@ -117,11 +132,16 @@ impl NativeClient {
             tx,
             reader_task: None,
             pending_updates: Vec::new(),
+            authoritative_snapshot: None,
             local_snapshot: None,
+            controlled_entity: None,
             pending_actions: Vec::new(),
+            prediction_history: Vec::new(),
             last_server_tick: 0,
+            last_acknowledged_action_tick: None,
             last_event_tick: 0,
             reconnect_token: None,
+            last_reconciliation: None,
         };
 
         // Send connect message
@@ -151,12 +171,32 @@ impl NativeClient {
             if let ServerMessage::Welcome {
                 client_id,
                 reconnect_token,
+                controlled_entity,
+                authoritative_digest,
                 snapshot,
                 ..
-            } = msg {
+            } = msg
+            {
                 self.client_id = Some(client_id);
+                self.controlled_entity = controlled_entity;
+                self.authoritative_snapshot = Some(snapshot.clone());
                 self.local_snapshot = Some(snapshot);
                 self.reconnect_token = Some(reconnect_token);
+                self.prediction_history.clear();
+                self.last_acknowledged_action_tick = None;
+                self.last_reconciliation = Some(ReconciliationReport {
+                    authoritative_tick: self
+                        .local_snapshot
+                        .as_ref()
+                        .map(|snapshot| snapshot.tick)
+                        .unwrap_or_default(),
+                    authoritative_digest,
+                    acknowledged_action_tick: None,
+                    pending_action_batches: 0,
+                    replayed_action_count: 0,
+                    predicted_digest: self.local_snapshot.as_ref().map(WorldSnapshot::digest),
+                    used_hard_resync: false,
+                });
                 debug!("Received welcome from server, client_id: {}", client_id.0);
                 Ok(())
             } else if let ServerMessage::Rejected { reason } = msg {
@@ -217,7 +257,8 @@ impl NativeClient {
             .as_ref()
             .ok_or_else(|| ClientError::NotConnected)?;
 
-        let bytes = msg.encode()
+        let bytes = msg
+            .encode()
             .map_err(|e| ClientError::Serialization(e.to_string()))?;
 
         let mut send = connection
@@ -256,8 +297,8 @@ impl NativeClient {
 
         buf.truncate(n);
 
-        let msg = ServerMessage::decode(&buf)
-            .map_err(|e| ClientError::Serialization(e.to_string()))?;
+        let msg =
+            ServerMessage::decode(&buf).map_err(|e| ClientError::Serialization(e.to_string()))?;
 
         Ok(msg)
     }
@@ -273,12 +314,21 @@ impl NativeClient {
             return Ok(());
         }
 
+        let actions = std::mem::take(&mut self.pending_actions);
         let msg = ClientMessage::ActionBatch {
             tick,
-            actions: std::mem::take(&mut self.pending_actions),
+            actions: actions.clone(),
         };
 
-        self.send_message(msg).await
+        if let Err(err) = self.send_message(msg).await {
+            self.pending_actions = actions;
+            return Err(err);
+        }
+
+        self.prediction_history
+            .push(PredictedActionBatch { tick, actions });
+        self.rebuild_predicted_snapshot();
+        Ok(())
     }
 
     /// Check for updates from the server (non-blocking)
@@ -298,32 +348,77 @@ impl NativeClient {
                 client_id,
                 reconnect_token,
                 tick,
+                controlled_entity,
+                authoritative_digest,
                 snapshot,
             } => {
                 self.client_id = Some(*client_id);
+                self.controlled_entity = *controlled_entity;
+                self.authoritative_snapshot = Some(snapshot.clone());
                 self.local_snapshot = Some(snapshot.clone());
+                self.prediction_history.clear();
+                self.last_acknowledged_action_tick = None;
                 self.last_server_tick = *tick;
                 self.last_event_tick = *tick;
                 self.reconnect_token = Some(*reconnect_token);
+                self.last_reconciliation = Some(ReconciliationReport {
+                    authoritative_tick: *tick,
+                    authoritative_digest: *authoritative_digest,
+                    acknowledged_action_tick: None,
+                    pending_action_batches: 0,
+                    replayed_action_count: 0,
+                    predicted_digest: self.local_snapshot.as_ref().map(WorldSnapshot::digest),
+                    used_hard_resync: false,
+                });
                 true
             }
-            ServerMessage::StateDelta { tick, delta } => {
+            ServerMessage::StateDelta {
+                tick,
+                acknowledged_action_tick,
+                authoritative_digest,
+                is_full_snapshot,
+                delta,
+            } => {
                 if *tick < self.last_server_tick {
                     return false;
                 }
 
-                if self.last_server_tick > 0 && *tick > self.last_server_tick + 1 {
+                let gap_detected = self.last_server_tick > 0 && *tick > self.last_server_tick + 1;
+                if gap_detected && !*is_full_snapshot {
+                    self.authoritative_snapshot = None;
                     self.local_snapshot = None;
+                    self.record_reconciliation(*tick, *authoritative_digest, true);
+                    return false;
                 }
 
-                self.local_snapshot = Some(match self.local_snapshot.take() {
-                    Some(snapshot) => delta.apply_to(&snapshot),
-                    None => WorldSnapshot {
-                        tick: *tick,
-                        entities: delta.updated.clone(),
-                    },
-                });
+                let previous = if *is_full_snapshot || gap_detected {
+                    None
+                } else {
+                    self.authoritative_snapshot.as_ref()
+                };
+
+                let authoritative_snapshot = match apply_authoritative_update(
+                    previous,
+                    *tick,
+                    *is_full_snapshot,
+                    delta,
+                    *authoritative_digest,
+                ) {
+                    Ok(snapshot) => snapshot,
+                    Err(err) => {
+                        error!("Authoritative update rejected at tick {}: {:?}", tick, err);
+                        self.authoritative_snapshot = None;
+                        self.local_snapshot = None;
+                        self.record_reconciliation(*tick, *authoritative_digest, true);
+                        return false;
+                    }
+                };
+
+                self.authoritative_snapshot = Some(authoritative_snapshot);
+                self.prune_acknowledged_predictions(*acknowledged_action_tick);
+                self.rebuild_predicted_snapshot();
                 self.last_server_tick = *tick;
+                self.record_reconciliation(*tick, *authoritative_digest, gap_detected);
                 true
             }
             ServerMessage::EventBatch { tick, .. } => {
@@ -382,6 +477,21 @@ impl NativeClient {
         self.local_snapshot.as_ref()
     }
 
+    /// Get the last authoritative world snapshot confirmed by the server.
+    pub fn authoritative_snapshot(&self) -> Option<&WorldSnapshot> {
+        self.authoritative_snapshot.as_ref()
+    }
+
+    /// Get the most recent reconciliation report.
+    pub fn last_reconciliation(&self) -> Option<&ReconciliationReport> {
+        self.last_reconciliation.as_ref()
+    }
+
+    /// Get the number of unacknowledged predicted action batches.
+    pub fn pending_prediction_batches(&self) -> usize {
+        self.prediction_history.len()
+    }
+
     /// Get the client ID
     pub fn client_id(&self) -> Option<ClientId> {
         self.client_id
@@ -390,6 +500,48 @@ impl NativeClient {
     /// Check if connected
     pub fn is_connected(&self) -> bool {
         self.connection.is_some() && self.client_id.is_some()
+    }
+
+    fn prune_acknowledged_predictions(&mut self, acknowledged_action_tick: Option<u64>) {
+        let Some(acknowledged_action_tick) = acknowledged_action_tick else {
+            return;
+        };
+
+        let acknowledged_action_tick = self
+            .last_acknowledged_action_tick
+            .map(|last| last.max(acknowledged_action_tick))
+            .unwrap_or(acknowledged_action_tick);
+        self.last_acknowledged_action_tick = Some(acknowledged_action_tick);
+        self.prediction_history
+            .retain(|batch| batch.tick > acknowledged_action_tick);
+    }
+
+    fn rebuild_predicted_snapshot(&mut self) {
+        self.local_snapshot = self.authoritative_snapshot.as_ref().map(|snapshot| {
+            snapshot.replay_predicted_actions(self.controlled_entity, &self.prediction_history)
+        });
+    }
+
+    fn record_reconciliation(
+        &mut self,
+        authoritative_tick: u64,
+        authoritative_digest: u64,
+        used_hard_resync: bool,
+    ) {
+        let replayed_action_count = self
+            .prediction_history
+            .iter()
+            .map(|batch| batch.actions.len())
+            .sum();
+        self.last_reconciliation = Some(ReconciliationReport {
+            authoritative_tick,
+            authoritative_digest,
+            acknowledged_action_tick: self.last_acknowledged_action_tick,
+            pending_action_batches: self.prediction_history.len(),
+            replayed_action_count,
+            predicted_digest: self.local_snapshot.as_ref().map(WorldSnapshot::digest),
+            used_hard_resync,
+        });
     }
 }
 

--- a/crates/pod-net/src/client_stdb.rs
+++ b/crates/pod-net/src/client_stdb.rs
@@ -510,6 +510,8 @@ impl SpacetimeDBClient {
                                 client_id,
                                 reconnect_token: self.reconnect_token,
                                 tick,
+                                controlled_entity: None,
+                                authoritative_digest: snapshot.digest(),
                                 snapshot,
                             });
                         }
@@ -537,9 +539,17 @@ impl SpacetimeDBClient {
                             continue;
                         }
                         self.upsert_local_snapshot(tick, &snap);
+                        let authoritative_digest = self
+                            .local_snapshot
+                            .as_ref()
+                            .map(WorldSnapshot::digest)
+                            .unwrap_or_default();
 
                         messages.push(ServerMessage::StateDelta {
                             tick,
+                            acknowledged_action_tick: None,
+                            authoritative_digest,
+                            is_full_snapshot: false,
                             delta: StateDelta {
                                 tick,
                                 updated: vec![snap],
@@ -558,9 +568,17 @@ impl SpacetimeDBClient {
                         local.tick = tick;
                         local.entities.retain(|e| e.id != entity_id);
                     }
+                    let authoritative_digest = self
+                        .local_snapshot
+                        .as_ref()
+                        .map(WorldSnapshot::digest)
+                        .unwrap_or_default();
 
                     messages.push(ServerMessage::StateDelta {
                         tick,
+                        acknowledged_action_tick: None,
+                        authoritative_digest,
+                        is_full_snapshot: false,
                         delta: StateDelta {
                             tick,
                             updated: vec![],

--- a/crates/pod-net/src/client_web.rs
+++ b/crates/pod-net/src/client_web.rs
@@ -14,7 +14,9 @@ use web_sys::WebSocket;
 use pod_core::Action;
 
 use crate::protocol::{ClientConfig, ClientId, ClientMessage, ReconnectToken, ServerMessage};
-use crate::snapshot::WorldSnapshot;
+use crate::snapshot::{
+    apply_authoritative_update, PredictedActionBatch, ReconciliationReport, WorldSnapshot,
+};
 
 #[derive(Debug, Default)]
 struct WebRuntimeState {
@@ -31,16 +33,26 @@ pub struct WebClient {
     /// Buffered server updates
     pending_updates: Arc<Mutex<Vec<ServerMessage>>>,
     runtime_state: Arc<Mutex<WebRuntimeState>>,
+    /// Authoritative world state as last confirmed by the server.
+    authoritative_snapshot: Option<WorldSnapshot>,
     /// Local prediction world state
     local_snapshot: Option<WorldSnapshot>,
+    /// Entity controlled by this client, if assigned by the server.
+    controlled_entity: Option<u64>,
     /// Actions pending transmission
     pending_actions: Vec<Action>,
+    /// Sent but not yet acknowledged action batches.
+    prediction_history: Vec<PredictedActionBatch>,
     /// Highest server tick applied locally.
     last_server_tick: u64,
+    /// Highest action tick acknowledged by the server.
+    last_acknowledged_action_tick: Option<u64>,
     /// Highest event tick accepted from server.
     last_event_tick: u64,
     /// Reconnect token issued by server and reused across reconnects.
     reconnect_token: Option<ReconnectToken>,
+    /// Last authoritative reconciliation outcome.
+    last_reconciliation: Option<ReconciliationReport>,
     reconnect_attempts: u32,
     next_reconnect_at_ms: f64,
 }
@@ -57,11 +69,16 @@ impl WebClient {
             connected: false,
             pending_updates,
             runtime_state,
+            authoritative_snapshot: None,
             local_snapshot: None,
+            controlled_entity: None,
             pending_actions: Vec::new(),
+            prediction_history: Vec::new(),
             last_server_tick: 0,
+            last_acknowledged_action_tick: None,
             last_event_tick: 0,
             reconnect_token: None,
+            last_reconciliation: None,
             reconnect_attempts: 0,
             next_reconnect_at_ms: 0.0,
         };
@@ -176,8 +193,8 @@ impl WebClient {
             return Err(ClientError::NotConnected);
         }
 
-        let json = serde_json::to_string(&msg)
-            .map_err(|e| ClientError::Serialization(e.to_string()))?;
+        let json =
+            serde_json::to_string(&msg).map_err(|e| ClientError::Serialization(e.to_string()))?;
 
         websocket
             .send_with_str(&json)
@@ -206,12 +223,21 @@ impl WebClient {
             return Ok(());
         }
 
+        let actions = std::mem::take(&mut self.pending_actions);
         let msg = ClientMessage::ActionBatch {
             tick,
-            actions: std::mem::take(&mut self.pending_actions),
+            actions: actions.clone(),
         };
 
-        self.send_message(msg)
+        if let Err(err) = self.send_message(msg) {
+            self.pending_actions = actions;
+            return Err(err);
+        }
+
+        self.prediction_history
+            .push(PredictedActionBatch { tick, actions });
+        self.rebuild_predicted_snapshot();
+        Ok(())
     }
 
     /// Check for updates from the server (non-blocking)
@@ -241,36 +267,82 @@ impl WebClient {
                 client_id,
                 reconnect_token,
                 tick,
+                controlled_entity,
+                authoritative_digest,
                 snapshot,
             } => {
                 self.client_id = Some(*client_id);
                 self.reconnect_token = Some(*reconnect_token);
+                self.controlled_entity = *controlled_entity;
+                self.authoritative_snapshot = Some(snapshot.clone());
                 self.local_snapshot = Some(snapshot.clone());
+                self.prediction_history.clear();
                 self.connected = true;
                 self.last_server_tick = *tick;
+                self.last_acknowledged_action_tick = None;
                 self.last_event_tick = *tick;
                 self.reconnect_attempts = 0;
+                self.last_reconciliation = Some(ReconciliationReport {
+                    authoritative_tick: *tick,
+                    authoritative_digest: *authoritative_digest,
+                    acknowledged_action_tick: None,
+                    pending_action_batches: 0,
+                    replayed_action_count: 0,
+                    predicted_digest: self.local_snapshot.as_ref().map(WorldSnapshot::digest),
+                    used_hard_resync: false,
+                });
                 true
             }
-            ServerMessage::StateDelta { tick, delta } => {
+            ServerMessage::StateDelta {
+                tick,
+                acknowledged_action_tick,
+                authoritative_digest,
+                is_full_snapshot,
+                delta,
+            } => {
                 if *tick < self.last_server_tick {
                     return false;
                 }
 
-                if self.last_server_tick > 0 && *tick > self.last_server_tick + 1 {
-                    // Gap detected; invalidate local prediction and rebuild from incoming stream.
+                let gap_detected = self.last_server_tick > 0 && *tick > self.last_server_tick + 1;
+                if gap_detected && !*is_full_snapshot {
+                    self.authoritative_snapshot = None;
                     self.local_snapshot = None;
+                    self.record_reconciliation(*tick, *authoritative_digest, true);
+                    return false;
                 }
 
-                self.local_snapshot = Some(match self.local_snapshot.take() {
-                    Some(snapshot) => delta.apply_to(&snapshot),
-                    None => WorldSnapshot {
-                        tick: *tick,
-                        entities: delta.updated.clone(),
-                    },
-                });
+                let previous = if *is_full_snapshot || gap_detected {
+                    None
+                } else {
+                    self.authoritative_snapshot.as_ref()
+                };
 
+                let authoritative_snapshot = match apply_authoritative_update(
+                    previous,
+                    *tick,
+                    *is_full_snapshot,
+                    delta,
+                    *authoritative_digest,
+                ) {
+                    Ok(snapshot) => snapshot,
+                    Err(err) => {
+                        web_sys::console::error_1(
+                            &format!("Authoritative update rejected at tick {}: {:?}", tick, err)
+                                .into(),
+                        );
+                        self.authoritative_snapshot = None;
+                        self.local_snapshot = None;
+                        self.record_reconciliation(*tick, *authoritative_digest, true);
+                        return false;
+                    }
+                };
+
+                self.authoritative_snapshot = Some(authoritative_snapshot);
+                self.prune_acknowledged_predictions(*acknowledged_action_tick);
+                self.rebuild_predicted_snapshot();
                 self.last_server_tick = *tick;
+                self.record_reconciliation(*tick, *authoritative_digest, gap_detected);
                 true
             }
             ServerMessage::EventBatch { tick, .. } => {
@@ -341,6 +413,21 @@ impl WebClient {
         self.local_snapshot.as_ref()
     }
 
+    /// Get the last authoritative world snapshot confirmed by the server.
+    pub fn authoritative_snapshot(&self) -> Option<&WorldSnapshot> {
+        self.authoritative_snapshot.as_ref()
+    }
+
+    /// Get the most recent reconciliation report.
+    pub fn last_reconciliation(&self) -> Option<&ReconciliationReport> {
+        self.last_reconciliation.as_ref()
+    }
+
+    /// Get the number of unacknowledged predicted action batches.
+    pub fn pending_prediction_batches(&self) -> usize {
+        self.prediction_history.len()
+    }
+
     /// Get the client ID
     pub fn client_id(&self) -> Option<ClientId> {
         self.client_id
@@ -359,8 +446,51 @@ impl WebClient {
     /// Update connection state (typically called after receiving Welcome)
     pub fn set_connected(&mut self, client_id: ClientId, snapshot: WorldSnapshot) {
         self.client_id = Some(client_id);
+        self.authoritative_snapshot = Some(snapshot.clone());
         self.local_snapshot = Some(snapshot);
         self.connected = true;
+    }
+
+    fn prune_acknowledged_predictions(&mut self, acknowledged_action_tick: Option<u64>) {
+        let Some(acknowledged_action_tick) = acknowledged_action_tick else {
+            return;
+        };
+
+        let acknowledged_action_tick = self
+            .last_acknowledged_action_tick
+            .map(|last| last.max(acknowledged_action_tick))
+            .unwrap_or(acknowledged_action_tick);
+        self.last_acknowledged_action_tick = Some(acknowledged_action_tick);
+        self.prediction_history
+            .retain(|batch| batch.tick > acknowledged_action_tick);
+    }
+
+    fn rebuild_predicted_snapshot(&mut self) {
+        self.local_snapshot = self.authoritative_snapshot.as_ref().map(|snapshot| {
+            snapshot.replay_predicted_actions(self.controlled_entity, &self.prediction_history)
+        });
+    }
+
+    fn record_reconciliation(
+        &mut self,
+        authoritative_tick: u64,
+        authoritative_digest: u64,
+        used_hard_resync: bool,
+    ) {
+        let replayed_action_count = self
+            .prediction_history
+            .iter()
+            .map(|batch| batch.actions.len())
+            .sum();
+        self.last_reconciliation = Some(ReconciliationReport {
+            authoritative_tick,
+            authoritative_digest,
+            acknowledged_action_tick: self.last_acknowledged_action_tick,
+            pending_action_batches: self.prediction_history.len(),
+            replayed_action_count,
+            predicted_digest: self.local_snapshot.as_ref().map(WorldSnapshot::digest),
+            used_hard_resync,
+        });
     }
 }
 

--- a/crates/pod-net/src/lib.rs
+++ b/crates/pod-net/src/lib.rs
@@ -63,8 +63,13 @@ pub mod client_web;
 pub mod client_stdb;
 
 // Re-export common types
-pub use protocol::{ClientConfig, ClientId, ClientMessage, ReconnectToken, ServerConfig, ServerMessage};
-pub use snapshot::{EntitySnapshot, StateDelta, WorldSnapshot};
+pub use protocol::{
+    ClientConfig, ClientId, ClientMessage, ReconnectToken, ServerConfig, ServerMessage,
+};
+pub use snapshot::{
+    apply_authoritative_update, EntitySnapshot, PredictedActionBatch, ReconciliationReport,
+    SnapshotUpdateError, StateDelta, WorldSnapshot,
+};
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use server::{GameServer, ServerError};

--- a/crates/pod-net/src/protocol.rs
+++ b/crates/pod-net/src/protocol.rs
@@ -53,20 +53,13 @@ pub enum ClientMessage {
     },
 
     /// Request to disconnect from the server
-    Disconnect {
-        reason: Option<String>,
-    },
+    Disconnect { reason: Option<String> },
 
     /// Batch of actions for a specific tick
-    ActionBatch {
-        tick: u64,
-        actions: Vec<Action>,
-    },
+    ActionBatch { tick: u64, actions: Vec<Action> },
 
     /// Ping request — measures round-trip time
-    Ping {
-        timestamp: u64,
-    },
+    Ping { timestamp: u64 },
 }
 
 impl ClientMessage {
@@ -93,31 +86,28 @@ pub enum ServerMessage {
         client_id: ClientId,
         reconnect_token: ReconnectToken,
         tick: u64,
+        controlled_entity: Option<u64>,
+        authoritative_digest: u64,
         snapshot: super::snapshot::WorldSnapshot,
     },
 
     /// Delta update — only changed state since last snapshot
     StateDelta {
         tick: u64,
+        acknowledged_action_tick: Option<u64>,
+        authoritative_digest: u64,
+        is_full_snapshot: bool,
         delta: super::snapshot::StateDelta,
     },
 
     /// Batch of game events
-    EventBatch {
-        tick: u64,
-        events: Vec<GameEvent>,
-    },
+    EventBatch { tick: u64, events: Vec<GameEvent> },
 
     /// Response to ping request
-    Pong {
-        client_ts: u64,
-        server_ts: u64,
-    },
+    Pong { client_ts: u64, server_ts: u64 },
 
     /// Connection rejected
-    Rejected {
-        reason: String,
-    },
+    Rejected { reason: String },
 }
 
 impl ServerMessage {
@@ -243,6 +233,8 @@ mod tests {
             client_id: ClientId::new(),
             reconnect_token: ReconnectToken::new(),
             tick: 100,
+            controlled_entity: Some(42),
+            authoritative_digest: snapshot.digest(),
             snapshot,
         };
 
@@ -250,8 +242,13 @@ mod tests {
         let decoded = ServerMessage::decode_json(&json).unwrap();
 
         match decoded {
-            ServerMessage::Welcome { tick, .. } => {
+            ServerMessage::Welcome {
+                tick,
+                controlled_entity,
+                ..
+            } => {
                 assert_eq!(tick, 100);
+                assert_eq!(controlled_entity, Some(42));
             }
             _ => panic!("Wrong message type"),
         }

--- a/crates/pod-net/src/server.rs
+++ b/crates/pod-net/src/server.rs
@@ -31,6 +31,7 @@ struct ClientSession {
     pending_actions: Vec<(u64, Action)>, // (tick, action)
     reconnect_token: ReconnectToken,
     last_action_tick: Option<u64>,
+    last_processed_action_tick: Option<u64>,
 }
 
 impl ClientSession {
@@ -42,6 +43,7 @@ impl ClientSession {
             pending_actions: Vec::new(),
             reconnect_token: ReconnectToken::new(),
             last_action_tick: None,
+            last_processed_action_tick: None,
         }
     }
 }
@@ -109,8 +111,8 @@ impl GameServer {
 
     /// Initialize the server (bind to network)
     pub async fn initialize(&mut self) -> Result<(), Box<dyn std::error::Error>> {
-        let addr: SocketAddr = format!("{}:{}", self.config.bind_addr, self.config.bind_port)
-            .parse()?;
+        let addr: SocketAddr =
+            format!("{}:{}", self.config.bind_addr, self.config.bind_port).parse()?;
 
         // Generate self-signed certificate for QUIC (rcgen 0.13+ API)
         let cert_key = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])?;
@@ -149,8 +151,7 @@ impl GameServer {
 
     /// Main server loop — step the world and handle client connections
     pub async fn run(&mut self) -> Result<(), Box<dyn std::error::Error>> {
-        let tick_duration =
-            std::time::Duration::from_secs_f32(1.0 / self.config.tick_rate as f32);
+        let tick_duration = std::time::Duration::from_secs_f32(1.0 / self.config.tick_rate as f32);
 
         loop {
             let frame_start = std::time::Instant::now();
@@ -189,6 +190,7 @@ impl GameServer {
                     continue;
                 };
 
+                let mut last_processed_action_tick = None;
                 for (action_tick, action) in session.pending_actions.drain(..) {
                     let min_tick = self.tick.saturating_sub(ACTION_WINDOW_BACKWARD_TICKS);
                     let max_tick = self.tick + ACTION_WINDOW_FORWARD_TICKS;
@@ -196,6 +198,15 @@ impl GameServer {
                         continue;
                     }
                     self.world.submit_external_action(agent_id, action);
+                    last_processed_action_tick = Some(
+                        last_processed_action_tick
+                            .map(|current: u64| current.max(action_tick))
+                            .unwrap_or(action_tick),
+                    );
+                }
+
+                if last_processed_action_tick.is_some() {
+                    session.last_processed_action_tick = last_processed_action_tick;
                 }
             }
         }
@@ -203,8 +214,12 @@ impl GameServer {
         // Step the world
         self.world.step();
 
-        debug!("Tick {}: {} entities, {} agents", self.tick,
-               self.world.entity_count(), self.world.agent_count());
+        debug!(
+            "Tick {}: {} entities, {} agents",
+            self.tick,
+            self.world.entity_count(),
+            self.world.agent_count()
+        );
 
         Ok(())
     }
@@ -213,11 +228,12 @@ impl GameServer {
     async fn handle_connections(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         if let Some(endpoint) = &self.endpoint {
             loop {
-                let incoming = match tokio::time::timeout(Duration::from_millis(1), endpoint.accept()).await {
-                    Ok(Some(incoming)) => incoming,
-                    Ok(None) => break,
-                    Err(_) => break,
-                };
+                let incoming =
+                    match tokio::time::timeout(Duration::from_millis(1), endpoint.accept()).await {
+                        Ok(Some(incoming)) => incoming,
+                        Ok(None) => break,
+                        Err(_) => break,
+                    };
 
                 let connection = match incoming.await {
                     Ok(conn) => conn,
@@ -315,64 +331,63 @@ impl GameServer {
 
         while let Ok(packet) = self.inbound_rx.try_recv() {
             match packet {
-                InboundPacket::Message { client_id, message } => {
-                    match message {
-                        ClientMessage::Connect {
-                            player_name,
-                            reconnect_token,
-                        } => {
-                            self.attach_remote_agent(client_id, player_name, reconnect_token)
-                                .await?;
-                        }
-                        ClientMessage::ActionBatch { tick, actions } => {
-                            let mut overflow = false;
-                            let mut unregistered = false;
-                            let mut stale_tick = false;
-                            let mut out_of_window = false;
-                            let min_tick = self.tick.saturating_sub(ACTION_WINDOW_BACKWARD_TICKS);
-                            let max_tick = self.tick + ACTION_WINDOW_FORWARD_TICKS;
-                            {
-                                let mut clients = self.clients.write().await;
-                                if let Some(session) = clients.get_mut(&client_id) {
-                                    if session.agent_id.is_none() {
-                                        unregistered = true;
-                                    }
+                InboundPacket::Message { client_id, message } => match message {
+                    ClientMessage::Connect {
+                        player_name,
+                        reconnect_token,
+                    } => {
+                        self.attach_remote_agent(client_id, player_name, reconnect_token)
+                            .await?;
+                    }
+                    ClientMessage::ActionBatch { tick, actions } => {
+                        let mut overflow = false;
+                        let mut unregistered = false;
+                        let mut stale_tick = false;
+                        let mut out_of_window = false;
+                        let min_tick = self.tick.saturating_sub(ACTION_WINDOW_BACKWARD_TICKS);
+                        let max_tick = self.tick + ACTION_WINDOW_FORWARD_TICKS;
+                        {
+                            let mut clients = self.clients.write().await;
+                            if let Some(session) = clients.get_mut(&client_id) {
+                                if session.agent_id.is_none() {
+                                    unregistered = true;
+                                }
 
-                                    if !unregistered {
-                                        if tick < min_tick || tick > max_tick {
-                                            out_of_window = true;
-                                        } else if session
-                                            .last_action_tick
-                                            .map(|last| tick < last)
-                                            .unwrap_or(false)
-                                        {
-                                            stale_tick = true;
-                                        } else {
-                                            let available = ACTION_QUEUE_MAX_DEPTH
-                                                .saturating_sub(session.pending_actions.len());
-                                            if actions.len() > available {
-                                                overflow = true;
-                                            }
-                                            for action in actions.into_iter().take(available) {
-                                                session.pending_actions.push((tick, action));
-                                            }
-                                            session.last_action_tick = Some(tick);
+                                if !unregistered {
+                                    if tick < min_tick || tick > max_tick {
+                                        out_of_window = true;
+                                    } else if session
+                                        .last_action_tick
+                                        .map(|last| tick < last)
+                                        .unwrap_or(false)
+                                    {
+                                        stale_tick = true;
+                                    } else {
+                                        let available = ACTION_QUEUE_MAX_DEPTH
+                                            .saturating_sub(session.pending_actions.len());
+                                        if actions.len() > available {
+                                            overflow = true;
                                         }
+                                        for action in actions.into_iter().take(available) {
+                                            session.pending_actions.push((tick, action));
+                                        }
+                                        session.last_action_tick = Some(tick);
                                     }
                                 }
                             }
-                            if unregistered {
-                                self.send_to_client(
-                                    client_id,
-                                    ServerMessage::Rejected {
-                                        reason: "client must send Connect before action batches".into(),
-                                    },
-                                )
-                                .await;
-                                continue;
-                            }
-                            if out_of_window {
-                                self.send_to_client(
+                        }
+                        if unregistered {
+                            self.send_to_client(
+                                client_id,
+                                ServerMessage::Rejected {
+                                    reason: "client must send Connect before action batches".into(),
+                                },
+                            )
+                            .await;
+                            continue;
+                        }
+                        if out_of_window {
+                            self.send_to_client(
                                     client_id,
                                     ServerMessage::Rejected {
                                         reason: format!(
@@ -381,10 +396,10 @@ impl GameServer {
                                     },
                                 )
                                 .await;
-                                continue;
-                            }
-                            if stale_tick {
-                                self.send_to_client(
+                            continue;
+                        }
+                        if stale_tick {
+                            self.send_to_client(
                                     client_id,
                                     ServerMessage::Rejected {
                                         reason: format!(
@@ -393,39 +408,38 @@ impl GameServer {
                                     },
                                 )
                                 .await;
-                                continue;
-                            }
-                            if overflow {
-                                self.send_to_client(
-                                    client_id,
-                                    ServerMessage::Rejected {
-                                        reason: format!(
-                                            "action queue full (max depth={ACTION_QUEUE_MAX_DEPTH})"
-                                        ),
-                                    },
-                                )
-                                .await;
-                            }
+                            continue;
                         }
-                        ClientMessage::Ping { timestamp } => {
+                        if overflow {
                             self.send_to_client(
                                 client_id,
-                                ServerMessage::Pong {
-                                    client_ts: timestamp,
-                                    server_ts: self.tick,
+                                ServerMessage::Rejected {
+                                    reason: format!(
+                                        "action queue full (max depth={ACTION_QUEUE_MAX_DEPTH})"
+                                    ),
                                 },
                             )
                             .await;
                         }
-                        ClientMessage::Disconnect { reason } => {
-                            self.disconnect_client(
-                                client_id,
-                                reason.as_deref().unwrap_or("client requested disconnect"),
-                            )
-                            .await;
-                        }
                     }
-                }
+                    ClientMessage::Ping { timestamp } => {
+                        self.send_to_client(
+                            client_id,
+                            ServerMessage::Pong {
+                                client_ts: timestamp,
+                                server_ts: self.tick,
+                            },
+                        )
+                        .await;
+                    }
+                    ClientMessage::Disconnect { reason } => {
+                        self.disconnect_client(
+                            client_id,
+                            reason.as_deref().unwrap_or("client requested disconnect"),
+                        )
+                        .await;
+                    }
+                },
                 InboundPacket::Disconnected { client_id, reason } => {
                     self.disconnect_client(client_id, &reason).await;
                 }
@@ -438,11 +452,13 @@ impl GameServer {
     /// Broadcast world updates to all connected clients
     async fn broadcast_updates(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         // Decide whether to send full snapshot or delta
-        let should_snapshot = (self.tick - self.last_snapshot_tick)
-            >= self.config.snapshot_interval;
+        let should_snapshot =
+            (self.tick - self.last_snapshot_tick) >= self.config.snapshot_interval;
         let current_snapshot = WorldSnapshot::capture(&self.world);
+        let authoritative_digest = current_snapshot.digest();
 
-        let delta = if should_snapshot || self.last_snapshot.is_none() {
+        let is_full_snapshot = should_snapshot || self.last_snapshot.is_none();
+        let delta = if is_full_snapshot {
             StateDelta {
                 tick: self.tick,
                 updated: current_snapshot.entities.clone(),
@@ -463,9 +479,12 @@ impl GameServer {
 
         let clients = self.clients.read().await;
 
-        for client_id in clients.keys() {
+        for (client_id, session) in clients.iter() {
             let msg = ServerMessage::StateDelta {
                 tick: self.tick,
+                acknowledged_action_tick: session.last_processed_action_tick,
+                authoritative_digest,
+                is_full_snapshot,
                 delta: delta.clone(),
             };
             if let Some(tx) = self.client_tx.read().await.get(client_id) {
@@ -475,7 +494,7 @@ impl GameServer {
             }
         }
 
-        if should_snapshot {
+        if is_full_snapshot {
             self.last_snapshot_tick = self.tick;
         }
         self.last_snapshot = Some(current_snapshot);
@@ -545,6 +564,7 @@ impl GameServer {
                         session.player_name = prev.player_name;
                         session.agent_id = prev.agent_id;
                         session.last_action_tick = prev.last_action_tick;
+                        session.last_processed_action_tick = prev.last_processed_action_tick;
                         session.pending_actions.clear();
                     } else if session.player_name.is_none() {
                         session.player_name = Some(player_name.clone());
@@ -584,12 +604,29 @@ impl GameServer {
 
         if already_attached {
             let snapshot = WorldSnapshot::capture(&self.world);
+            let authoritative_digest = snapshot.digest();
+            let controlled_entity = self
+                .clients
+                .read()
+                .await
+                .get(&client_id)
+                .and_then(|session| session.agent_id)
+                .and_then(|agent_id| {
+                    self.world
+                        .agents
+                        .iter()
+                        .find(|slot| slot.agent.id() == agent_id)
+                        .and_then(|slot| slot.entity_id)
+                        .map(|entity| entity.id() as u64)
+                });
             self.send_to_client(
                 client_id,
                 ServerMessage::Welcome {
                     client_id,
                     reconnect_token,
                     tick: self.tick,
+                    controlled_entity,
+                    authoritative_digest,
                     snapshot,
                 },
             )
@@ -613,12 +650,15 @@ impl GameServer {
         }
 
         let snapshot = WorldSnapshot::capture(&self.world);
+        let authoritative_digest = snapshot.digest();
         self.send_to_client(
             client_id,
             ServerMessage::Welcome {
                 client_id,
                 reconnect_token,
                 tick: self.tick,
+                controlled_entity: Some(entity.id() as u64),
+                authoritative_digest,
                 snapshot,
             },
         )

--- a/crates/pod-net/src/snapshot.rs
+++ b/crates/pod-net/src/snapshot.rs
@@ -1,12 +1,18 @@
 //! World state serialization for network transmission.
 //!
-//! Handles capturing world snapshots and computing efficient deltas.
+//! Handles capturing world snapshots, computing efficient deltas, and
+//! replaying a deterministic subset of client-side prediction.
 
 use glam::Vec2;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use pod_core::{Transform, Velocity, Health, Label};
+use pod_core::{Action, Health, Label, Movement, Transform, Velocity};
+
+const FIXED_TICK_DURATION_SECS: f32 = 1.0 / 60.0;
+const DEFAULT_PREDICTION_MOVE_SPEED: f32 = 200.0;
+const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
+const FNV_PRIME: u64 = 0x100000001b3;
 
 /// A serializable snapshot of world state
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -32,6 +38,8 @@ pub struct EntitySnapshot {
     pub health: Option<f32>,
     /// Max health if applicable
     pub max_health: Option<f32>,
+    /// Movement speed if applicable.
+    pub movement_speed: Option<f32>,
     /// Entity label/name
     pub label: Option<String>,
 }
@@ -47,22 +55,51 @@ pub struct StateDelta {
     pub destroyed: Vec<u64>,
 }
 
+/// Tick-aligned locally predicted actions that have been sent to the server but
+/// not yet acknowledged by the authoritative simulation.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PredictedActionBatch {
+    pub tick: u64,
+    pub actions: Vec<Action>,
+}
+
+/// Result of reconciling local prediction against an authoritative update.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct ReconciliationReport {
+    pub authoritative_tick: u64,
+    pub authoritative_digest: u64,
+    pub acknowledged_action_tick: Option<u64>,
+    pub pending_action_batches: usize,
+    pub replayed_action_count: usize,
+    pub predicted_digest: Option<u64>,
+    pub used_hard_resync: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SnapshotUpdateError {
+    MissingBaseline {
+        tick: u64,
+    },
+    DigestMismatch {
+        tick: u64,
+        expected: u64,
+        actual: u64,
+    },
+}
+
 impl WorldSnapshot {
     /// Capture current world state into a snapshot
     pub fn capture(world: &pod_core::World) -> Self {
         let mut entities = Vec::new();
 
-        for (entity, (transform, velocity)) in world
-            .ecs
-            .query::<(&Transform, &Velocity)>()
-            .iter()
-        {
+        for (entity, (transform, velocity)) in world.ecs.query::<(&Transform, &Velocity)>().iter() {
             let id = entity.id();
             let health_opt = world.ecs.get::<&Health>(entity).ok();
             let label_opt = world.ecs.get::<&Label>(entity).ok();
 
             let health = health_opt.as_ref().map(|h| h.current);
             let max_health = health_opt.as_ref().map(|h| h.max);
+            let movement_speed = world.ecs.get::<&Movement>(entity).ok().map(|m| m.max_speed);
             let label = label_opt.map(|l| l.name.clone());
 
             entities.push(EntitySnapshot {
@@ -72,6 +109,7 @@ impl WorldSnapshot {
                 rotation: transform.rotation,
                 health,
                 max_health,
+                movement_speed,
                 label,
             });
         }
@@ -96,6 +134,65 @@ impl WorldSnapshot {
     /// Get entity count in snapshot
     pub fn entity_count(&self) -> usize {
         self.entities.len()
+    }
+
+    /// Stable digest for client/server divergence detection.
+    pub fn digest(&self) -> u64 {
+        let mut hash = FNV_OFFSET_BASIS;
+        hash_u64(&mut hash, self.tick);
+
+        let mut entities = self.entities.iter().collect::<Vec<_>>();
+        entities.sort_by_key(|entity| entity.id);
+
+        for entity in entities {
+            hash_u64(&mut hash, entity.id);
+            hash_f32(&mut hash, entity.position.x);
+            hash_f32(&mut hash, entity.position.y);
+            hash_f32(&mut hash, entity.velocity.x);
+            hash_f32(&mut hash, entity.velocity.y);
+            hash_f32(&mut hash, entity.rotation);
+            hash_option_f32(&mut hash, entity.health);
+            hash_option_f32(&mut hash, entity.max_health);
+            hash_option_f32(&mut hash, entity.movement_speed);
+            hash_option_str(&mut hash, entity.label.as_deref());
+        }
+
+        hash
+    }
+
+    /// Replays locally predicted action batches over an authoritative snapshot.
+    ///
+    /// This intentionally models a narrow shared-sim subset: kinematic movement,
+    /// stop, and facing updates for the locally controlled entity while advancing
+    /// all entities by their current velocities between ticks.
+    pub fn replay_predicted_actions(
+        &self,
+        controlled_entity: Option<u64>,
+        batches: &[PredictedActionBatch],
+    ) -> Self {
+        let mut predicted = self.clone();
+
+        for batch in batches {
+            if let Some(controlled_entity) = controlled_entity {
+                if let Some(entity) = predicted
+                    .entities
+                    .iter_mut()
+                    .find(|entity| entity.id == controlled_entity)
+                {
+                    for action in &batch.actions {
+                        apply_predicted_action(entity, action);
+                    }
+                }
+            }
+
+            for entity in &mut predicted.entities {
+                entity.position += entity.velocity * FIXED_TICK_DURATION_SECS;
+            }
+
+            predicted.tick = batch.tick;
+        }
+
+        predicted
     }
 }
 
@@ -175,7 +272,94 @@ fn entity_changed(old: &EntitySnapshot, new: &EntitySnapshot) -> bool {
         || old.velocity.distance(new.velocity) > EPSILON
         || (old.rotation - new.rotation).abs() > EPSILON
         || old.health != new.health
+        || old.max_health != new.max_health
+        || old.movement_speed != new.movement_speed
         || old.label != new.label
+}
+
+/// Applies an authoritative state update and validates its digest.
+pub fn apply_authoritative_update(
+    previous: Option<&WorldSnapshot>,
+    tick: u64,
+    is_full_snapshot: bool,
+    delta: &StateDelta,
+    authoritative_digest: u64,
+) -> Result<WorldSnapshot, SnapshotUpdateError> {
+    let snapshot = if is_full_snapshot {
+        WorldSnapshot {
+            tick,
+            entities: delta.updated.clone(),
+        }
+    } else {
+        let previous = previous.ok_or(SnapshotUpdateError::MissingBaseline { tick })?;
+        delta.apply_to(previous)
+    };
+
+    let actual_digest = snapshot.digest();
+    if actual_digest != authoritative_digest {
+        return Err(SnapshotUpdateError::DigestMismatch {
+            tick,
+            expected: authoritative_digest,
+            actual: actual_digest,
+        });
+    }
+
+    Ok(snapshot)
+}
+
+fn apply_predicted_action(entity: &mut EntitySnapshot, action: &Action) {
+    match action {
+        Action::Move { direction } => {
+            let speed = entity
+                .movement_speed
+                .unwrap_or(DEFAULT_PREDICTION_MOVE_SPEED);
+            entity.velocity = direction.normalize_or_zero() * speed;
+        }
+        Action::Stop => {
+            entity.velocity = Vec2::ZERO;
+        }
+        Action::Rotate { angle } => {
+            entity.rotation = *angle;
+        }
+        Action::LookAt { target } => {
+            let delta = *target - entity.position;
+            if delta.length_squared() > f32::EPSILON {
+                entity.rotation = delta.y.atan2(delta.x);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn hash_u64(hash: &mut u64, value: u64) {
+    *hash ^= value;
+    *hash = hash.wrapping_mul(FNV_PRIME);
+}
+
+fn hash_f32(hash: &mut u64, value: f32) {
+    hash_u64(hash, value.to_bits() as u64);
+}
+
+fn hash_option_f32(hash: &mut u64, value: Option<f32>) {
+    match value {
+        Some(value) => {
+            hash_u64(hash, 1);
+            hash_f32(hash, value);
+        }
+        None => hash_u64(hash, 0),
+    }
+}
+
+fn hash_option_str(hash: &mut u64, value: Option<&str>) {
+    match value {
+        Some(value) => {
+            hash_u64(hash, 1);
+            for byte in value.as_bytes() {
+                hash_u64(hash, *byte as u64);
+            }
+        }
+        None => hash_u64(hash, 0),
+    }
 }
 
 #[cfg(test)]
@@ -199,6 +383,7 @@ mod tests {
             rotation: 0.0,
             health: Some(100.0),
             max_health: Some(100.0),
+            movement_speed: Some(200.0),
             label: Some("Player".into()),
         });
 
@@ -210,6 +395,7 @@ mod tests {
             rotation: 0.0,
             health: Some(100.0),
             max_health: Some(100.0),
+            movement_speed: Some(200.0),
             label: Some("Player".into()),
         });
 
@@ -228,6 +414,7 @@ mod tests {
             rotation: 0.0,
             health: None,
             max_health: None,
+            movement_speed: None,
             label: None,
         });
 
@@ -240,6 +427,7 @@ mod tests {
                 rotation: 0.0,
                 health: None,
                 max_health: None,
+                movement_speed: None,
                 label: None,
             }],
             destroyed: vec![],
@@ -259,6 +447,7 @@ mod tests {
             rotation: 0.0,
             health: None,
             max_health: None,
+            movement_speed: Some(200.0),
             label: Some("sprite2d".into()),
         });
 
@@ -270,6 +459,7 @@ mod tests {
             rotation: 0.003,
             health: None,
             max_health: None,
+            movement_speed: Some(200.0),
             label: Some("sprite2d".into()),
         });
 
@@ -288,6 +478,7 @@ mod tests {
             rotation: 0.0,
             health: Some(100.0),
             max_health: Some(100.0),
+            movement_speed: Some(200.0),
             label: Some("sprite2d".into()),
         });
 
@@ -299,6 +490,7 @@ mod tests {
             rotation: 0.0,
             health: Some(100.0),
             max_health: Some(100.0),
+            movement_speed: Some(200.0),
             label: Some("sprite3d".into()),
         });
 
@@ -329,6 +521,7 @@ mod tests {
             rotation: 0.0,
             health: Some(100.0),
             max_health: Some(100.0),
+            movement_speed: None,
             label: Some("keep".into()),
         });
         base.entities.push(EntitySnapshot {
@@ -338,6 +531,7 @@ mod tests {
             rotation: 0.0,
             health: Some(50.0),
             max_health: Some(50.0),
+            movement_speed: None,
             label: Some("to_remove".into()),
         });
 
@@ -350,6 +544,7 @@ mod tests {
                 rotation: 0.0,
                 health: Some(100.0),
                 max_health: Some(100.0),
+                movement_speed: None,
                 label: Some("updated".into()),
             }],
             destroyed: vec![11, 99_999],
@@ -358,7 +553,127 @@ mod tests {
         let applied = delta.apply_to(&base);
         assert_eq!(applied.entities.len(), 1);
         assert_eq!(applied.entities[0].id, 10);
-        assert_eq!(applied.entities.iter().find(|e| e.id == 10).unwrap().label.as_deref(), Some("updated"));
+        assert_eq!(
+            applied
+                .entities
+                .iter()
+                .find(|e| e.id == 10)
+                .unwrap()
+                .label
+                .as_deref(),
+            Some("updated")
+        );
         assert!(applied.entities.iter().all(|entity| entity.id != 99_999));
+    }
+
+    #[test]
+    fn test_snapshot_digest_is_stable_for_entity_order() {
+        let entity_a = EntitySnapshot {
+            id: 1,
+            position: Vec2::new(1.0, 2.0),
+            velocity: Vec2::new(3.0, 4.0),
+            rotation: 0.5,
+            health: Some(10.0),
+            max_health: Some(20.0),
+            movement_speed: Some(200.0),
+            label: Some("a".into()),
+        };
+        let entity_b = EntitySnapshot {
+            id: 2,
+            position: Vec2::new(5.0, 6.0),
+            velocity: Vec2::new(7.0, 8.0),
+            rotation: 1.5,
+            health: None,
+            max_health: None,
+            movement_speed: None,
+            label: Some("b".into()),
+        };
+
+        let snapshot_a = WorldSnapshot {
+            tick: 4,
+            entities: vec![entity_a.clone(), entity_b.clone()],
+        };
+        let snapshot_b = WorldSnapshot {
+            tick: 4,
+            entities: vec![entity_b, entity_a],
+        };
+
+        assert_eq!(snapshot_a.digest(), snapshot_b.digest());
+    }
+
+    #[test]
+    fn test_replay_predicted_actions_replays_move_and_stop() {
+        let snapshot = WorldSnapshot {
+            tick: 10,
+            entities: vec![EntitySnapshot {
+                id: 7,
+                position: Vec2::ZERO,
+                velocity: Vec2::ZERO,
+                rotation: 0.0,
+                health: None,
+                max_health: None,
+                movement_speed: Some(120.0),
+                label: Some("player".into()),
+            }],
+        };
+
+        let predicted = snapshot.replay_predicted_actions(
+            Some(7),
+            &[
+                PredictedActionBatch {
+                    tick: 11,
+                    actions: vec![Action::Move { direction: Vec2::X }],
+                },
+                PredictedActionBatch {
+                    tick: 12,
+                    actions: vec![Action::Stop],
+                },
+            ],
+        );
+
+        let entity = &predicted.entities[0];
+        assert_eq!(predicted.tick, 12);
+        assert!((entity.position.x - 2.0).abs() < 0.001);
+        assert_eq!(entity.velocity, Vec2::ZERO);
+    }
+
+    #[test]
+    fn test_apply_authoritative_update_requires_baseline_for_delta() {
+        let delta = StateDelta {
+            tick: 5,
+            updated: vec![],
+            destroyed: vec![],
+        };
+
+        let error = apply_authoritative_update(None, 5, false, &delta, 0).unwrap_err();
+        assert_eq!(error, SnapshotUpdateError::MissingBaseline { tick: 5 });
+    }
+
+    #[test]
+    fn test_apply_authoritative_update_accepts_full_snapshot() {
+        let full = StateDelta {
+            tick: 5,
+            updated: vec![EntitySnapshot {
+                id: 1,
+                position: Vec2::new(2.0, 3.0),
+                velocity: Vec2::X,
+                rotation: 0.25,
+                health: Some(10.0),
+                max_health: Some(10.0),
+                movement_speed: Some(200.0),
+                label: Some("player".into()),
+            }],
+            destroyed: vec![],
+        };
+
+        let expected_snapshot = WorldSnapshot {
+            tick: 5,
+            entities: full.updated.clone(),
+        };
+
+        let applied =
+            apply_authoritative_update(None, 5, true, &full, expected_snapshot.digest()).unwrap();
+
+        assert_eq!(applied.digest(), expected_snapshot.digest());
     }
 }


### PR DESCRIPTION
## Summary
- add authoritative digest, full-snapshot, and action-ack metadata to the direct-connect `pod-net` protocol
- split native/web direct clients into authoritative vs predicted snapshot tracking with replay of unacknowledged action batches
- add deterministic snapshot digest and replay tests, and record the slice in `IMPLEMENTATION_PLAN.md`

## Validation
- `cargo test -p pod-net --lib`

## Notes
- `cargo check -p pod-net` currently fails in this checkout inside the `quinn` dependency (`can't find crate for quinn_proto`), which appears pre-existing and is not introduced by this patch.
- `cargo check -p pod-net --features spacetimedb --lib` and `cargo check -p pod-net --target wasm32-unknown-unknown` hit existing dependency/build-environment issues outside this slice as well.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Server-authoritative state tracking for clients with automatic prediction and rollback capabilities.
  * Action acknowledgment system to track confirmed vs. pending player actions.
  * Snapshot-based reconciliation with deterministic validation to ensure consistency across clients and server.
  * Automatic replay of unacknowledged actions after server corrections.

* **Tests**
  * Added tests for snapshot determinism and prediction recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->