### PR TITLE
Add pod-net recovery retry telemetry

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -451,5 +451,16 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cargo test -p pod-net --lib`
   - `cargo check -p pod-net --target wasm32-unknown-unknown --lib`
 
-**Last updated**: Iteration 54
+### Iteration 55 — Pod-Net Recovery Retry Telemetry
+
+- [x] Added shared `RecoveryRequestState` to `pod-net` diagnostics so tooling can inspect whether a client is awaiting a full snapshot, how many requests have been issued, and when the next retry becomes eligible.
+- [x] Replaced the direct-connect clients' one-bit recovery latch with throttled retry state, allowing native QUIC and browser WebSocket clients to re-request recovery snapshots after a bounded tick interval instead of getting stuck after one failed attempt.
+- [x] Threaded recovery telemetry through `CatchUpDiagnostics` for native, web, and SpacetimeDB-facing diagnostics surfaces.
+- [x] Added deterministic coverage for retry throttling and recovery telemetry in the snapshot-layer diagnostics tests.
+- [x] Validated touched targets:
+  - `cargo test -p pod-net --lib`
+  - `cargo test -p pod-net --features spacetimedb --lib`
+  - `cargo check -p pod-net --target wasm32-unknown-unknown --lib`
+
+**Last updated**: Iteration 55
 **Current focus**: Phase 3 authority parity and shared-simulation recovery for the RuneScape-style MMO + companion-creature vertical slice

--- a/crates/pod-net/src/client_native.rs
+++ b/crates/pod-net/src/client_native.rs
@@ -19,8 +19,11 @@ use crate::protocol::{
 use crate::snapshot::{
     apply_authoritative_update, build_catch_up_diagnostics, build_rollback_preview,
     compose_presentation_snapshot, CatchUpDiagnostics, InterpolatedSnapshot, PredictedActionBatch,
-    ReconciliationReport, RenderClock, RollbackPreview, SnapshotInterpolationBuffer, WorldSnapshot,
+    ReconciliationReport, RecoveryRequestState, RenderClock, RollbackPreview,
+    SnapshotInterpolationBuffer, WorldSnapshot,
 };
+
+const RECOVERY_REQUEST_RETRY_TICKS: u64 = 5;
 
 // ============================================================
 // NATIVE CLIENT
@@ -59,8 +62,8 @@ pub struct NativeClient {
     reconnect_token: Option<ReconnectToken>,
     /// Last authoritative reconciliation outcome.
     last_reconciliation: Option<ReconciliationReport>,
-    /// Whether the client has already requested an immediate recovery snapshot.
-    awaiting_recovery_snapshot: bool,
+    /// Recovery request throttle/telemetry for full-snapshot resync.
+    recovery_state: RecoveryRequestState,
     /// Authoritative history for presentation smoothing.
     render_buffer: SnapshotInterpolationBuffer,
     /// Presentation clock for interpolation/catch-up recovery.
@@ -150,7 +153,7 @@ impl NativeClient {
             last_event_tick: 0,
             reconnect_token: None,
             last_reconciliation: None,
-            awaiting_recovery_snapshot: false,
+            recovery_state: RecoveryRequestState::default(),
             render_buffer: SnapshotInterpolationBuffer::default(),
             render_clock: RenderClock::default(),
         };
@@ -196,7 +199,7 @@ impl NativeClient {
                 self.reconnect_token = Some(reconnect_token);
                 self.prediction_history.clear();
                 self.last_acknowledged_action_tick = None;
-                self.awaiting_recovery_snapshot = false;
+                self.recovery_state.clear();
                 self.last_reconciliation = Some(ReconciliationReport {
                     authoritative_tick: self
                         .local_snapshot
@@ -372,7 +375,7 @@ impl NativeClient {
                 self.ingest_authoritative_snapshot();
                 self.prediction_history.clear();
                 self.last_acknowledged_action_tick = None;
-                self.awaiting_recovery_snapshot = false;
+                self.recovery_state.clear();
                 self.last_server_tick = *tick;
                 self.last_event_tick = *tick;
                 self.reconnect_token = Some(*reconnect_token);
@@ -400,7 +403,7 @@ impl NativeClient {
 
                 let gap_detected = self.last_server_tick > 0 && *tick > self.last_server_tick + 1;
                 if gap_detected && !*is_full_snapshot {
-                    self.request_full_snapshot();
+                    self.request_full_snapshot(*tick);
                     self.authoritative_snapshot = None;
                     self.local_snapshot = None;
                     self.clear_presentation_state();
@@ -424,7 +427,7 @@ impl NativeClient {
                     Ok(snapshot) => snapshot,
                     Err(err) => {
                         error!("Authoritative update rejected at tick {}: {:?}", tick, err);
-                        self.request_full_snapshot();
+                        self.request_full_snapshot(*tick);
                         self.authoritative_snapshot = None;
                         self.local_snapshot = None;
                         self.clear_presentation_state();
@@ -435,7 +438,7 @@ impl NativeClient {
 
                 self.authoritative_snapshot = Some(authoritative_snapshot);
                 if *is_full_snapshot {
-                    self.awaiting_recovery_snapshot = false;
+                    self.recovery_state.clear();
                 }
                 self.ingest_authoritative_snapshot();
                 self.prune_acknowledged_predictions(*acknowledged_action_tick);
@@ -490,7 +493,7 @@ impl NativeClient {
             quinn::VarInt::from_u32(0),
             reason.unwrap_or("Disconnect").as_bytes(),
         );
-        self.awaiting_recovery_snapshot = false;
+        self.recovery_state.clear();
         self.clear_presentation_state();
 
         info!("Disconnected from server");
@@ -561,6 +564,7 @@ impl NativeClient {
             self.controlled_entity,
             &self.prediction_history,
             &self.render_clock,
+            &self.recovery_state,
         )
     }
 
@@ -610,8 +614,17 @@ impl NativeClient {
         self.render_clock.reset();
     }
 
-    fn request_full_snapshot(&mut self) {
-        if self.awaiting_recovery_snapshot {
+    fn request_full_snapshot(&mut self, observed_server_tick: u64) {
+        let current_server_tick = observed_server_tick.max(
+            self.authoritative_snapshot
+                .as_ref()
+                .map(|snapshot| snapshot.tick)
+                .unwrap_or(self.last_server_tick),
+        );
+        if !self
+            .recovery_state
+            .can_request(current_server_tick, RECOVERY_REQUEST_RETRY_TICKS)
+        {
             return;
         }
 
@@ -643,7 +656,8 @@ impl NativeClient {
             return;
         };
 
-        self.awaiting_recovery_snapshot = true;
+        self.recovery_state
+            .record_request(current_server_tick, last_known_digest);
         tokio::spawn(async move {
             let mut send = match connection.open_uni().await {
                 Ok(send) => send,
@@ -666,9 +680,9 @@ impl NativeClient {
 
     #[cfg(test)]
     fn request_full_snapshot_without_connection_is_safe(&mut self) {
-        self.request_full_snapshot();
+        self.request_full_snapshot(self.last_server_tick);
         if self.connection.is_none() {
-            self.awaiting_recovery_snapshot = false;
+            self.recovery_state.clear();
         }
     }
 
@@ -861,7 +875,7 @@ mod tests {
             last_event_tick: 20,
             reconnect_token: None,
             last_reconciliation: None,
-            awaiting_recovery_snapshot: false,
+            recovery_state: RecoveryRequestState::default(),
             render_buffer,
             render_clock,
         };
@@ -906,12 +920,12 @@ mod tests {
             last_event_tick: 0,
             reconnect_token: None,
             last_reconciliation: None,
-            awaiting_recovery_snapshot: false,
+            recovery_state: RecoveryRequestState::default(),
             render_buffer: SnapshotInterpolationBuffer::default(),
             render_clock: RenderClock::default(),
         };
 
         client.request_full_snapshot_without_connection_is_safe();
-        assert!(!client.awaiting_recovery_snapshot);
+        assert_eq!(client.recovery_state, RecoveryRequestState::default());
     }
 }

--- a/crates/pod-net/src/client_stdb.rs
+++ b/crates/pod-net/src/client_stdb.rs
@@ -60,8 +60,8 @@ use pod_stdb::types::{
 use crate::protocol::{ClientId, ReconnectToken, ServerMessage};
 use crate::snapshot::{
     build_catch_up_diagnostics, build_rollback_preview, compose_presentation_snapshot,
-    CatchUpDiagnostics, EntitySnapshot, InterpolatedSnapshot, RenderClock, RollbackPreview,
-    SnapshotInterpolationBuffer, StateDelta, WorldSnapshot,
+    CatchUpDiagnostics, EntitySnapshot, InterpolatedSnapshot, RecoveryRequestState, RenderClock,
+    RollbackPreview, SnapshotInterpolationBuffer, StateDelta, WorldSnapshot,
 };
 
 // ============================================================
@@ -869,6 +869,7 @@ impl SpacetimeDBClient {
             self.inner.controlled_entity(),
             &[],
             &self.render_clock,
+            &RecoveryRequestState::default(),
         )
     }
 

--- a/crates/pod-net/src/client_web.rs
+++ b/crates/pod-net/src/client_web.rs
@@ -17,8 +17,11 @@ use crate::protocol::{ClientConfig, ClientId, ClientMessage, ReconnectToken, Ser
 use crate::snapshot::{
     apply_authoritative_update, build_catch_up_diagnostics, build_rollback_preview,
     compose_presentation_snapshot, CatchUpDiagnostics, InterpolatedSnapshot, PredictedActionBatch,
-    ReconciliationReport, RenderClock, RollbackPreview, SnapshotInterpolationBuffer, WorldSnapshot,
+    ReconciliationReport, RecoveryRequestState, RenderClock, RollbackPreview,
+    SnapshotInterpolationBuffer, WorldSnapshot,
 };
+
+const RECOVERY_REQUEST_RETRY_TICKS: u64 = 5;
 
 #[derive(Debug, Default)]
 struct WebRuntimeState {
@@ -55,8 +58,8 @@ pub struct WebClient {
     reconnect_token: Option<ReconnectToken>,
     /// Last authoritative reconciliation outcome.
     last_reconciliation: Option<ReconciliationReport>,
-    /// Whether the client has already requested an immediate recovery snapshot.
-    awaiting_recovery_snapshot: bool,
+    /// Recovery request throttle/telemetry for full-snapshot resync.
+    recovery_state: RecoveryRequestState,
     /// Authoritative history for presentation smoothing.
     render_buffer: SnapshotInterpolationBuffer,
     /// Presentation clock for interpolation/catch-up recovery.
@@ -87,7 +90,7 @@ impl WebClient {
             last_event_tick: 0,
             reconnect_token: None,
             last_reconciliation: None,
-            awaiting_recovery_snapshot: false,
+            recovery_state: RecoveryRequestState::default(),
             render_buffer: SnapshotInterpolationBuffer::default(),
             render_clock: RenderClock::default(),
             reconnect_attempts: 0,
@@ -293,7 +296,7 @@ impl WebClient {
                 self.last_server_tick = *tick;
                 self.last_acknowledged_action_tick = None;
                 self.last_event_tick = *tick;
-                self.awaiting_recovery_snapshot = false;
+                self.recovery_state.clear();
                 self.reconnect_attempts = 0;
                 self.last_reconciliation = Some(ReconciliationReport {
                     authoritative_tick: *tick,
@@ -319,7 +322,7 @@ impl WebClient {
 
                 let gap_detected = self.last_server_tick > 0 && *tick > self.last_server_tick + 1;
                 if gap_detected && !*is_full_snapshot {
-                    self.request_full_snapshot();
+                    self.request_full_snapshot(*tick);
                     self.authoritative_snapshot = None;
                     self.local_snapshot = None;
                     self.clear_presentation_state();
@@ -346,7 +349,7 @@ impl WebClient {
                             &format!("Authoritative update rejected at tick {}: {:?}", tick, err)
                                 .into(),
                         );
-                        self.request_full_snapshot();
+                        self.request_full_snapshot(*tick);
                         self.authoritative_snapshot = None;
                         self.local_snapshot = None;
                         self.clear_presentation_state();
@@ -357,7 +360,7 @@ impl WebClient {
 
                 self.authoritative_snapshot = Some(authoritative_snapshot);
                 if *is_full_snapshot {
-                    self.awaiting_recovery_snapshot = false;
+                    self.recovery_state.clear();
                 }
                 self.ingest_authoritative_snapshot();
                 self.prune_acknowledged_predictions(*acknowledged_action_tick);
@@ -426,7 +429,7 @@ impl WebClient {
 
         self.websocket = None;
         self.connected = false;
-        self.awaiting_recovery_snapshot = false;
+        self.recovery_state.clear();
         self.clear_presentation_state();
         Ok(())
     }
@@ -495,6 +498,7 @@ impl WebClient {
             self.controlled_entity,
             &self.prediction_history,
             &self.render_clock,
+            &self.recovery_state,
         )
     }
 
@@ -525,7 +529,7 @@ impl WebClient {
         self.local_snapshot = Some(snapshot);
         self.ingest_authoritative_snapshot();
         self.connected = true;
-        self.awaiting_recovery_snapshot = false;
+        self.recovery_state.clear();
     }
 
     fn prune_acknowledged_predictions(&mut self, acknowledged_action_tick: Option<u64>) {
@@ -559,8 +563,17 @@ impl WebClient {
         self.render_clock.reset();
     }
 
-    fn request_full_snapshot(&mut self) {
-        if self.awaiting_recovery_snapshot {
+    fn request_full_snapshot(&mut self, observed_server_tick: u64) {
+        let current_server_tick = observed_server_tick.max(
+            self.authoritative_snapshot
+                .as_ref()
+                .map(|snapshot| snapshot.tick)
+                .unwrap_or(self.last_server_tick),
+        );
+        if !self
+            .recovery_state
+            .can_request(current_server_tick, RECOVERY_REQUEST_RETRY_TICKS)
+        {
             return;
         }
 
@@ -579,7 +592,8 @@ impl WebClient {
             last_known_digest,
         }) {
             Ok(()) => {
-                self.awaiting_recovery_snapshot = true;
+                self.recovery_state
+                    .record_request(current_server_tick, last_known_digest);
             }
             Err(err) => {
                 web_sys::console::warn_1(

--- a/crates/pod-net/src/lib.rs
+++ b/crates/pod-net/src/lib.rs
@@ -70,8 +70,8 @@ pub use snapshot::{
     apply_authoritative_update, build_catch_up_diagnostics, build_rollback_preview,
     compose_presentation_snapshot, CatchUpDiagnostics, EntityDrift, EntitySnapshot,
     InterpolatedSnapshot, InterpolationConfig, PredictedActionBatch, ReconciliationReport,
-    RenderClock, RollbackPreview, SnapshotInterpolationBuffer, SnapshotSampleMode,
-    SnapshotUpdateError, StateDelta, WorldSnapshot,
+    RecoveryRequestState, RenderClock, RollbackPreview, SnapshotInterpolationBuffer,
+    SnapshotSampleMode, SnapshotUpdateError, StateDelta, WorldSnapshot,
 };
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/pod-net/src/snapshot.rs
+++ b/crates/pod-net/src/snapshot.rs
@@ -122,6 +122,45 @@ pub struct CatchUpDiagnostics {
     pub pending_action_batches: usize,
     pub replayed_action_count: usize,
     pub controlled_entity_drift: Option<EntityDrift>,
+    pub recovery: RecoveryRequestState,
+}
+
+/// State for throttled full-snapshot recovery requests after drift or baseline
+/// loss.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RecoveryRequestState {
+    pub awaiting_full_snapshot: bool,
+    pub request_attempts: u32,
+    pub last_request_server_tick: Option<u64>,
+    pub last_request_digest: Option<u64>,
+}
+
+impl RecoveryRequestState {
+    pub fn clear(&mut self) {
+        *self = Self::default();
+    }
+
+    pub fn can_request(&self, current_server_tick: u64, retry_interval_ticks: u64) -> bool {
+        if !self.awaiting_full_snapshot {
+            return true;
+        }
+
+        self.last_request_server_tick
+            .map(|last_tick| current_server_tick >= last_tick.saturating_add(retry_interval_ticks))
+            .unwrap_or(true)
+    }
+
+    pub fn record_request(&mut self, current_server_tick: u64, digest: Option<u64>) {
+        self.awaiting_full_snapshot = true;
+        self.request_attempts = self.request_attempts.saturating_add(1);
+        self.last_request_server_tick = Some(current_server_tick);
+        self.last_request_digest = digest;
+    }
+
+    pub fn next_retry_tick(&self, retry_interval_ticks: u64) -> Option<u64> {
+        self.last_request_server_tick
+            .map(|tick| tick.saturating_add(retry_interval_ticks))
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -678,6 +717,7 @@ pub fn build_catch_up_diagnostics(
     controlled_entity: Option<u64>,
     prediction_history: &[PredictedActionBatch],
     render_clock: &RenderClock,
+    recovery: &RecoveryRequestState,
 ) -> CatchUpDiagnostics {
     let latest_authoritative_tick = authoritative_history
         .latest_tick()
@@ -709,6 +749,7 @@ pub fn build_catch_up_diagnostics(
         controlled_entity_drift: controlled_entity.and_then(|entity_id| {
             entity_drift_between_snapshots(authoritative_snapshot?, predicted_snapshot?, entity_id)
         }),
+        recovery: recovery.clone(),
     }
 }
 
@@ -1444,6 +1485,9 @@ mod tests {
         let presentation_tick = clock.advance(12, 1.0 / 60.0);
         assert!((presentation_tick - 11.0).abs() < 0.001);
 
+        let mut recovery = RecoveryRequestState::default();
+        recovery.record_request(12, Some(authoritative.digest()));
+
         let diagnostics = build_catch_up_diagnostics(
             &buffer,
             Some(&authoritative),
@@ -1454,6 +1498,7 @@ mod tests {
                 actions: vec![Action::Move { direction: Vec2::X }],
             }],
             &clock,
+            &recovery,
         );
 
         assert_eq!(diagnostics.authoritative_tick, Some(12));
@@ -1474,6 +1519,23 @@ mod tests {
                 .position_error
                 > 1.9
         );
+        assert!(diagnostics.recovery.awaiting_full_snapshot);
+        assert_eq!(diagnostics.recovery.request_attempts, 1);
+        assert_eq!(diagnostics.recovery.last_request_server_tick, Some(12));
+    }
+
+    #[test]
+    fn test_recovery_request_state_throttles_retries() {
+        let mut recovery = RecoveryRequestState::default();
+        assert!(recovery.can_request(10, 5));
+
+        recovery.record_request(10, Some(99));
+        assert!(!recovery.can_request(12, 5));
+        assert!(recovery.can_request(15, 5));
+        assert_eq!(recovery.next_retry_tick(5), Some(15));
+
+        recovery.clear();
+        assert_eq!(recovery, RecoveryRequestState::default());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add shared recovery retry telemetry to pod-net diagnostics
- throttle native and web full-snapshot recovery requests by server tick instead of using a one-bit latch
- expose recovery request state through catch-up diagnostics for native, web, and SpacetimeDB adapters

## Validation
- cargo test -p pod-net --lib
- cargo test -p pod-net --features spacetimedb --lib
- cargo check -p pod-net --target wasm32-unknown-unknown --lib

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated implementation plan with Iteration 55 details and recovery-related notes.

* **Refactor**
  * Enhanced recovery request handling mechanism across all client implementations with improved state tracking and throttling.
  * Introduced new recovery state type with request lifecycle management capabilities.
  * Updated diagnostics to include recovery state information.
  * Modified snapshot request method to accept tick parameter for improved request timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->