### PR TITLE
Add immediate pod-net resync recovery

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -441,5 +441,15 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cargo test -p pod-net --features spacetimedb --lib`
   - `cargo check -p pod-net --target wasm32-unknown-unknown --lib`
 
-**Last updated**: Iteration 53
+### Iteration 54 — Pod-Net Immediate Resync Recovery
+
+- [x] Added a direct-connect `RequestFullSnapshot` client message so drifted or gapped clients can explicitly request an immediate authoritative full snapshot instead of waiting for the next periodic broadcast.
+- [x] Added server-side full-resync response helpers that answer those requests with a full `StateDelta` snapshot including the latest acknowledged action tick for that client.
+- [x] Wired native QUIC and browser WebSocket clients to trigger a one-shot recovery request automatically when they detect a snapshot gap or reject an authoritative update due to baseline/digest failure.
+- [x] Added deterministic protocol and server coverage for full-snapshot request round-tripping and full-resync message construction.
+- [x] Validated touched targets:
+  - `cargo test -p pod-net --lib`
+  - `cargo check -p pod-net --target wasm32-unknown-unknown --lib`
+
+**Last updated**: Iteration 54
 **Current focus**: Phase 3 authority parity and shared-simulation recovery for the RuneScape-style MMO + companion-creature vertical slice

--- a/crates/pod-net/src/client_native.rs
+++ b/crates/pod-net/src/client_native.rs
@@ -7,7 +7,7 @@
 
 use std::sync::Arc;
 
-use log::{debug, error, info};
+use log::{debug, error, info, warn};
 use quinn::Endpoint;
 use tokio::sync::mpsc;
 
@@ -59,6 +59,8 @@ pub struct NativeClient {
     reconnect_token: Option<ReconnectToken>,
     /// Last authoritative reconciliation outcome.
     last_reconciliation: Option<ReconciliationReport>,
+    /// Whether the client has already requested an immediate recovery snapshot.
+    awaiting_recovery_snapshot: bool,
     /// Authoritative history for presentation smoothing.
     render_buffer: SnapshotInterpolationBuffer,
     /// Presentation clock for interpolation/catch-up recovery.
@@ -148,6 +150,7 @@ impl NativeClient {
             last_event_tick: 0,
             reconnect_token: None,
             last_reconciliation: None,
+            awaiting_recovery_snapshot: false,
             render_buffer: SnapshotInterpolationBuffer::default(),
             render_clock: RenderClock::default(),
         };
@@ -193,6 +196,7 @@ impl NativeClient {
                 self.reconnect_token = Some(reconnect_token);
                 self.prediction_history.clear();
                 self.last_acknowledged_action_tick = None;
+                self.awaiting_recovery_snapshot = false;
                 self.last_reconciliation = Some(ReconciliationReport {
                     authoritative_tick: self
                         .local_snapshot
@@ -368,6 +372,7 @@ impl NativeClient {
                 self.ingest_authoritative_snapshot();
                 self.prediction_history.clear();
                 self.last_acknowledged_action_tick = None;
+                self.awaiting_recovery_snapshot = false;
                 self.last_server_tick = *tick;
                 self.last_event_tick = *tick;
                 self.reconnect_token = Some(*reconnect_token);
@@ -395,6 +400,7 @@ impl NativeClient {
 
                 let gap_detected = self.last_server_tick > 0 && *tick > self.last_server_tick + 1;
                 if gap_detected && !*is_full_snapshot {
+                    self.request_full_snapshot();
                     self.authoritative_snapshot = None;
                     self.local_snapshot = None;
                     self.clear_presentation_state();
@@ -418,6 +424,7 @@ impl NativeClient {
                     Ok(snapshot) => snapshot,
                     Err(err) => {
                         error!("Authoritative update rejected at tick {}: {:?}", tick, err);
+                        self.request_full_snapshot();
                         self.authoritative_snapshot = None;
                         self.local_snapshot = None;
                         self.clear_presentation_state();
@@ -427,6 +434,9 @@ impl NativeClient {
                 };
 
                 self.authoritative_snapshot = Some(authoritative_snapshot);
+                if *is_full_snapshot {
+                    self.awaiting_recovery_snapshot = false;
+                }
                 self.ingest_authoritative_snapshot();
                 self.prune_acknowledged_predictions(*acknowledged_action_tick);
                 self.rebuild_predicted_snapshot();
@@ -480,6 +490,7 @@ impl NativeClient {
             quinn::VarInt::from_u32(0),
             reason.unwrap_or("Disconnect").as_bytes(),
         );
+        self.awaiting_recovery_snapshot = false;
         self.clear_presentation_state();
 
         info!("Disconnected from server");
@@ -597,6 +608,68 @@ impl NativeClient {
     fn clear_presentation_state(&mut self) {
         self.render_buffer.clear();
         self.render_clock.reset();
+    }
+
+    fn request_full_snapshot(&mut self) {
+        if self.awaiting_recovery_snapshot {
+            return;
+        }
+
+        let last_known_tick = self
+            .authoritative_snapshot
+            .as_ref()
+            .map(|snapshot| snapshot.tick)
+            .or(Some(self.last_server_tick).filter(|tick| *tick > 0));
+        let last_known_digest = self
+            .authoritative_snapshot
+            .as_ref()
+            .map(WorldSnapshot::digest);
+
+        let message = ClientMessage::RequestFullSnapshot {
+            last_known_tick,
+            last_known_digest,
+        };
+
+        let payload = match message.encode() {
+            Ok(payload) => payload,
+            Err(err) => {
+                warn!("Failed to encode full snapshot recovery request: {}", err);
+                return;
+            }
+        };
+
+        let Some(connection) = self.connection.as_ref().cloned() else {
+            warn!("Failed to request full snapshot recovery: not connected");
+            return;
+        };
+
+        self.awaiting_recovery_snapshot = true;
+        tokio::spawn(async move {
+            let mut send = match connection.open_uni().await {
+                Ok(send) => send,
+                Err(err) => {
+                    warn!("Failed to open recovery request stream: {}", err);
+                    return;
+                }
+            };
+
+            if let Err(err) = send.write_all(&payload).await {
+                warn!("Failed to write recovery request payload: {}", err);
+                return;
+            }
+
+            if let Err(err) = send.finish() {
+                warn!("Failed to finish recovery request stream: {}", err);
+            }
+        });
+    }
+
+    #[cfg(test)]
+    fn request_full_snapshot_without_connection_is_safe(&mut self) {
+        self.request_full_snapshot();
+        if self.connection.is_none() {
+            self.awaiting_recovery_snapshot = false;
+        }
     }
 
     fn record_reconciliation(
@@ -788,6 +861,7 @@ mod tests {
             last_event_tick: 20,
             reconnect_token: None,
             last_reconciliation: None,
+            awaiting_recovery_snapshot: false,
             render_buffer,
             render_clock,
         };
@@ -802,5 +876,42 @@ mod tests {
             client.rollback_preview(Some(20)).unwrap().replayed_batches,
             1
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_request_full_snapshot_without_connection_does_not_arm_recovery_flag() {
+        let endpoint = Endpoint::client("0.0.0.0:0".parse().unwrap()).unwrap();
+        let (tx, rx) = mpsc::channel(1);
+        let mut client = NativeClient {
+            config: ProtoClientConfig {
+                server_addr: "localhost".into(),
+                server_port: 5000,
+                player_name: "Tester".into(),
+                timeout_ms: 1000,
+            },
+            client_id: None,
+            connection: None,
+            endpoint,
+            rx,
+            tx,
+            reader_task: None,
+            pending_updates: Vec::new(),
+            authoritative_snapshot: None,
+            local_snapshot: None,
+            controlled_entity: None,
+            pending_actions: Vec::new(),
+            prediction_history: Vec::new(),
+            last_server_tick: 0,
+            last_acknowledged_action_tick: None,
+            last_event_tick: 0,
+            reconnect_token: None,
+            last_reconciliation: None,
+            awaiting_recovery_snapshot: false,
+            render_buffer: SnapshotInterpolationBuffer::default(),
+            render_clock: RenderClock::default(),
+        };
+
+        client.request_full_snapshot_without_connection_is_safe();
+        assert!(!client.awaiting_recovery_snapshot);
     }
 }

--- a/crates/pod-net/src/client_web.rs
+++ b/crates/pod-net/src/client_web.rs
@@ -55,6 +55,8 @@ pub struct WebClient {
     reconnect_token: Option<ReconnectToken>,
     /// Last authoritative reconciliation outcome.
     last_reconciliation: Option<ReconciliationReport>,
+    /// Whether the client has already requested an immediate recovery snapshot.
+    awaiting_recovery_snapshot: bool,
     /// Authoritative history for presentation smoothing.
     render_buffer: SnapshotInterpolationBuffer,
     /// Presentation clock for interpolation/catch-up recovery.
@@ -85,6 +87,7 @@ impl WebClient {
             last_event_tick: 0,
             reconnect_token: None,
             last_reconciliation: None,
+            awaiting_recovery_snapshot: false,
             render_buffer: SnapshotInterpolationBuffer::default(),
             render_clock: RenderClock::default(),
             reconnect_attempts: 0,
@@ -290,6 +293,7 @@ impl WebClient {
                 self.last_server_tick = *tick;
                 self.last_acknowledged_action_tick = None;
                 self.last_event_tick = *tick;
+                self.awaiting_recovery_snapshot = false;
                 self.reconnect_attempts = 0;
                 self.last_reconciliation = Some(ReconciliationReport {
                     authoritative_tick: *tick,
@@ -315,6 +319,7 @@ impl WebClient {
 
                 let gap_detected = self.last_server_tick > 0 && *tick > self.last_server_tick + 1;
                 if gap_detected && !*is_full_snapshot {
+                    self.request_full_snapshot();
                     self.authoritative_snapshot = None;
                     self.local_snapshot = None;
                     self.clear_presentation_state();
@@ -341,6 +346,7 @@ impl WebClient {
                             &format!("Authoritative update rejected at tick {}: {:?}", tick, err)
                                 .into(),
                         );
+                        self.request_full_snapshot();
                         self.authoritative_snapshot = None;
                         self.local_snapshot = None;
                         self.clear_presentation_state();
@@ -350,6 +356,9 @@ impl WebClient {
                 };
 
                 self.authoritative_snapshot = Some(authoritative_snapshot);
+                if *is_full_snapshot {
+                    self.awaiting_recovery_snapshot = false;
+                }
                 self.ingest_authoritative_snapshot();
                 self.prune_acknowledged_predictions(*acknowledged_action_tick);
                 self.rebuild_predicted_snapshot();
@@ -417,6 +426,7 @@ impl WebClient {
 
         self.websocket = None;
         self.connected = false;
+        self.awaiting_recovery_snapshot = false;
         self.clear_presentation_state();
         Ok(())
     }
@@ -515,6 +525,7 @@ impl WebClient {
         self.local_snapshot = Some(snapshot);
         self.ingest_authoritative_snapshot();
         self.connected = true;
+        self.awaiting_recovery_snapshot = false;
     }
 
     fn prune_acknowledged_predictions(&mut self, acknowledged_action_tick: Option<u64>) {
@@ -546,6 +557,36 @@ impl WebClient {
     fn clear_presentation_state(&mut self) {
         self.render_buffer.clear();
         self.render_clock.reset();
+    }
+
+    fn request_full_snapshot(&mut self) {
+        if self.awaiting_recovery_snapshot {
+            return;
+        }
+
+        let last_known_tick = self
+            .authoritative_snapshot
+            .as_ref()
+            .map(|snapshot| snapshot.tick)
+            .or(Some(self.last_server_tick).filter(|tick| *tick > 0));
+        let last_known_digest = self
+            .authoritative_snapshot
+            .as_ref()
+            .map(WorldSnapshot::digest);
+
+        match self.send_message(ClientMessage::RequestFullSnapshot {
+            last_known_tick,
+            last_known_digest,
+        }) {
+            Ok(()) => {
+                self.awaiting_recovery_snapshot = true;
+            }
+            Err(err) => {
+                web_sys::console::warn_1(
+                    &format!("Failed to request full snapshot recovery: {err}").into(),
+                );
+            }
+        }
     }
 
     fn record_reconciliation(

--- a/crates/pod-net/src/protocol.rs
+++ b/crates/pod-net/src/protocol.rs
@@ -58,6 +58,13 @@ pub enum ClientMessage {
     /// Batch of actions for a specific tick
     ActionBatch { tick: u64, actions: Vec<Action> },
 
+    /// Request an immediate authoritative full snapshot after drift, gap, or
+    /// local baseline loss.
+    RequestFullSnapshot {
+        last_known_tick: Option<u64>,
+        last_known_digest: Option<u64>,
+    },
+
     /// Ping request — measures round-trip time
     Ping { timestamp: u64 },
 }
@@ -221,6 +228,28 @@ mod tests {
             assert_eq!(decoded_token, Some(reconnect_token));
         } else {
             panic!("Wrong message type");
+        }
+    }
+
+    #[test]
+    fn test_full_snapshot_request_roundtrip() {
+        let msg = ClientMessage::RequestFullSnapshot {
+            last_known_tick: Some(42),
+            last_known_digest: Some(99),
+        };
+
+        let encoded = msg.encode().unwrap();
+        let decoded = ClientMessage::decode(&encoded).unwrap();
+
+        match decoded {
+            ClientMessage::RequestFullSnapshot {
+                last_known_tick,
+                last_known_digest,
+            } => {
+                assert_eq!(last_known_tick, Some(42));
+                assert_eq!(last_known_digest, Some(99));
+            }
+            other => panic!("Wrong message type: {other:?}"),
         }
     }
 

--- a/crates/pod-net/src/server.rs
+++ b/crates/pod-net/src/server.rs
@@ -422,6 +422,16 @@ impl GameServer {
                             .await;
                         }
                     }
+                    ClientMessage::RequestFullSnapshot {
+                        last_known_tick,
+                        last_known_digest,
+                    } => {
+                        debug!(
+                            "Client {} requested full snapshot recovery (tick={:?}, digest={:?})",
+                            client_id.0, last_known_tick, last_known_digest
+                        );
+                        self.send_full_snapshot_to_client(client_id).await;
+                    }
                     ClientMessage::Ping { timestamp } => {
                         self.send_to_client(
                             client_id,
@@ -536,6 +546,36 @@ impl GameServer {
                 warn!("Failed to send message to {}: {}", client_id.0, err);
             }
         }
+    }
+
+    fn build_full_snapshot_message(&self, acknowledged_action_tick: Option<u64>) -> ServerMessage {
+        let snapshot = WorldSnapshot::capture(&self.world);
+        let authoritative_digest = snapshot.digest();
+        ServerMessage::StateDelta {
+            tick: self.tick,
+            acknowledged_action_tick,
+            authoritative_digest,
+            is_full_snapshot: true,
+            delta: StateDelta {
+                tick: self.tick,
+                updated: snapshot.entities,
+                destroyed: vec![],
+            },
+        }
+    }
+
+    async fn send_full_snapshot_to_client(&self, client_id: ClientId) {
+        let acknowledged_action_tick = self
+            .clients
+            .read()
+            .await
+            .get(&client_id)
+            .and_then(|session| session.last_processed_action_tick);
+        self.send_to_client(
+            client_id,
+            self.build_full_snapshot_message(acknowledged_action_tick),
+        )
+        .await;
     }
 
     async fn attach_remote_agent(
@@ -703,5 +743,34 @@ mod tests {
 
         assert_eq!(server.current_tick(), 0);
         assert_eq!(server.client_count().await, 0);
+    }
+
+    #[tokio::test]
+    async fn test_build_full_snapshot_message_marks_full_resync() {
+        let config = ProtoServerConfig::default();
+        let world = World::new(42);
+        let server = GameServer::new(config, world);
+
+        let message = server.build_full_snapshot_message(Some(12));
+        match message {
+            ServerMessage::StateDelta {
+                tick,
+                acknowledged_action_tick,
+                authoritative_digest,
+                is_full_snapshot,
+                delta,
+            } => {
+                assert_eq!(tick, 0);
+                assert_eq!(acknowledged_action_tick, Some(12));
+                assert!(is_full_snapshot);
+                assert_eq!(delta.destroyed.len(), 0);
+                let snapshot = WorldSnapshot {
+                    tick,
+                    entities: delta.updated,
+                };
+                assert_eq!(snapshot.digest(), authoritative_digest);
+            }
+            other => panic!("unexpected message: {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add a direct-connect full-snapshot recovery request to the pod-net protocol
- let the authoritative server answer recovery requests with an immediate full StateDelta snapshot
- trigger one-shot recovery requests from native and web clients when they detect snapshot gaps or digest/baseline failures

## Validation
- cargo test -p pod-net --lib
- cargo test -p pod-net --features spacetimedb --lib
- cargo check -p pod-net --target wasm32-unknown-unknown --lib