### PR TITLE
Fix pod-net target gating and build hygiene

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target-dir = ".cargo-target"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.cargo-target/

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -398,5 +398,16 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
 - [x] Validated touched crate:
   - `cargo test -p pod-net --lib`
 
-**Last updated**: Iteration 49
+### Iteration 50 — Pod-Net Build Hygiene and Target Split
+
+- [x] Moved `pod-net`'s native transport dependencies (`tokio`, `quinn`, and Criterion benches) behind non-wasm target gates so the browser client no longer pulls native-only networking code into `wasm32` builds.
+- [x] Enabled the specific `web-sys` DOM bindings used by `client_web.rs` (`Window`, `Location`, `Event`, and `console`) so the browser transport compiles under the workspace's wasm target again.
+- [x] Fixed the SpacetimeDB snapshot conversion path to populate `EntitySnapshot.movement_speed` from cached authority state and added deterministic coverage for that mapping.
+- [x] Moved the workspace's default Cargo target output to `.cargo-target/` and ignored it so normal checks stop inheriting stale tracked artifacts from the repository root `target/` tree.
+- [x] Validated touched targets:
+  - `cargo check -p pod-net --lib`
+  - `cargo check -p pod-net --features spacetimedb --lib`
+  - `cargo check -p pod-net --target wasm32-unknown-unknown --lib`
+
+**Last updated**: Iteration 50
 **Current focus**: Phase 3 authority parity and shared-simulation recovery for the RuneScape-style MMO + companion-creature vertical slice

--- a/crates/pod-net/Cargo.toml
+++ b/crates/pod-net/Cargo.toml
@@ -18,20 +18,20 @@ serde.workspace = true
 serde_json.workspace = true
 bincode.workspace = true
 log.workspace = true
-tokio.workspace = true
-quinn.workspace = true
 uuid.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"
-web-sys = { version = "0.3", features = ["WebSocket", "MessageEvent", "ErrorEvent", "CloseEvent", "BinaryType"] }
+web-sys = { version = "0.3", features = ["BinaryType", "CloseEvent", "ErrorEvent", "Event", "Location", "MessageEvent", "WebSocket", "Window", "console"] }
 js-sys = "0.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio.workspace = true
+quinn.workspace = true
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 rcgen = "0.13"
 
-[dev-dependencies]
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
 
 [[bench]]

--- a/crates/pod-net/src/client_stdb.rs
+++ b/crates/pod-net/src/client_stdb.rs
@@ -869,6 +869,7 @@ fn entity_to_snapshot(cached: &CachedEntity) -> EntitySnapshot {
         rotation: cached.rotation.unwrap_or(0.0),
         health: cached.health,
         max_health: cached.max_health,
+        movement_speed: cached.max_speed,
         label: cached.name.clone(),
     }
 }
@@ -1119,6 +1120,7 @@ mod tests {
         assert_eq!(snap.rotation, 0.0);
         assert!(snap.health.is_none());
         assert!(snap.max_health.is_none());
+        assert!(snap.movement_speed.is_none());
         assert!(snap.label.is_none());
     }
 
@@ -1132,6 +1134,7 @@ mod tests {
         cached.rotation = Some(1.57);
         cached.health = Some(80.0);
         cached.max_health = Some(100.0);
+        cached.max_speed = Some(240.0);
         cached.name = Some("Hero".into());
 
         let snap = entity_to_snapshot(&cached);
@@ -1142,6 +1145,7 @@ mod tests {
         assert!((snap.rotation - 1.57).abs() < f32::EPSILON);
         assert_eq!(snap.health, Some(80.0));
         assert_eq!(snap.max_health, Some(100.0));
+        assert_eq!(snap.movement_speed, Some(240.0));
         assert_eq!(snap.label.as_deref(), Some("Hero"));
     }
 


### PR DESCRIPTION
## Summary
- gate native-only pod-net transport dependencies behind non-wasm targets
- enable the web-sys DOM bindings required by client_web.rs and restore wasm pod-net builds
- route cargo output to .cargo-target and fix SpacetimeDB snapshot movement_speed mapping

## Testing
- cargo check -p pod-net --lib
- cargo check -p pod-net --features spacetimedb --lib
- cargo check -p pod-net --target wasm32-unknown-unknown --lib
- cargo test -p pod-net --lib

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Movement speed information is now tracked and included in entity snapshots

* **Chores**
  * Optimized build system configuration to use dedicated artifact storage directory
  * Reorganized project dependencies for improved compilation efficiency
  * Updated development roadmap for current iteration cycle

<!-- end of auto-generated comment: release notes by coderabbit.ai -->