### PR TITLE
Add core agent telemetry primitives

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -462,5 +462,16 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cargo test -p pod-net --features spacetimedb --lib`
   - `cargo check -p pod-net --target wasm32-unknown-unknown --lib`
 
-**Last updated**: Iteration 55
-**Current focus**: Phase 3 authority parity and shared-simulation recovery for the RuneScape-style MMO + companion-creature vertical slice
+### Iteration 56 — Core Agent Telemetry and Trajectory Primitives
+
+- [x] Added `pod-core::telemetry` with authoritative trajectory samples, per-action lifecycle traces, shared tool-call telemetry, tick-scoped agent telemetry frames, and a ring-buffer `TelemetryArchive` resource for tooling/debug overlays.
+- [x] Extended `TickResult` so the authoritative observe → decide → validate → execute pipeline emits per-agent telemetry for both human and AI agents, including start/end trajectory samples and submitted/executed/rejected action traces.
+- [x] Registered telemetry contracts/resources in `pod-core::App`, automatically persisted the latest tick telemetry into `TelemetryArchive`, and added a versioned `VersionedTickTelemetry` contract primitive alongside existing action/observation wrappers.
+- [x] Extended `pod-agents::DecisionEntry` with shared tool-call telemetry primitives so LLM-backed and non-LLM agents can report external side effects through one log schema.
+- [x] Added deterministic coverage for trajectory reconstruction, authoritative tick telemetry capture, rejected external-action traces, telemetry archive retention, and decision-log tool-call preservation.
+- [x] Validated touched targets:
+  - `cargo test -p pod-core --lib`
+  - `cargo test -p pod-agents --lib`
+
+**Last updated**: Iteration 56
+**Current focus**: Phase 4 agent/runtime parity instrumentation for the RuneScape-style MMO + companion-creature vertical slice, then surfacing telemetry into browser/editor debug tooling

--- a/crates/pod-agents/src/decision_log.rs
+++ b/crates/pod-agents/src/decision_log.rs
@@ -34,6 +34,7 @@
 //!     decision_method: DecisionMethod::Scripted { rule_name: "patrol".into() },
 //!     actions_produced: vec![],
 //!     timing: DecisionTiming { observe_us: 10, decide_us: 20, total_us: 30 },
+//!     tool_calls: vec![],
 //!     metadata: HashMap::new(),
 //! };
 //!
@@ -48,7 +49,7 @@ use serde::{Deserialize, Serialize};
 
 use pod_core::observation::Relationship;
 use pod_core::replay::{DecisionTrace, ReplayFile, ReplayHeader};
-use pod_core::{Action, AgentId, AgentType, Observation};
+use pod_core::{Action, AgentId, AgentToolCallTrace, AgentType, Observation};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // ObservationSummary
@@ -221,6 +222,8 @@ pub struct DecisionEntry {
     pub actions_produced: Vec<Action>,
     /// Timing breakdown for this cycle.
     pub timing: DecisionTiming,
+    /// Tool/LLM side effects emitted while producing the decision.
+    pub tool_calls: Vec<AgentToolCallTrace>,
     /// Arbitrary key/value metadata (agent-specific diagnostics, test tags, …).
     pub metadata: HashMap<String, String>,
 }
@@ -627,7 +630,7 @@ impl DecisionLogger {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pod_core::{Action, AgentId, AgentType, Observation};
+    use pod_core::{Action, AgentId, AgentToolCallTrace, AgentType, Observation};
 
     // ── helpers ────────────────────────────────────────────────────────────
 
@@ -654,6 +657,7 @@ mod tests {
                 decide_us: 200,
                 total_us: 300,
             },
+            tool_calls: Vec::new(),
             metadata: HashMap::new(),
         }
     }
@@ -958,5 +962,23 @@ mod tests {
         assert!((summary.health_fraction.unwrap() - 0.5).abs() < f32::EPSILON);
         assert_eq!(summary.position, Vec2::new(3.0, 4.0));
         assert_eq!(summary.active_objectives, 1); // only the non-completed one
+    }
+
+    #[test]
+    fn decision_entries_preserve_tool_call_telemetry() {
+        let mut logger = DecisionLogger::new();
+        let agent_id = AgentId::new();
+        let mut entry = make_llm_entry(8, agent_id);
+        entry.tool_calls.push(AgentToolCallTrace::success(
+            8, "pathfind", "openai", 22, 144, 64,
+        ));
+
+        logger.log(entry);
+
+        let stored = logger.entries_for_agent(agent_id);
+        assert_eq!(stored.len(), 1);
+        assert_eq!(stored[0].tool_calls.len(), 1);
+        assert_eq!(stored[0].tool_calls[0].tool_name, "pathfind");
+        assert_eq!(stored[0].tool_calls[0].provider, "openai");
     }
 }

--- a/crates/pod-core/src/app.rs
+++ b/crates/pod-core/src/app.rs
@@ -7,8 +7,9 @@ use crate::component::{
     Health, Inventory, Label, LootContainer, Movement, Perception, ResourceNode, Script, SkillBook,
     Sprite, Transform, Transform3D, Velocity,
 };
-use crate::contract::{VersionedAgentAction, VersionedObservation};
+use crate::contract::{VersionedAgentAction, VersionedObservation, VersionedTickTelemetry};
 use crate::observation::Observation;
+use crate::telemetry::{TelemetryArchive, TickTelemetryFrame};
 use crate::tick::TickResult;
 use crate::World;
 
@@ -167,6 +168,7 @@ impl App {
             broadcast: Vec::new(),
         };
         app.register_core_types();
+        let _ = app.resources.insert(TelemetryArchive::default());
         app
     }
 
@@ -224,6 +226,9 @@ impl App {
 
         let result = self.world.step();
         let _ = self.resources.insert(LastTickResult(result.clone()));
+        if let Some(archive) = self.resources.get_mut::<TelemetryArchive>() {
+            archive.record_tick(result.telemetry.clone());
+        }
 
         self.run_phase(SchedulePhase::PostTick);
         self.run_phase(SchedulePhase::Broadcast);
@@ -301,15 +306,22 @@ impl App {
         self.types.register_contract::<Observation>("Observation");
         self.types.register_contract::<AgentAction>("AgentAction");
         self.types
+            .register_contract::<TickTelemetryFrame>("TickTelemetryFrame");
+        self.types
             .register_contract::<VersionedObservation>("VersionedObservation");
         self.types
             .register_contract::<VersionedAgentAction>("VersionedAgentAction");
+        self.types
+            .register_contract::<VersionedTickTelemetry>("VersionedTickTelemetry");
+        self.types
+            .register_resource::<TelemetryArchive>("TelemetryArchive");
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::{App, LastTickResult, Plugin, RegisteredTypeCategory, SchedulePhase};
+    use crate::telemetry::TelemetryArchive;
 
     struct TracePlugin;
 
@@ -395,5 +407,26 @@ mod tests {
             .metadata::<crate::observation::Observation>()
             .expect("observation metadata");
         assert_eq!(observation.category, RegisteredTypeCategory::Contract);
+
+        let archive = app
+            .resources()
+            .get::<TelemetryArchive>()
+            .expect("telemetry archive resource");
+        assert!(archive.latest().is_none());
+    }
+
+    #[test]
+    fn app_records_tick_telemetry_into_archive() {
+        let mut app = App::new(11);
+
+        let result = app.update();
+
+        let archive = app
+            .resources()
+            .get::<TelemetryArchive>()
+            .expect("telemetry archive resource");
+        let latest = archive.latest().expect("latest tick telemetry");
+        assert_eq!(latest.tick, result.tick);
+        assert_eq!(latest.tick, 0);
     }
 }

--- a/crates/pod-core/src/contract.rs
+++ b/crates/pod-core/src/contract.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::action::AgentAction;
 use crate::agent::AgentType;
 use crate::observation::Observation;
+use crate::telemetry::TickTelemetryFrame;
 
 pub const RUNTIME_CONTRACT_VERSION_V1: u16 = 1;
 
@@ -160,16 +161,33 @@ impl VersionedObservation {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VersionedTickTelemetry {
+    pub version: RuntimeContractVersion,
+    pub payload: TickTelemetryFrame,
+}
+
+impl VersionedTickTelemetry {
+    pub fn new(payload: TickTelemetryFrame) -> Self {
+        Self {
+            version: RuntimeContractVersion::V1,
+            payload,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::action::{Action, AgentAction};
     use crate::agent::AgentType;
     use crate::id::AgentId;
     use crate::observation::Observation;
+    use crate::telemetry::TickTelemetryFrame;
 
     use super::{
         AgentCapabilities, AgentRole, AgentRuntimeProfile, RuntimeContractVersion,
-        VersionedAgentAction, VersionedObservation, RUNTIME_CONTRACT_VERSION_V1,
+        VersionedAgentAction, VersionedObservation, VersionedTickTelemetry,
+        RUNTIME_CONTRACT_VERSION_V1,
     };
 
     #[test]
@@ -213,5 +231,9 @@ mod tests {
         let observation = Observation::default();
         let versioned_observation = VersionedObservation::new(profile, observation.clone());
         assert_eq!(versioned_observation.payload.tick, observation.tick);
+
+        let telemetry = TickTelemetryFrame::empty(9);
+        let versioned_telemetry = VersionedTickTelemetry::new(telemetry.clone());
+        assert_eq!(versioned_telemetry.payload.tick, telemetry.tick);
     }
 }

--- a/crates/pod-core/src/lib.rs
+++ b/crates/pod-core/src/lib.rs
@@ -14,6 +14,7 @@
 //! - **Orchestrator** (`orchestrator`): Efficiently batches many AI agents with priority scheduling
 //! - **Enhanced Constraints** (`constraint`): Production-grade validation with budgets and reaction gates
 //! - **Observation Filtering** (`observation_filter`): Compresses observations to fit LLM token budgets
+//! - **Telemetry** (`telemetry`): Authoritative per-tick trajectories, action traces, and tool-call primitives
 
 #![allow(clippy::assign_op_pattern)]
 #![allow(clippy::collapsible_if)]
@@ -41,6 +42,7 @@ pub mod observation;
 pub mod observation_filter;
 pub mod orchestrator;
 pub mod replay;
+pub mod telemetry;
 pub mod tick;
 pub mod world;
 
@@ -57,7 +59,8 @@ pub use constraint::{
 };
 pub use contract::{
     AgentCapabilities, AgentRole, AgentRuntimeProfile, RuntimeContractVersion,
-    VersionedAgentAction, VersionedObservation, RUNTIME_CONTRACT_VERSION_V1,
+    VersionedAgentAction, VersionedObservation, VersionedTickTelemetry,
+    RUNTIME_CONTRACT_VERSION_V1,
 };
 pub use event::*;
 pub use id::*;
@@ -67,6 +70,10 @@ pub use observation_filter::{
 };
 pub use orchestrator::{AgentBatch, AgentOrchestrator, DecisionFreshness, PriorityScore};
 pub use replay::{DecisionTrace, ReplayFile, ReplayHeader, ReplayPlayer, ReplayRecorder};
+pub use telemetry::{
+    ActionLifecycleStage, ActionSource, AgentActionTrace, AgentTelemetryFrame, AgentToolCallTrace,
+    AgentTrajectoryFrame, TelemetryArchive, TickTelemetryFrame, ToolCallStatus, TrajectorySample,
+};
 pub use world::World;
 
 /// Fixed tick rate — all agents operate on the same clock

--- a/crates/pod-core/src/telemetry.rs
+++ b/crates/pod-core/src/telemetry.rs
@@ -1,0 +1,403 @@
+use std::collections::VecDeque;
+
+use glam::Vec2;
+use serde::{Deserialize, Serialize};
+
+use crate::action::Action;
+use crate::contract::AgentRuntimeProfile;
+use crate::id::{AgentId, EntityId};
+
+/// Single trajectory sample for one agent at a specific simulation boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct TrajectorySample {
+    pub tick: u64,
+    pub elapsed_secs: f32,
+    pub position: Vec2,
+    pub velocity: Vec2,
+    pub rotation: f32,
+}
+
+impl TrajectorySample {
+    pub fn new(
+        tick: u64,
+        elapsed_secs: f32,
+        position: Vec2,
+        velocity: Vec2,
+        rotation: f32,
+    ) -> Self {
+        Self {
+            tick,
+            elapsed_secs,
+            position,
+            velocity,
+            rotation,
+        }
+    }
+}
+
+/// Start/end trajectory state for one agent during a single authoritative tick.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AgentTrajectoryFrame {
+    pub start: TrajectorySample,
+    pub end: TrajectorySample,
+    pub displacement: Vec2,
+    pub distance_travelled: f32,
+}
+
+impl AgentTrajectoryFrame {
+    pub fn new(start: TrajectorySample, end: TrajectorySample) -> Self {
+        let displacement = end.position - start.position;
+        Self {
+            start,
+            end,
+            displacement,
+            distance_travelled: displacement.length(),
+        }
+    }
+
+    pub fn update_end(&mut self, end: TrajectorySample) {
+        *self = Self::new(self.start, end);
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ActionSource {
+    AgentDecision,
+    ExternalSubmission,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ActionLifecycleStage {
+    Submitted,
+    Executed,
+    Rejected,
+    Queued,
+}
+
+/// Action event recorded for parity/debug telemetry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentActionTrace {
+    pub source: ActionSource,
+    pub stage: ActionLifecycleStage,
+    pub action: Action,
+    pub rejection_reason: Option<String>,
+}
+
+impl AgentActionTrace {
+    pub fn new(
+        source: ActionSource,
+        stage: ActionLifecycleStage,
+        action: Action,
+        rejection_reason: Option<String>,
+    ) -> Self {
+        Self {
+            source,
+            stage,
+            action,
+            rejection_reason,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ToolCallStatus {
+    Requested,
+    Succeeded,
+    Failed,
+    TimedOut,
+    Rejected,
+}
+
+/// Generic tool/LLM side-effect telemetry shared across embedded agent runtimes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentToolCallTrace {
+    pub tick: u64,
+    pub tool_name: String,
+    pub provider: String,
+    pub status: ToolCallStatus,
+    pub latency_ms: u32,
+    pub request_units: u32,
+    pub response_units: u32,
+    pub error_message: Option<String>,
+}
+
+impl AgentToolCallTrace {
+    pub fn success(
+        tick: u64,
+        tool_name: impl Into<String>,
+        provider: impl Into<String>,
+        latency_ms: u32,
+        request_units: u32,
+        response_units: u32,
+    ) -> Self {
+        Self {
+            tick,
+            tool_name: tool_name.into(),
+            provider: provider.into(),
+            status: ToolCallStatus::Succeeded,
+            latency_ms,
+            request_units,
+            response_units,
+            error_message: None,
+        }
+    }
+
+    pub fn failure(
+        tick: u64,
+        tool_name: impl Into<String>,
+        provider: impl Into<String>,
+        status: ToolCallStatus,
+        latency_ms: u32,
+        error_message: impl Into<String>,
+    ) -> Self {
+        Self {
+            tick,
+            tool_name: tool_name.into(),
+            provider: provider.into(),
+            status,
+            latency_ms,
+            request_units: 0,
+            response_units: 0,
+            error_message: Some(error_message.into()),
+        }
+    }
+}
+
+/// Authoritative telemetry for one agent over one simulation tick.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentTelemetryFrame {
+    pub tick: u64,
+    pub agent_id: AgentId,
+    pub entity_id: Option<EntityId>,
+    pub runtime_profile: AgentRuntimeProfile,
+    pub visible_entity_count: usize,
+    pub audible_event_count: usize,
+    pub message_count: usize,
+    pub available_action_count: usize,
+    pub objective_count: usize,
+    pub trajectory: Option<AgentTrajectoryFrame>,
+    pub action_trace: Vec<AgentActionTrace>,
+    pub tool_calls: Vec<AgentToolCallTrace>,
+}
+
+impl AgentTelemetryFrame {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        tick: u64,
+        agent_id: AgentId,
+        entity_id: Option<EntityId>,
+        runtime_profile: AgentRuntimeProfile,
+        visible_entity_count: usize,
+        audible_event_count: usize,
+        message_count: usize,
+        available_action_count: usize,
+        objective_count: usize,
+        trajectory_start: Option<TrajectorySample>,
+    ) -> Self {
+        Self {
+            tick,
+            agent_id,
+            entity_id,
+            runtime_profile,
+            visible_entity_count,
+            audible_event_count,
+            message_count,
+            available_action_count,
+            objective_count,
+            trajectory: trajectory_start.map(|start| AgentTrajectoryFrame::new(start, start)),
+            action_trace: Vec::new(),
+            tool_calls: Vec::new(),
+        }
+    }
+
+    pub fn record_action(
+        &mut self,
+        source: ActionSource,
+        stage: ActionLifecycleStage,
+        action: Action,
+        rejection_reason: Option<String>,
+    ) {
+        self.action_trace.push(AgentActionTrace::new(
+            source,
+            stage,
+            action,
+            rejection_reason,
+        ));
+    }
+
+    pub fn record_tool_call(&mut self, trace: AgentToolCallTrace) {
+        self.tool_calls.push(trace);
+    }
+
+    pub fn update_trajectory_end(&mut self, end: TrajectorySample) {
+        if let Some(trajectory) = &mut self.trajectory {
+            trajectory.update_end(end);
+        } else {
+            self.trajectory = Some(AgentTrajectoryFrame::new(end, end));
+        }
+    }
+}
+
+/// Telemetry for the full authoritative tick.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TickTelemetryFrame {
+    pub tick: u64,
+    pub agents: Vec<AgentTelemetryFrame>,
+}
+
+impl TickTelemetryFrame {
+    pub fn empty(tick: u64) -> Self {
+        Self {
+            tick,
+            agents: Vec::new(),
+        }
+    }
+}
+
+/// Ring buffer retaining recent authoritative telemetry for tooling/debugging.
+#[derive(Debug, Clone)]
+pub struct TelemetryArchive {
+    frames: VecDeque<TickTelemetryFrame>,
+    max_frames: usize,
+}
+
+impl Default for TelemetryArchive {
+    fn default() -> Self {
+        Self::with_capacity(256)
+    }
+}
+
+impl TelemetryArchive {
+    pub fn with_capacity(max_frames: usize) -> Self {
+        Self {
+            frames: VecDeque::with_capacity(max_frames.max(1)),
+            max_frames,
+        }
+    }
+
+    pub fn record_tick(&mut self, frame: TickTelemetryFrame) {
+        if self.max_frames == 0 {
+            return;
+        }
+        if self.frames.len() >= self.max_frames {
+            self.frames.pop_front();
+        }
+        self.frames.push_back(frame);
+    }
+
+    pub fn frames(&self) -> &VecDeque<TickTelemetryFrame> {
+        &self.frames
+    }
+
+    pub fn latest(&self) -> Option<&TickTelemetryFrame> {
+        self.frames.back()
+    }
+
+    pub fn trajectory_for_agent(&self, agent_id: AgentId) -> Vec<TrajectorySample> {
+        let mut samples = Vec::new();
+        for frame in &self.frames {
+            if let Some(agent_frame) = frame.agents.iter().find(|entry| entry.agent_id == agent_id)
+            {
+                if let Some(trajectory) = &agent_frame.trajectory {
+                    if samples.is_empty() {
+                        samples.push(trajectory.start);
+                    }
+                    samples.push(trajectory.end);
+                }
+            }
+        }
+        samples
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use glam::Vec2;
+
+    use crate::agent::AgentType;
+    use crate::contract::{AgentCapabilities, AgentRole};
+
+    use super::{
+        AgentTelemetryFrame, AgentToolCallTrace, TelemetryArchive, TickTelemetryFrame,
+        ToolCallStatus, TrajectorySample,
+    };
+
+    #[test]
+    fn trajectory_frame_tracks_distance() {
+        let start = TrajectorySample::new(5, 0.5, Vec2::ZERO, Vec2::ZERO, 0.0);
+        let end = TrajectorySample::new(5, 0.516, Vec2::new(3.0, 4.0), Vec2::X, 0.25);
+        let frame = super::AgentTrajectoryFrame::new(start, end);
+
+        assert_eq!(frame.displacement, Vec2::new(3.0, 4.0));
+        assert!((frame.distance_travelled - 5.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn telemetry_archive_reconstructs_agent_trajectory() {
+        let agent_id = crate::id::AgentId::new();
+        let runtime_profile = crate::contract::AgentRuntimeProfile {
+            role: AgentRole::Player,
+            agent_type: AgentType::Human,
+            capabilities: AgentCapabilities::player_default(),
+        };
+        let start = TrajectorySample::new(0, 0.0, Vec2::ZERO, Vec2::ZERO, 0.0);
+        let mid = TrajectorySample::new(0, 1.0 / 60.0, Vec2::new(1.0, 0.0), Vec2::X, 0.0);
+        let end = TrajectorySample::new(1, 2.0 / 60.0, Vec2::new(2.0, 0.0), Vec2::X, 0.0);
+
+        let mut archive = TelemetryArchive::with_capacity(4);
+        let mut first = AgentTelemetryFrame::new(
+            0,
+            agent_id,
+            Some(crate::id::EntityId(1)),
+            runtime_profile,
+            3,
+            1,
+            0,
+            4,
+            1,
+            Some(start),
+        );
+        first.update_trajectory_end(mid);
+        first.record_tool_call(AgentToolCallTrace::success(0, "observe", "demo", 4, 12, 20));
+        archive.record_tick(TickTelemetryFrame {
+            tick: 0,
+            agents: vec![first],
+        });
+
+        let mut second = AgentTelemetryFrame::new(
+            1,
+            agent_id,
+            Some(crate::id::EntityId(1)),
+            runtime_profile,
+            2,
+            0,
+            1,
+            3,
+            1,
+            Some(mid),
+        );
+        second.update_trajectory_end(end);
+        second.record_tool_call(AgentToolCallTrace::failure(
+            1,
+            "act",
+            "demo",
+            ToolCallStatus::TimedOut,
+            30,
+            "timeout",
+        ));
+        archive.record_tick(TickTelemetryFrame {
+            tick: 1,
+            agents: vec![second],
+        });
+
+        let samples = archive.trajectory_for_agent(agent_id);
+        assert_eq!(samples.len(), 3);
+        assert_eq!(samples[0].position, Vec2::ZERO);
+        assert_eq!(samples[1].position, Vec2::new(1.0, 0.0));
+        assert_eq!(samples[2].position, Vec2::new(2.0, 0.0));
+        assert_eq!(
+            archive.latest().expect("latest frame").agents[0].tool_calls[0].status,
+            ToolCallStatus::TimedOut
+        );
+    }
+}

--- a/crates/pod-core/src/tick.rs
+++ b/crates/pod-core/src/tick.rs
@@ -4,8 +4,12 @@ use crate::component::*;
 use crate::event::{Event, EventBus};
 use crate::id::EntityId;
 use crate::observation::*;
+use crate::telemetry::{
+    ActionLifecycleStage, ActionSource, AgentTelemetryFrame, TickTelemetryFrame, TrajectorySample,
+};
 use crate::TICK_DURATION_SECS;
 use glam::{Vec2, Vec3};
+use std::collections::HashMap;
 
 /// Result of a single tick
 #[derive(Debug, Clone)]
@@ -15,6 +19,7 @@ pub struct TickResult {
     pub entity_count: usize,
     pub actions_processed: usize,
     pub actions_rejected: usize,
+    pub telemetry: TickTelemetryFrame,
 }
 
 /// Execute one tick of the simulation
@@ -26,6 +31,11 @@ pub fn execute_tick(
     external_actions: Vec<AgentAction>,
     _next_entity_id: &mut u64,
 ) -> TickResult {
+    struct PendingAction {
+        agent_action: AgentAction,
+        source: ActionSource,
+    }
+
     let elapsed = tick as f32 * TICK_DURATION_SECS;
     let mut actions_processed = 0u32;
     let mut actions_rejected = 0u32;
@@ -43,28 +53,79 @@ pub fn execute_tick(
     // ========================================
     // PHASE 2: DELIVER OBSERVATIONS & COLLECT DECISIONS
     // ========================================
-    let mut all_actions: Vec<AgentAction> = Vec::new();
+    let mut all_actions: Vec<PendingAction> = Vec::new();
+    let mut telemetry_frames = Vec::<AgentTelemetryFrame>::new();
+    let mut telemetry_indices = HashMap::<crate::id::AgentId, usize>::new();
 
     for (slot, obs) in agents.iter_mut().zip(observations.into_iter()) {
         if !slot.connected {
             continue;
         }
+        let entity_id = slot.entity_id.map(|entity| EntityId(entity.id() as u64));
+        let trajectory_start = entity_id.map(|_| {
+            TrajectorySample::new(
+                tick,
+                elapsed,
+                obs.self_state.position,
+                obs.self_state.velocity,
+                obs.self_state.rotation,
+            )
+        });
+        let telemetry_index = telemetry_frames.len();
+        telemetry_frames.push(AgentTelemetryFrame::new(
+            tick,
+            slot.agent.id(),
+            entity_id,
+            slot.agent.runtime_profile(),
+            obs.visible_entities.len(),
+            obs.audible_events.len(),
+            obs.messages.len(),
+            obs.available_actions.len(),
+            obs.objectives.len(),
+            trajectory_start,
+        ));
+        telemetry_indices.insert(slot.agent.id(), telemetry_index);
         slot.agent.observe(obs);
         let decisions = slot.agent.decide();
         for action in decisions {
-            all_actions.push(AgentAction {
-                agent_id: slot.agent.id(),
-                tick,
-                action,
+            if let Some(index) = telemetry_indices.get(&slot.agent.id()).copied() {
+                telemetry_frames[index].record_action(
+                    ActionSource::AgentDecision,
+                    ActionLifecycleStage::Submitted,
+                    action.clone(),
+                    None,
+                );
+            }
+            all_actions.push(PendingAction {
+                agent_action: AgentAction {
+                    agent_id: slot.agent.id(),
+                    tick,
+                    action,
+                },
+                source: ActionSource::AgentDecision,
             });
         }
     }
-    all_actions.extend(external_actions);
+    for agent_action in external_actions {
+        if let Some(index) = telemetry_indices.get(&agent_action.agent_id).copied() {
+            telemetry_frames[index].record_action(
+                ActionSource::ExternalSubmission,
+                ActionLifecycleStage::Submitted,
+                agent_action.action.clone(),
+                None,
+            );
+        }
+        all_actions.push(PendingAction {
+            agent_action,
+            source: ActionSource::ExternalSubmission,
+        });
+    }
 
     // ========================================
     // PHASE 3: VALIDATE & EXECUTE ACTIONS
     // ========================================
-    for agent_action in &all_actions {
+    for pending in &all_actions {
+        let agent_action = &pending.agent_action;
         // Find the agent's constraints
         let constraints = agents
             .iter()
@@ -79,10 +140,26 @@ pub fn execute_tick(
             ActionResult::Valid => {
                 execute_action(ecs, agents, events, agent_action);
                 actions_processed += 1;
+                if let Some(index) = telemetry_indices.get(&agent_action.agent_id).copied() {
+                    telemetry_frames[index].record_action(
+                        pending.source,
+                        ActionLifecycleStage::Executed,
+                        agent_action.action.clone(),
+                        None,
+                    );
+                }
             }
             ActionResult::Rejected(reason) => {
                 log::debug!("Action rejected for {}: {}", agent_action.agent_id, reason);
                 actions_rejected += 1;
+                if let Some(index) = telemetry_indices.get(&agent_action.agent_id).copied() {
+                    telemetry_frames[index].record_action(
+                        pending.source,
+                        ActionLifecycleStage::Rejected,
+                        agent_action.action.clone(),
+                        Some(reason),
+                    );
+                }
             }
             ActionResult::Queued => {
                 log::debug!(
@@ -91,6 +168,14 @@ pub fn execute_tick(
                     tick
                 );
                 actions_rejected += 1;
+                if let Some(index) = telemetry_indices.get(&agent_action.agent_id).copied() {
+                    telemetry_frames[index].record_action(
+                        pending.source,
+                        ActionLifecycleStage::Queued,
+                        agent_action.action.clone(),
+                        None,
+                    );
+                }
             }
         }
     }
@@ -104,6 +189,29 @@ pub fn execute_tick(
     // ========================================
     // PHASE 5: FLUSH EVENTS
     // ========================================
+    for slot in agents.iter() {
+        let Some(index) = telemetry_indices.get(&slot.agent.id()).copied() else {
+            continue;
+        };
+        let Some(entity) = slot.entity_id else {
+            continue;
+        };
+        let Ok(transform) = ecs.get::<&Transform>(entity) else {
+            continue;
+        };
+        let velocity = ecs
+            .get::<&Velocity>(entity)
+            .map(|value| value.linear)
+            .unwrap_or(Vec2::ZERO);
+        telemetry_frames[index].update_trajectory_end(TrajectorySample::new(
+            tick,
+            elapsed + TICK_DURATION_SECS,
+            transform.position,
+            velocity,
+            transform.rotation,
+        ));
+    }
+
     let tick_events = events.current_events().to_vec();
     events.flush(tick + 1);
 
@@ -113,6 +221,10 @@ pub fn execute_tick(
         entity_count: ecs.len() as usize,
         actions_processed: actions_processed as usize,
         actions_rejected: actions_rejected as usize,
+        telemetry: TickTelemetryFrame {
+            tick,
+            agents: telemetry_frames,
+        },
     }
 }
 
@@ -1908,6 +2020,107 @@ mod tests {
                 .species_name,
             "Moss Turtle"
         );
+    }
+
+    #[test]
+    fn tick_result_records_authoritative_agent_trajectory_and_action_trace() {
+        let mut ecs = hecs::World::new();
+        let mover_entity = spawn_actor(
+            &mut ecs,
+            Vec2::new(0.0, 0.0),
+            Team::Team(1),
+            Health::new(100.0),
+        );
+
+        let observed_messages = Arc::new(Mutex::new(Vec::<Observation>::new()));
+        let (agent, agent_id) =
+            RecordingAgent::new(vec![Action::Move { direction: Vec2::X }], observed_messages);
+        let mut slot = AgentSlot::new(Box::new(agent));
+        slot.entity_id = Some(mover_entity);
+        let mut agents = vec![slot];
+        let mut events = EventBus::new();
+        let mut next_entity_id = 1;
+
+        let result = execute_tick(
+            &mut ecs,
+            &mut agents,
+            &mut events,
+            3,
+            vec![],
+            &mut next_entity_id,
+        );
+
+        assert_eq!(result.telemetry.tick, 3);
+        assert_eq!(result.telemetry.agents.len(), 1);
+
+        let telemetry = &result.telemetry.agents[0];
+        assert_eq!(telemetry.agent_id, agent_id);
+        assert_eq!(telemetry.runtime_profile.agent_type, AgentType::ScriptedNpc);
+        let trajectory = telemetry.trajectory.as_ref().expect("trajectory frame");
+        assert_eq!(trajectory.start.position, Vec2::ZERO);
+        assert!(trajectory.end.position.x > 0.0);
+        assert!(trajectory.distance_travelled > 0.0);
+        assert!(telemetry.action_trace.iter().any(|trace| {
+            trace.stage == ActionLifecycleStage::Submitted
+                && matches!(trace.source, ActionSource::AgentDecision)
+                && matches!(trace.action, Action::Move { .. })
+        }));
+        assert!(telemetry.action_trace.iter().any(|trace| {
+            trace.stage == ActionLifecycleStage::Executed
+                && matches!(trace.source, ActionSource::AgentDecision)
+                && matches!(trace.action, Action::Move { .. })
+        }));
+    }
+
+    #[test]
+    fn rejected_external_actions_are_captured_in_tick_telemetry() {
+        let mut ecs = hecs::World::new();
+        let observer_entity = spawn_actor(
+            &mut ecs,
+            Vec2::new(0.0, 0.0),
+            Team::Team(1),
+            Health::new(100.0),
+        );
+
+        let observed_messages = Arc::new(Mutex::new(Vec::<Observation>::new()));
+        let (agent, agent_id) = RecordingAgent::new(vec![], observed_messages);
+        let mut slot = AgentSlot::new(Box::new(agent));
+        slot.entity_id = Some(observer_entity);
+        let mut agents = vec![slot];
+        let mut events = EventBus::new();
+        let mut next_entity_id = 1;
+
+        let result = execute_tick(
+            &mut ecs,
+            &mut agents,
+            &mut events,
+            4,
+            vec![AgentAction {
+                agent_id,
+                tick: 4,
+                action: Action::Move {
+                    direction: Vec2::splat(10.0),
+                },
+            }],
+            &mut next_entity_id,
+        );
+
+        let telemetry = &result.telemetry.agents[0];
+        assert!(telemetry.action_trace.iter().any(|trace| {
+            trace.stage == ActionLifecycleStage::Submitted
+                && matches!(trace.source, ActionSource::ExternalSubmission)
+        }));
+        let rejected = telemetry
+            .action_trace
+            .iter()
+            .find(|trace| trace.stage == ActionLifecycleStage::Rejected)
+            .expect("rejected action trace");
+        assert!(matches!(rejected.source, ActionSource::ExternalSubmission));
+        assert!(rejected
+            .rejection_reason
+            .as_deref()
+            .expect("rejection reason")
+            .contains("magnitude too large"));
     }
 
     #[test]

--- a/crates/pod-core/src/world.rs
+++ b/crates/pod-core/src/world.rs
@@ -3,6 +3,7 @@ use crate::agent::{Agent, AgentSlot};
 use crate::component::*;
 use crate::event::EventBus;
 use crate::id::AgentId;
+use crate::telemetry::TickTelemetryFrame;
 use crate::tick::{execute_tick, TickResult};
 use glam::Vec2;
 use rand::SeedableRng;
@@ -56,6 +57,7 @@ impl World {
                 entity_count: self.ecs.len() as usize,
                 actions_processed: 0,
                 actions_rejected: 0,
+                telemetry: TickTelemetryFrame::empty(self.tick),
             };
         }
 


### PR DESCRIPTION
## Summary\n- add authoritative pod-core telemetry primitives for trajectories, action lifecycle traces, and tool-call traces\n- capture tick telemetry in the core observe/decide/validate/execute pipeline and retain it in App via TelemetryArchive\n- extend pod-agents decision logs with shared tool-call telemetry primitives\n\n## Testing\n- cargo test -p pod-core --lib\n- cargo test -p pod-agents --lib

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced comprehensive telemetry system for agent runtime monitoring and performance tracking.
  * Enhanced decision logging to include tool interaction records for better observability.
  * Added per-tick telemetry archiving with trajectory reconstruction capabilities for historical analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->