### PR TITLE
Add pod-net presentation interpolation

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -419,5 +419,16 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `git ls-files target`
   - `git status --short`
 
-**Last updated**: Iteration 51
+### Iteration 52 — Pod-Net Presentation Interpolation and Catch-Up Pass
+
+- [x] Added reusable `pod-net` snapshot interpolation primitives: bounded authoritative history, render-time drift correction, exact/interpolated/extrapolated sample modes, and local-player presentation overlay.
+- [x] Integrated the presentation pipeline into native QUIC, browser WebSocket, and SpacetimeDB clients so each adapter now exposes a smoothed `presentation_snapshot()` and `presentation_tick()` API on top of the existing authoritative/predicted state split.
+- [x] Preserved local input responsiveness by overlaying the currently predicted controlled entity onto interpolated authoritative snapshots while keeping remote entities on the smoothed authoritative timeline.
+- [x] Added deterministic coverage for interpolation replacement, shared-entity lerping, bounded extrapolation, render-clock catch-up snapping, local-player overlay composition, and SpacetimeDB adapter presentation sampling.
+- [x] Validated touched targets:
+  - `cargo test -p pod-net --lib`
+  - `cargo test -p pod-net --features spacetimedb --lib`
+  - `cargo check -p pod-net --target wasm32-unknown-unknown --lib`
+
+**Last updated**: Iteration 52
 **Current focus**: Phase 3 authority parity and shared-simulation recovery for the RuneScape-style MMO + companion-creature vertical slice

--- a/crates/pod-net/src/client_native.rs
+++ b/crates/pod-net/src/client_native.rs
@@ -17,7 +17,9 @@ use crate::protocol::{
     ClientConfig as ProtoClientConfig, ClientId, ClientMessage, ReconnectToken, ServerMessage,
 };
 use crate::snapshot::{
-    apply_authoritative_update, PredictedActionBatch, ReconciliationReport, WorldSnapshot,
+    apply_authoritative_update, compose_presentation_snapshot, InterpolatedSnapshot,
+    PredictedActionBatch, ReconciliationReport, RenderClock, SnapshotInterpolationBuffer,
+    WorldSnapshot,
 };
 
 // ============================================================
@@ -57,6 +59,10 @@ pub struct NativeClient {
     reconnect_token: Option<ReconnectToken>,
     /// Last authoritative reconciliation outcome.
     last_reconciliation: Option<ReconciliationReport>,
+    /// Authoritative history for presentation smoothing.
+    render_buffer: SnapshotInterpolationBuffer,
+    /// Presentation clock for interpolation/catch-up recovery.
+    render_clock: RenderClock,
 }
 
 impl NativeClient {
@@ -142,6 +148,8 @@ impl NativeClient {
             last_event_tick: 0,
             reconnect_token: None,
             last_reconciliation: None,
+            render_buffer: SnapshotInterpolationBuffer::default(),
+            render_clock: RenderClock::default(),
         };
 
         // Send connect message
@@ -181,6 +189,7 @@ impl NativeClient {
                 self.controlled_entity = controlled_entity;
                 self.authoritative_snapshot = Some(snapshot.clone());
                 self.local_snapshot = Some(snapshot);
+                self.ingest_authoritative_snapshot();
                 self.reconnect_token = Some(reconnect_token);
                 self.prediction_history.clear();
                 self.last_acknowledged_action_tick = None;
@@ -356,6 +365,7 @@ impl NativeClient {
                 self.controlled_entity = *controlled_entity;
                 self.authoritative_snapshot = Some(snapshot.clone());
                 self.local_snapshot = Some(snapshot.clone());
+                self.ingest_authoritative_snapshot();
                 self.prediction_history.clear();
                 self.last_acknowledged_action_tick = None;
                 self.last_server_tick = *tick;
@@ -387,6 +397,7 @@ impl NativeClient {
                 if gap_detected && !*is_full_snapshot {
                     self.authoritative_snapshot = None;
                     self.local_snapshot = None;
+                    self.clear_presentation_state();
                     self.record_reconciliation(*tick, *authoritative_digest, true);
                     return false;
                 }
@@ -409,12 +420,14 @@ impl NativeClient {
                         error!("Authoritative update rejected at tick {}: {:?}", tick, err);
                         self.authoritative_snapshot = None;
                         self.local_snapshot = None;
+                        self.clear_presentation_state();
                         self.record_reconciliation(*tick, *authoritative_digest, true);
                         return false;
                     }
                 };
 
                 self.authoritative_snapshot = Some(authoritative_snapshot);
+                self.ingest_authoritative_snapshot();
                 self.prune_acknowledged_predictions(*acknowledged_action_tick);
                 self.rebuild_predicted_snapshot();
                 self.last_server_tick = *tick;
@@ -467,6 +480,7 @@ impl NativeClient {
             quinn::VarInt::from_u32(0),
             reason.unwrap_or("Disconnect").as_bytes(),
         );
+        self.clear_presentation_state();
 
         info!("Disconnected from server");
         Ok(())
@@ -477,9 +491,29 @@ impl NativeClient {
         self.local_snapshot.as_ref()
     }
 
+    /// Sample a smoothed presentation snapshot for rendering.
+    pub fn presentation_snapshot(
+        &mut self,
+        frame_delta_seconds: f32,
+    ) -> Option<InterpolatedSnapshot> {
+        let latest_tick = self.render_buffer.latest_tick()?;
+        let target_tick = self.render_clock.advance(latest_tick, frame_delta_seconds);
+        let sampled = self.render_buffer.sample(target_tick)?;
+        Some(compose_presentation_snapshot(
+            sampled,
+            self.local_snapshot.as_ref(),
+            self.controlled_entity,
+        ))
+    }
+
     /// Get the last authoritative world snapshot confirmed by the server.
     pub fn authoritative_snapshot(&self) -> Option<&WorldSnapshot> {
         self.authoritative_snapshot.as_ref()
+    }
+
+    /// Current presentation tick after interpolation/catch-up correction.
+    pub fn presentation_tick(&self) -> Option<f32> {
+        self.render_clock.current_tick()
     }
 
     /// Get the most recent reconciliation report.
@@ -520,6 +554,17 @@ impl NativeClient {
         self.local_snapshot = self.authoritative_snapshot.as_ref().map(|snapshot| {
             snapshot.replay_predicted_actions(self.controlled_entity, &self.prediction_history)
         });
+    }
+
+    fn ingest_authoritative_snapshot(&mut self) {
+        if let Some(snapshot) = self.authoritative_snapshot.as_ref() {
+            self.render_buffer.push(snapshot.clone());
+        }
+    }
+
+    fn clear_presentation_state(&mut self) {
+        self.render_buffer.clear();
+        self.render_clock.reset();
     }
 
     fn record_reconciliation(

--- a/crates/pod-net/src/client_stdb.rs
+++ b/crates/pod-net/src/client_stdb.rs
@@ -58,7 +58,10 @@ use pod_stdb::types::{
 };
 
 use crate::protocol::{ClientId, ReconnectToken, ServerMessage};
-use crate::snapshot::{EntitySnapshot, StateDelta, WorldSnapshot};
+use crate::snapshot::{
+    compose_presentation_snapshot, EntitySnapshot, InterpolatedSnapshot, RenderClock,
+    SnapshotInterpolationBuffer, StateDelta, WorldSnapshot,
+};
 
 // ============================================================
 // SUBSCRIPTION MANAGEMENT
@@ -384,6 +387,8 @@ pub struct SpacetimeDBClient {
     reconnect_token: ReconnectToken,
     pending_actions: Vec<Action>,
     local_snapshot: Option<WorldSnapshot>,
+    render_buffer: SnapshotInterpolationBuffer,
+    render_clock: RenderClock,
     welcome_sent: bool,
     last_emitted_tick: u64,
 }
@@ -398,6 +403,8 @@ impl SpacetimeDBClient {
             reconnect_token: ReconnectToken::new(),
             pending_actions: Vec::new(),
             local_snapshot: None,
+            render_buffer: SnapshotInterpolationBuffer::default(),
+            render_clock: RenderClock::default(),
             welcome_sent: false,
             last_emitted_tick: 0,
         }
@@ -503,6 +510,7 @@ impl SpacetimeDBClient {
                         let snapshot = self.build_world_snapshot();
                         let tick = self.current_tick_or_zero();
                         self.local_snapshot = Some(snapshot.clone());
+                        self.ingest_local_snapshot();
                         self.welcome_sent = true;
 
                         if let Some(client_id) = self.client_id {
@@ -527,6 +535,7 @@ impl SpacetimeDBClient {
                     log::info!("[pod-net stdb] Disconnected: {reason}");
                     self.client_id = None;
                     self.welcome_sent = false;
+                    self.clear_presentation_state();
                 }
 
                 // ── Entity lifecycle → StateDelta ──
@@ -539,6 +548,7 @@ impl SpacetimeDBClient {
                             continue;
                         }
                         self.upsert_local_snapshot(tick, &snap);
+                        self.ingest_local_snapshot();
                         let authoritative_digest = self
                             .local_snapshot
                             .as_ref()
@@ -568,6 +578,7 @@ impl SpacetimeDBClient {
                         local.tick = tick;
                         local.entities.retain(|e| e.id != entity_id);
                     }
+                    self.ingest_local_snapshot();
                     let authoritative_digest = self
                         .local_snapshot
                         .as_ref()
@@ -677,6 +688,7 @@ impl SpacetimeDBClient {
                     if let Some(ref mut local) = self.local_snapshot {
                         local.tick = new_tick;
                     }
+                    self.ingest_local_snapshot();
                 }
 
                 StdbEvent::WorldStateUpdated { tick, .. } => {
@@ -684,6 +696,7 @@ impl SpacetimeDBClient {
                     if let Some(ref mut local) = self.local_snapshot {
                         local.tick = tick;
                     }
+                    self.ingest_local_snapshot();
                 }
 
                 // ── Internal events (no ServerMessage equivalent) ──
@@ -703,6 +716,7 @@ impl SpacetimeDBClient {
         self.welcome_sent = false;
         self.last_emitted_tick = 0;
         self.subscriptions.reset_connection();
+        self.clear_presentation_state();
     }
 
     /// Configure subscriptions for spectator mode (all public tables + events).
@@ -794,6 +808,21 @@ impl SpacetimeDBClient {
         self.local_snapshot.as_ref()
     }
 
+    /// Sample a smoothed presentation snapshot for rendering.
+    pub fn presentation_snapshot(
+        &mut self,
+        frame_delta_seconds: f32,
+    ) -> Option<InterpolatedSnapshot> {
+        let latest_tick = self.render_buffer.latest_tick()?;
+        let target_tick = self.render_clock.advance(latest_tick, frame_delta_seconds);
+        let sampled = self.render_buffer.sample(target_tick)?;
+        Some(compose_presentation_snapshot(
+            sampled,
+            self.local_snapshot.as_ref(),
+            self.inner.controlled_entity(),
+        ))
+    }
+
     /// Get the assigned client ID (available after `Connected` event).
     pub fn client_id(&self) -> Option<ClientId> {
         self.client_id
@@ -802,6 +831,11 @@ impl SpacetimeDBClient {
     /// Whether the client is connected to SpacetimeDB.
     pub fn is_connected(&self) -> bool {
         self.inner.is_connected()
+    }
+
+    /// Current presentation tick after interpolation/catch-up correction.
+    pub fn presentation_tick(&self) -> Option<f32> {
+        self.render_clock.current_tick()
     }
 
     /// Access the underlying [`StdbClient`] for advanced operations
@@ -852,6 +886,18 @@ impl SpacetimeDBClient {
                 local.entities.push(snap.clone());
             }
         }
+    }
+
+    fn ingest_local_snapshot(&mut self) {
+        if let Some(snapshot) = self.local_snapshot.as_ref() {
+            self.render_buffer.push(snapshot.clone());
+        }
+    }
+
+    fn clear_presentation_state(&mut self) {
+        self.local_snapshot = None;
+        self.render_buffer.clear();
+        self.render_clock.reset();
     }
 }
 
@@ -1364,6 +1410,31 @@ mod tests {
         assert!(!client.is_connected());
         assert!(client.client_id().is_none());
         assert!(client.local_snapshot().is_none());
+    }
+
+    #[test]
+    fn test_presentation_snapshot_uses_local_snapshot_history() {
+        let mut client = SpacetimeDBClient::new(SpacetimeDBClientConfig::default());
+        client.local_snapshot = Some(WorldSnapshot {
+            tick: 10,
+            entities: vec![EntitySnapshot {
+                id: 7,
+                position: Vec2::new(4.0, 2.0),
+                velocity: Vec2::new(60.0, 0.0),
+                rotation: 0.0,
+                health: Some(90.0),
+                max_health: Some(100.0),
+                movement_speed: Some(120.0),
+                label: Some("player".into()),
+            }],
+        });
+        client.ingest_local_snapshot();
+
+        let sampled = client.presentation_snapshot(1.0 / 60.0).unwrap();
+
+        assert_eq!(sampled.snapshot.entities.len(), 1);
+        assert!(sampled.snapshot.entities[0].position.x >= 4.0);
+        assert!(client.presentation_tick().is_some());
     }
 
     #[test]

--- a/crates/pod-net/src/client_web.rs
+++ b/crates/pod-net/src/client_web.rs
@@ -15,7 +15,9 @@ use pod_core::Action;
 
 use crate::protocol::{ClientConfig, ClientId, ClientMessage, ReconnectToken, ServerMessage};
 use crate::snapshot::{
-    apply_authoritative_update, PredictedActionBatch, ReconciliationReport, WorldSnapshot,
+    apply_authoritative_update, compose_presentation_snapshot, InterpolatedSnapshot,
+    PredictedActionBatch, ReconciliationReport, RenderClock, SnapshotInterpolationBuffer,
+    WorldSnapshot,
 };
 
 #[derive(Debug, Default)]
@@ -53,6 +55,10 @@ pub struct WebClient {
     reconnect_token: Option<ReconnectToken>,
     /// Last authoritative reconciliation outcome.
     last_reconciliation: Option<ReconciliationReport>,
+    /// Authoritative history for presentation smoothing.
+    render_buffer: SnapshotInterpolationBuffer,
+    /// Presentation clock for interpolation/catch-up recovery.
+    render_clock: RenderClock,
     reconnect_attempts: u32,
     next_reconnect_at_ms: f64,
 }
@@ -79,6 +85,8 @@ impl WebClient {
             last_event_tick: 0,
             reconnect_token: None,
             last_reconciliation: None,
+            render_buffer: SnapshotInterpolationBuffer::default(),
+            render_clock: RenderClock::default(),
             reconnect_attempts: 0,
             next_reconnect_at_ms: 0.0,
         };
@@ -276,6 +284,7 @@ impl WebClient {
                 self.controlled_entity = *controlled_entity;
                 self.authoritative_snapshot = Some(snapshot.clone());
                 self.local_snapshot = Some(snapshot.clone());
+                self.ingest_authoritative_snapshot();
                 self.prediction_history.clear();
                 self.connected = true;
                 self.last_server_tick = *tick;
@@ -308,6 +317,7 @@ impl WebClient {
                 if gap_detected && !*is_full_snapshot {
                     self.authoritative_snapshot = None;
                     self.local_snapshot = None;
+                    self.clear_presentation_state();
                     self.record_reconciliation(*tick, *authoritative_digest, true);
                     return false;
                 }
@@ -333,12 +343,14 @@ impl WebClient {
                         );
                         self.authoritative_snapshot = None;
                         self.local_snapshot = None;
+                        self.clear_presentation_state();
                         self.record_reconciliation(*tick, *authoritative_digest, true);
                         return false;
                     }
                 };
 
                 self.authoritative_snapshot = Some(authoritative_snapshot);
+                self.ingest_authoritative_snapshot();
                 self.prune_acknowledged_predictions(*acknowledged_action_tick);
                 self.rebuild_predicted_snapshot();
                 self.last_server_tick = *tick;
@@ -405,6 +417,7 @@ impl WebClient {
 
         self.websocket = None;
         self.connected = false;
+        self.clear_presentation_state();
         Ok(())
     }
 
@@ -413,9 +426,29 @@ impl WebClient {
         self.local_snapshot.as_ref()
     }
 
+    /// Sample a smoothed presentation snapshot for rendering.
+    pub fn presentation_snapshot(
+        &mut self,
+        frame_delta_seconds: f32,
+    ) -> Option<InterpolatedSnapshot> {
+        let latest_tick = self.render_buffer.latest_tick()?;
+        let target_tick = self.render_clock.advance(latest_tick, frame_delta_seconds);
+        let sampled = self.render_buffer.sample(target_tick)?;
+        Some(compose_presentation_snapshot(
+            sampled,
+            self.local_snapshot.as_ref(),
+            self.controlled_entity,
+        ))
+    }
+
     /// Get the last authoritative world snapshot confirmed by the server.
     pub fn authoritative_snapshot(&self) -> Option<&WorldSnapshot> {
         self.authoritative_snapshot.as_ref()
+    }
+
+    /// Current presentation tick after interpolation/catch-up correction.
+    pub fn presentation_tick(&self) -> Option<f32> {
+        self.render_clock.current_tick()
     }
 
     /// Get the most recent reconciliation report.
@@ -448,6 +481,7 @@ impl WebClient {
         self.client_id = Some(client_id);
         self.authoritative_snapshot = Some(snapshot.clone());
         self.local_snapshot = Some(snapshot);
+        self.ingest_authoritative_snapshot();
         self.connected = true;
     }
 
@@ -469,6 +503,17 @@ impl WebClient {
         self.local_snapshot = self.authoritative_snapshot.as_ref().map(|snapshot| {
             snapshot.replay_predicted_actions(self.controlled_entity, &self.prediction_history)
         });
+    }
+
+    fn ingest_authoritative_snapshot(&mut self) {
+        if let Some(snapshot) = self.authoritative_snapshot.as_ref() {
+            self.render_buffer.push(snapshot.clone());
+        }
+    }
+
+    fn clear_presentation_state(&mut self) {
+        self.render_buffer.clear();
+        self.render_clock.reset();
     }
 
     fn record_reconciliation(

--- a/crates/pod-net/src/lib.rs
+++ b/crates/pod-net/src/lib.rs
@@ -67,8 +67,10 @@ pub use protocol::{
     ClientConfig, ClientId, ClientMessage, ReconnectToken, ServerConfig, ServerMessage,
 };
 pub use snapshot::{
-    apply_authoritative_update, EntitySnapshot, PredictedActionBatch, ReconciliationReport,
-    SnapshotUpdateError, StateDelta, WorldSnapshot,
+    apply_authoritative_update, compose_presentation_snapshot, EntitySnapshot,
+    InterpolatedSnapshot, InterpolationConfig, PredictedActionBatch, ReconciliationReport,
+    RenderClock, SnapshotInterpolationBuffer, SnapshotSampleMode, SnapshotUpdateError, StateDelta,
+    WorldSnapshot,
 };
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/pod-net/src/snapshot.rs
+++ b/crates/pod-net/src/snapshot.rs
@@ -5,7 +5,7 @@
 
 use glam::Vec2;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 
 use pod_core::{Action, Health, Label, Movement, Transform, Velocity};
 
@@ -13,6 +13,9 @@ const FIXED_TICK_DURATION_SECS: f32 = 1.0 / 60.0;
 const DEFAULT_PREDICTION_MOVE_SPEED: f32 = 200.0;
 const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
 const FNV_PRIME: u64 = 0x100000001b3;
+
+/// Default network tick rate used for client-side presentation smoothing.
+pub const DEFAULT_NETWORK_TICK_RATE: f32 = 60.0;
 
 /// A serializable snapshot of world state
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -85,6 +88,223 @@ pub enum SnapshotUpdateError {
         expected: u64,
         actual: u64,
     },
+}
+
+/// Configuration for rendering/interpolating authoritative snapshots between
+/// network updates while recovering smoothly from drift.
+#[derive(Debug, Clone, PartialEq)]
+pub struct InterpolationConfig {
+    /// How many authoritative ticks behind the latest server tick the render
+    /// clock should target by default.
+    pub interpolation_delay_ticks: f32,
+    /// Maximum number of future ticks a client may extrapolate beyond the last
+    /// authoritative snapshot before clamping.
+    pub max_extrapolation_ticks: f32,
+    /// If the render clock drifts farther than this many ticks from the desired
+    /// delayed target, snap directly instead of correcting gradually.
+    pub snap_threshold_ticks: f32,
+    /// Maximum number of ticks per second the render clock may correct by while
+    /// catching up or slowing down toward the desired delayed target.
+    pub catch_up_rate_ticks_per_second: f32,
+    /// Maximum authoritative snapshots retained for interpolation history.
+    pub history_limit: usize,
+}
+
+impl Default for InterpolationConfig {
+    fn default() -> Self {
+        Self {
+            interpolation_delay_ticks: 2.0,
+            max_extrapolation_ticks: 2.0,
+            snap_threshold_ticks: 4.0,
+            catch_up_rate_ticks_per_second: 8.0,
+            history_limit: 32,
+        }
+    }
+}
+
+/// How a presentation snapshot was produced.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotSampleMode {
+    Exact,
+    Interpolated,
+    Extrapolated,
+    ClampedPast,
+    ClampedFuture,
+}
+
+/// A sampled world snapshot suitable for rendering/presentation.
+#[derive(Debug, Clone)]
+pub struct InterpolatedSnapshot {
+    pub target_tick: f32,
+    pub mode: SnapshotSampleMode,
+    pub snapshot: WorldSnapshot,
+}
+
+/// Bounded authoritative history for rendering/interpolating remote state.
+#[derive(Debug, Clone)]
+pub struct SnapshotInterpolationBuffer {
+    config: InterpolationConfig,
+    snapshots: VecDeque<WorldSnapshot>,
+}
+
+impl Default for SnapshotInterpolationBuffer {
+    fn default() -> Self {
+        Self::new(InterpolationConfig::default())
+    }
+}
+
+impl SnapshotInterpolationBuffer {
+    pub fn new(config: InterpolationConfig) -> Self {
+        Self {
+            config,
+            snapshots: VecDeque::new(),
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.snapshots.clear();
+    }
+
+    pub fn latest_tick(&self) -> Option<u64> {
+        self.snapshots.back().map(|snapshot| snapshot.tick)
+    }
+
+    pub fn push(&mut self, snapshot: WorldSnapshot) {
+        if let Some(existing) = self
+            .snapshots
+            .iter_mut()
+            .find(|existing| existing.tick == snapshot.tick)
+        {
+            *existing = snapshot;
+        } else if let Some(index) = self
+            .snapshots
+            .iter()
+            .position(|existing| existing.tick > snapshot.tick)
+        {
+            self.snapshots.insert(index, snapshot);
+        } else {
+            self.snapshots.push_back(snapshot);
+        }
+
+        while self.snapshots.len() > self.config.history_limit {
+            self.snapshots.pop_front();
+        }
+    }
+
+    pub fn sample(&self, target_tick: f32) -> Option<InterpolatedSnapshot> {
+        let first = self.snapshots.front()?;
+        let last = self.snapshots.back()?;
+
+        if let Some(exact) = self
+            .snapshots
+            .iter()
+            .find(|snapshot| (snapshot.tick as f32 - target_tick).abs() <= f32::EPSILON)
+        {
+            return Some(InterpolatedSnapshot {
+                target_tick,
+                mode: SnapshotSampleMode::Exact,
+                snapshot: exact.clone(),
+            });
+        }
+
+        if target_tick <= first.tick as f32 {
+            return Some(InterpolatedSnapshot {
+                target_tick,
+                mode: SnapshotSampleMode::ClampedPast,
+                snapshot: first.clone(),
+            });
+        }
+
+        let lower_index = self
+            .snapshots
+            .iter()
+            .rposition(|snapshot| (snapshot.tick as f32) < target_tick)?;
+
+        if let Some(upper) = self
+            .snapshots
+            .iter()
+            .skip(lower_index + 1)
+            .find(|snapshot| snapshot.tick as f32 > target_tick)
+        {
+            let lower = &self.snapshots[lower_index];
+            let factor =
+                (target_tick - lower.tick as f32) / (upper.tick as f32 - lower.tick as f32);
+
+            return Some(InterpolatedSnapshot {
+                target_tick,
+                mode: SnapshotSampleMode::Interpolated,
+                snapshot: interpolate_snapshots(lower, upper, factor, target_tick),
+            });
+        }
+
+        let clamped_tick =
+            target_tick.min(last.tick as f32 + self.config.max_extrapolation_ticks.max(0.0));
+        let mode = if clamped_tick < target_tick {
+            SnapshotSampleMode::ClampedFuture
+        } else {
+            SnapshotSampleMode::Extrapolated
+        };
+
+        Some(InterpolatedSnapshot {
+            target_tick,
+            mode,
+            snapshot: extrapolate_snapshot(last, clamped_tick),
+        })
+    }
+}
+
+/// Render-time clock that stays a few authoritative ticks behind the server and
+/// catches up smoothly as new snapshots arrive.
+#[derive(Debug, Clone)]
+pub struct RenderClock {
+    config: InterpolationConfig,
+    render_tick: Option<f32>,
+}
+
+impl Default for RenderClock {
+    fn default() -> Self {
+        Self::new(InterpolationConfig::default())
+    }
+}
+
+impl RenderClock {
+    pub fn new(config: InterpolationConfig) -> Self {
+        Self {
+            config,
+            render_tick: None,
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.render_tick = None;
+    }
+
+    pub fn current_tick(&self) -> Option<f32> {
+        self.render_tick
+    }
+
+    pub fn advance(&mut self, latest_authoritative_tick: u64, frame_delta_seconds: f32) -> f32 {
+        let frame_delta_seconds = frame_delta_seconds.max(0.0);
+        let desired_tick =
+            latest_authoritative_tick as f32 - self.config.interpolation_delay_ticks.max(0.0);
+        let mut render_tick = self.render_tick.unwrap_or(desired_tick);
+        let drift = desired_tick - render_tick;
+
+        if drift.abs() > self.config.snap_threshold_ticks {
+            render_tick = desired_tick;
+        } else {
+            let max_correction =
+                self.config.catch_up_rate_ticks_per_second.max(0.0) * frame_delta_seconds;
+            render_tick += drift.clamp(-max_correction, max_correction);
+        }
+
+        render_tick += frame_delta_seconds * DEFAULT_NETWORK_TICK_RATE;
+        render_tick = render_tick
+            .min(latest_authoritative_tick as f32 + self.config.max_extrapolation_ticks.max(0.0));
+
+        self.render_tick = Some(render_tick);
+        render_tick
+    }
 }
 
 impl WorldSnapshot {
@@ -305,6 +525,119 @@ pub fn apply_authoritative_update(
     }
 
     Ok(snapshot)
+}
+
+/// Overlays the locally predicted controlled entity onto an interpolated
+/// authoritative snapshot, preserving responsive local control while still
+/// smoothing remote entities from authoritative history.
+pub fn compose_presentation_snapshot(
+    mut sampled: InterpolatedSnapshot,
+    predicted_local: Option<&WorldSnapshot>,
+    controlled_entity: Option<u64>,
+) -> InterpolatedSnapshot {
+    let Some(controlled_entity) = controlled_entity else {
+        return sampled;
+    };
+
+    let Some(predicted_entity) = predicted_local.and_then(|snapshot| {
+        snapshot
+            .entities
+            .iter()
+            .find(|entity| entity.id == controlled_entity)
+    }) else {
+        return sampled;
+    };
+
+    if let Some(existing) = sampled
+        .snapshot
+        .entities
+        .iter_mut()
+        .find(|entity| entity.id == controlled_entity)
+    {
+        *existing = predicted_entity.clone();
+    } else {
+        sampled.snapshot.entities.push(predicted_entity.clone());
+    }
+
+    sampled
+}
+
+fn interpolate_snapshots(
+    lower: &WorldSnapshot,
+    upper: &WorldSnapshot,
+    factor: f32,
+    target_tick: f32,
+) -> WorldSnapshot {
+    let factor = factor.clamp(0.0, 1.0);
+    let mut upper_entities = upper
+        .entities
+        .iter()
+        .map(|entity| (entity.id, entity))
+        .collect::<HashMap<_, _>>();
+    let mut entities = Vec::with_capacity(lower.entities.len());
+
+    for lower_entity in &lower.entities {
+        if let Some(upper_entity) = upper_entities.remove(&lower_entity.id) {
+            entities.push(interpolate_entity(lower_entity, upper_entity, factor));
+        } else {
+            // An entity that disappears in the upper snapshot remains visible
+            // until that authoritative tick is fully reached.
+            entities.push(lower_entity.clone());
+        }
+    }
+
+    WorldSnapshot {
+        tick: target_tick.floor().max(0.0) as u64,
+        entities,
+    }
+}
+
+fn interpolate_entity(
+    lower: &EntitySnapshot,
+    upper: &EntitySnapshot,
+    factor: f32,
+) -> EntitySnapshot {
+    EntitySnapshot {
+        id: lower.id,
+        position: lower.position.lerp(upper.position, factor),
+        velocity: lower.velocity.lerp(upper.velocity, factor),
+        rotation: lerp_f32(lower.rotation, upper.rotation, factor),
+        health: lerp_option_f32(lower.health, upper.health, factor),
+        max_health: lerp_option_f32(lower.max_health, upper.max_health, factor),
+        movement_speed: lerp_option_f32(lower.movement_speed, upper.movement_speed, factor),
+        label: if factor < 1.0 {
+            lower.label.clone()
+        } else {
+            upper.label.clone()
+        },
+    }
+}
+
+fn extrapolate_snapshot(snapshot: &WorldSnapshot, target_tick: f32) -> WorldSnapshot {
+    let dt_ticks = (target_tick - snapshot.tick as f32).max(0.0);
+    let dt_seconds = dt_ticks * FIXED_TICK_DURATION_SECS;
+    let mut extrapolated = snapshot.clone();
+    extrapolated.tick = target_tick.floor().max(0.0) as u64;
+
+    for entity in &mut extrapolated.entities {
+        entity.position += entity.velocity * dt_seconds;
+    }
+
+    extrapolated
+}
+
+fn lerp_f32(lower: f32, upper: f32, factor: f32) -> f32 {
+    lower + (upper - lower) * factor
+}
+
+fn lerp_option_f32(lower: Option<f32>, upper: Option<f32>, factor: f32) -> Option<f32> {
+    match (lower, upper) {
+        (Some(lower), Some(upper)) => Some(lerp_f32(lower, upper, factor)),
+        (Some(lower), None) => Some(lower),
+        (None, Some(upper)) if factor >= 1.0 => Some(upper),
+        (None, Some(_)) => None,
+        (None, None) => None,
+    }
 }
 
 fn apply_predicted_action(entity: &mut EntitySnapshot, action: &Action) {
@@ -635,6 +968,209 @@ mod tests {
         assert_eq!(predicted.tick, 12);
         assert!((entity.position.x - 2.0).abs() < 0.001);
         assert_eq!(entity.velocity, Vec2::ZERO);
+    }
+
+    #[test]
+    fn test_interpolation_buffer_replaces_same_tick_snapshot() {
+        let mut buffer = SnapshotInterpolationBuffer::default();
+
+        buffer.push(WorldSnapshot {
+            tick: 10,
+            entities: vec![EntitySnapshot {
+                id: 1,
+                position: Vec2::ZERO,
+                velocity: Vec2::ZERO,
+                rotation: 0.0,
+                health: None,
+                max_health: None,
+                movement_speed: None,
+                label: Some("old".into()),
+            }],
+        });
+        buffer.push(WorldSnapshot {
+            tick: 10,
+            entities: vec![EntitySnapshot {
+                id: 1,
+                position: Vec2::new(5.0, 0.0),
+                velocity: Vec2::ZERO,
+                rotation: 0.0,
+                health: None,
+                max_health: None,
+                movement_speed: None,
+                label: Some("new".into()),
+            }],
+        });
+
+        let sampled = buffer.sample(10.0).unwrap();
+        assert_eq!(sampled.mode, SnapshotSampleMode::Exact);
+        assert_eq!(sampled.snapshot.entities.len(), 1);
+        assert_eq!(sampled.snapshot.entities[0].label.as_deref(), Some("new"));
+        assert_eq!(sampled.snapshot.entities[0].position, Vec2::new(5.0, 0.0));
+    }
+
+    #[test]
+    fn test_interpolation_buffer_lerps_shared_entities() {
+        let mut buffer = SnapshotInterpolationBuffer::default();
+        buffer.push(WorldSnapshot {
+            tick: 10,
+            entities: vec![EntitySnapshot {
+                id: 1,
+                position: Vec2::new(0.0, 0.0),
+                velocity: Vec2::new(10.0, 0.0),
+                rotation: 0.0,
+                health: Some(80.0),
+                max_health: Some(100.0),
+                movement_speed: Some(120.0),
+                label: Some("player".into()),
+            }],
+        });
+        buffer.push(WorldSnapshot {
+            tick: 12,
+            entities: vec![EntitySnapshot {
+                id: 1,
+                position: Vec2::new(12.0, 0.0),
+                velocity: Vec2::new(14.0, 0.0),
+                rotation: 1.0,
+                health: Some(60.0),
+                max_health: Some(100.0),
+                movement_speed: Some(160.0),
+                label: Some("player".into()),
+            }],
+        });
+
+        let sampled = buffer.sample(11.0).unwrap();
+        let entity = &sampled.snapshot.entities[0];
+
+        assert_eq!(sampled.mode, SnapshotSampleMode::Interpolated);
+        assert!((entity.position.x - 6.0).abs() < 0.001);
+        assert!((entity.velocity.x - 12.0).abs() < 0.001);
+        assert!((entity.rotation - 0.5).abs() < 0.001);
+        assert!((entity.health.unwrap() - 70.0).abs() < 0.001);
+        assert!((entity.movement_speed.unwrap() - 140.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_interpolation_buffer_extrapolates_latest_snapshot() {
+        let mut buffer = SnapshotInterpolationBuffer::default();
+        buffer.push(WorldSnapshot {
+            tick: 5,
+            entities: vec![EntitySnapshot {
+                id: 9,
+                position: Vec2::new(1.0, 2.0),
+                velocity: Vec2::new(60.0, 0.0),
+                rotation: 0.0,
+                health: None,
+                max_health: None,
+                movement_speed: Some(60.0),
+                label: Some("npc".into()),
+            }],
+        });
+
+        let sampled = buffer.sample(6.0).unwrap();
+        let entity = &sampled.snapshot.entities[0];
+
+        assert_eq!(sampled.mode, SnapshotSampleMode::Extrapolated);
+        assert!((entity.position.x - 2.0).abs() < 0.001);
+        assert!((entity.position.y - 2.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_interpolation_buffer_clamps_past_and_future() {
+        let mut buffer = SnapshotInterpolationBuffer::new(InterpolationConfig {
+            max_extrapolation_ticks: 1.0,
+            ..InterpolationConfig::default()
+        });
+        buffer.push(WorldSnapshot {
+            tick: 10,
+            entities: vec![EntitySnapshot {
+                id: 1,
+                position: Vec2::new(5.0, 0.0),
+                velocity: Vec2::new(30.0, 0.0),
+                rotation: 0.0,
+                health: None,
+                max_health: None,
+                movement_speed: None,
+                label: None,
+            }],
+        });
+
+        let past = buffer.sample(9.0).unwrap();
+        assert_eq!(past.mode, SnapshotSampleMode::ClampedPast);
+        assert_eq!(past.snapshot.tick, 10);
+
+        let future = buffer.sample(13.0).unwrap();
+        let entity = &future.snapshot.entities[0];
+        assert_eq!(future.mode, SnapshotSampleMode::ClampedFuture);
+        assert!((entity.position.x - 5.5).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_render_clock_advances_and_snaps_on_large_drift() {
+        let mut clock = RenderClock::default();
+
+        let first = clock.advance(20, 1.0 / 60.0);
+        assert!((first - 19.0).abs() < 0.001);
+
+        let second = clock.advance(40, 0.0);
+        assert!((second - 38.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_compose_presentation_snapshot_overlays_predicted_controlled_entity() {
+        let sampled = InterpolatedSnapshot {
+            target_tick: 12.0,
+            mode: SnapshotSampleMode::Interpolated,
+            snapshot: WorldSnapshot {
+                tick: 12,
+                entities: vec![
+                    EntitySnapshot {
+                        id: 1,
+                        position: Vec2::new(5.0, 0.0),
+                        velocity: Vec2::new(1.0, 0.0),
+                        rotation: 0.0,
+                        health: None,
+                        max_health: None,
+                        movement_speed: Some(120.0),
+                        label: Some("player".into()),
+                    },
+                    EntitySnapshot {
+                        id: 2,
+                        position: Vec2::new(10.0, 0.0),
+                        velocity: Vec2::ZERO,
+                        rotation: 0.0,
+                        health: None,
+                        max_health: None,
+                        movement_speed: None,
+                        label: Some("npc".into()),
+                    },
+                ],
+            },
+        };
+        let predicted_local = WorldSnapshot {
+            tick: 13,
+            entities: vec![EntitySnapshot {
+                id: 1,
+                position: Vec2::new(8.0, 1.0),
+                velocity: Vec2::new(3.0, 0.0),
+                rotation: 1.0,
+                health: None,
+                max_health: None,
+                movement_speed: Some(120.0),
+                label: Some("player".into()),
+            }],
+        };
+
+        let composed = compose_presentation_snapshot(sampled, Some(&predicted_local), Some(1));
+
+        assert_eq!(composed.snapshot.entities.len(), 2);
+        let controlled = composed
+            .snapshot
+            .entities
+            .iter()
+            .find(|entity| entity.id == 1)
+            .unwrap();
+        assert_eq!(controlled.position, Vec2::new(8.0, 1.0));
+        assert_eq!(controlled.velocity, Vec2::new(3.0, 0.0));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add authoritative snapshot interpolation, bounded extrapolation, and render-clock catch-up utilities to pod-net
- expose smoothed presentation snapshots on native, web, and SpacetimeDB clients while preserving predicted local control overlay
- add deterministic coverage for interpolation behavior and the SpacetimeDB presentation adapter path

## Testing
- cargo test -p pod-net --lib
- cargo test -p pod-net --features spacetimedb --lib
- cargo check -p pod-net --target wasm32-unknown-unknown --lib

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Pod-Net presentation interpolation for smooth, frame-level rendering across all client types.
  * Introduced local input responsiveness overlay to provide immediate visual feedback for user interactions.
  * Implemented deterministic interpolation with comprehensive test coverage for reliable visual updates.
  * Enhanced rendering with new presentation tick APIs for frame-perfect synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->