### PR TITLE
Add browser and editor telemetry consumers

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -473,5 +473,26 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cargo test -p pod-core --lib`
   - `cargo test -p pod-agents --lib`
 
-**Last updated**: Iteration 56
-**Current focus**: Phase 4 agent/runtime parity instrumentation for the RuneScape-style MMO + companion-creature vertical slice, then surfacing telemetry into browser/editor debug tooling
+### Iteration 57 — One-page App Summary PDF
+
+- [x] Generated a repo-evidence-only one-page summary PDF at `output/pdf/prompt-or-die-summary.pdf`.
+- [x] Verified the artifact stays on a single page and remains legible after rendering to PNG for visual QA.
+
+### Iteration 58 — Browser and Editor Telemetry Consumers
+
+- [x] Added `TelemetryConfig` to `pod-core` as the shared retention source for runtime archives, browser debug trails, and editor timelines, and wired `App::new()` to size `TelemetryArchive` from that config.
+- [x] Added a typed `pod-web` telemetry contract plus `window.podRender.renderTickTelemetry(...)`, `window.podRender.resetTelemetry()`, and `window.podRender.getTelemetryStats()` for editor/debug clients.
+- [x] Added a debug-only browser telemetry HUD with selected-agent cycling, world-space trajectory trails, action and tool-call summaries, and recovery-diagnostic display.
+- [x] Added `EditorPanel::Telemetry` and `TelemetryPanelState` to `pod-editor`, reusing the existing selected entity across hierarchy, inspector, viewport, and telemetry views.
+- [x] Replaced the old `SpacetimeDashboardState` placeholder counters with authoritative telemetry rollups: latest tick, rejection/error rates, per-agent trajectory summaries, and visible/audible/message counts.
+- [x] Applied Three.js toon-material shading to the stylized opaque world-geometry path while keeping transparent/glass surfaces on the standard material path.
+- [x] Added deterministic coverage for telemetry config defaults, editor telemetry retention/selection sync, browser telemetry parsing/summary logic, and toon-material selection.
+- [x] Validated touched targets:
+  - `cargo test -p pod-core --lib`
+  - `cargo test -p pod-editor --lib`
+  - `bun test`
+  - `bun run typecheck`
+  - `bun run build`
+
+**Last updated**: Iteration 58
+**Current focus**: Iteration 59 authority export for direct-connect and SpacetimeDB telemetry, then provider/tool-call instrumentation for embedded agents

--- a/apps/pod-web/index.html
+++ b/apps/pod-web/index.html
@@ -56,6 +56,11 @@
         box-shadow: 0 30px 80px rgba(0, 0, 0, 0.28);
       }
 
+      .hud--telemetry {
+        inset: 20px 20px auto auto;
+        width: min(420px, calc(100vw - 40px));
+      }
+
       .hud h1 {
         margin: 0 0 8px;
         font-size: 1.1rem;
@@ -87,6 +92,42 @@
       .hud dd {
         margin: 0;
       }
+
+      .hud__controls {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        margin-top: 14px;
+      }
+
+      .hud__controls-group {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .hud button {
+        border: 1px solid rgba(138, 245, 207, 0.26);
+        border-radius: 999px;
+        background: rgba(138, 245, 207, 0.08);
+        color: var(--copy);
+        padding: 7px 12px;
+        font: inherit;
+        cursor: pointer;
+      }
+
+      .hud button:hover {
+        background: rgba(138, 245, 207, 0.16);
+      }
+
+      .hud code {
+        color: var(--panel-accent);
+      }
+
+      #telemetry-panel[data-telemetry-enabled="false"] .telemetry-debug-only {
+        opacity: 0.56;
+      }
     </style>
   </head>
   <body>
@@ -110,6 +151,31 @@
           <dd id="stats-label">warming up…</dd>
           <dt>Bridge</dt>
           <dd><code>window.podRender.renderThreeJsWebGpuFrame(...)</code></dd>
+        </dl>
+      </section>
+      <section class="hud hud--telemetry" id="telemetry-panel" data-telemetry-enabled="false">
+        <h1>Debug Telemetry</h1>
+        <p id="telemetry-summary">
+          Authoritative trails, action traces, tool-call metrics, and recovery diagnostics for
+          editor/debug clients.
+        </p>
+        <div class="hud__controls">
+          <button id="telemetry-toggle" type="button">Enable Telemetry</button>
+          <div class="hud__controls-group telemetry-debug-only">
+            <button id="telemetry-prev" type="button">Prev</button>
+            <span id="telemetry-selection">No agent selected</span>
+            <button id="telemetry-next" type="button">Next</button>
+          </div>
+        </div>
+        <dl class="telemetry-debug-only">
+          <dt>Trail</dt>
+          <dd id="telemetry-trail">0 samples</dd>
+          <dt>Actions</dt>
+          <dd id="telemetry-actions">submitted 0 · executed 0 · rejected 0</dd>
+          <dt>Tools</dt>
+          <dd id="telemetry-tools">No tool calls</dd>
+          <dt>Recovery</dt>
+          <dd id="telemetry-recovery">No recovery telemetry</dd>
         </dl>
       </section>
     </div>

--- a/apps/pod-web/src/assets.test.ts
+++ b/apps/pod-web/src/assets.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+
+import { createMeshMaterial } from "./assets";
+import type { ThreeJsMeshBatch } from "./contracts";
+
+const QUALITY = {
+  environmentIntensity: 1
+} as const;
+
+function meshBatch(
+  overrides: Partial<ThreeJsMeshBatch> = {}
+): ThreeJsMeshBatch {
+  return {
+    mesh: "basalt-column",
+    material: "obsidian",
+    layer: 0,
+    phase: "opaque",
+    sortDepth: 0,
+    renderOrder: 0,
+    transparent: false,
+    doubleSided: false,
+    castShadows: true,
+    receiveShadows: true,
+    tint: [1, 1, 1, 1],
+    roughness: 0.92,
+    metallic: 0.08,
+    emissive: [0, 0, 0],
+    depthWrite: true,
+    depthTest: true,
+    instances: [],
+    ...overrides
+  };
+}
+
+describe("createMeshMaterial", () => {
+  test("uses toon shading for stylized opaque world geometry", () => {
+    const material = createMeshMaterial(meshBatch(), 0, QUALITY);
+    expect(material.type).toBe("MeshToonMaterial");
+  });
+
+  test("keeps transparent glass surfaces on the standard material path", () => {
+    const material = createMeshMaterial(
+      meshBatch({
+        mesh: "glass-spire",
+        material: "aether-glass",
+        transparent: true,
+        metallic: 0.4
+      }),
+      0,
+      QUALITY
+    );
+    expect(material.type).toBe("MeshStandardMaterial");
+  });
+});

--- a/apps/pod-web/src/assets.ts
+++ b/apps/pod-web/src/assets.ts
@@ -7,7 +7,9 @@ import {
   DodecahedronGeometry,
   FrontSide,
   MeshBasicMaterial,
+  MeshToonMaterial,
   MeshStandardMaterial,
+  NearestFilter,
   PlaneGeometry,
   RepeatWrapping,
   SRGBColorSpace,
@@ -106,7 +108,23 @@ export function createMeshMaterial(
   batch: ThreeJsMeshBatch,
   lodLevel: 0 | 1 | 2,
   quality: Pick<PodThreeQualityProfile, "environmentIntensity">
-): MeshStandardMaterial {
+): Material {
+  if (shouldUseToonShading(batch)) {
+    const material = new MeshToonMaterial({
+      color: new Color(batch.tint[0], batch.tint[1], batch.tint[2]),
+      transparent: batch.transparent,
+      opacity: batch.tint[3],
+      emissive: new Color(batch.emissive[0], batch.emissive[1], batch.emissive[2]),
+      emissiveIntensity: 0.4 + quality.environmentIntensity * 0.25,
+      depthWrite: batch.depthWrite,
+      depthTest: batch.depthTest,
+      side: batch.doubleSided ? 2 : FrontSide,
+      gradientMap: getToonGradientMap()
+    });
+    material.name = `pod-toon:${batch.mesh}:${batch.material}`;
+    return material;
+  }
+
   const material = new MeshStandardMaterial({
     color: new Color(batch.tint[0], batch.tint[1], batch.tint[2]),
     transparent: batch.transparent,
@@ -204,4 +222,39 @@ function hashColor(input: string): [number, number, number] {
 
 function lodSegments(levels: [number, number, number], lodLevel: 0 | 1 | 2): number {
   return levels[lodLevel];
+}
+
+let toonGradientMap: Texture | null = null;
+
+function getToonGradientMap(): Texture {
+  if (toonGradientMap) {
+    return toonGradientMap;
+  }
+
+  const gradient = new Uint8Array([
+    48, 48, 48, 255, 116, 116, 116, 255, 184, 184, 184, 255, 255, 255, 255, 255
+  ]);
+  const texture = new DataTexture(gradient, 4, 1);
+  texture.needsUpdate = true;
+  texture.colorSpace = SRGBColorSpace;
+  texture.minFilter = NearestFilter;
+  texture.magFilter = NearestFilter;
+  texture.generateMipmaps = false;
+  texture.name = "pod-toon-gradient";
+  toonGradientMap = texture;
+  return texture;
+}
+
+function shouldUseToonShading(batch: ThreeJsMeshBatch): boolean {
+  if (batch.transparent) {
+    return false;
+  }
+
+  const token = `${batch.mesh} ${batch.material}`.toLowerCase();
+  return (
+    batch.metallic <= 0.2 &&
+    /basalt|obsidian|stone|tower|column|pillar|rock|boulder|tree|pine|terrain|foliage/.test(
+      token
+    )
+  );
 }

--- a/apps/pod-web/src/contracts.ts
+++ b/apps/pod-web/src/contracts.ts
@@ -1,5 +1,6 @@
 export type Vec3Tuple = [number, number, number];
 export type Vec4Tuple = [number, number, number, number];
+export type Vec2Tuple = [number, number];
 export type RgbaTuple = [number, number, number, number];
 
 export interface CameraState {
@@ -129,6 +130,135 @@ export function parseThreeJsWebGpuFrame(
 
 export function parseRenderFrame(frame: string | RenderFrame): RenderFrame {
   return typeof frame === "string" ? (JSON.parse(frame) as RenderFrame) : frame;
+}
+
+export interface TelemetryRuntimeProfile {
+  role: string;
+  agent_type: string;
+  capabilities: Record<string, boolean>;
+}
+
+export interface TelemetryTrajectorySample {
+  tick: number;
+  elapsed_secs: number;
+  position: Vec2Tuple;
+  velocity: Vec2Tuple;
+  rotation: number;
+}
+
+export interface TelemetryTrajectoryFrame {
+  start: TelemetryTrajectorySample;
+  end: TelemetryTrajectorySample;
+  displacement: Vec2Tuple;
+  distance_travelled: number;
+}
+
+export interface TelemetryActionTrace {
+  source: string;
+  stage: string;
+  action: Record<string, unknown>;
+  rejection_reason?: string | null;
+}
+
+export interface TelemetryToolCallTrace {
+  tick: number;
+  tool_name: string;
+  provider: string;
+  status: string;
+  latency_ms: number;
+  request_units: number;
+  response_units: number;
+  error_message?: string | null;
+}
+
+export interface TelemetryAgentFrame {
+  tick: number;
+  agent_id: string;
+  entity_id?: number | null;
+  runtime_profile: TelemetryRuntimeProfile;
+  visible_entity_count: number;
+  audible_event_count: number;
+  message_count: number;
+  available_action_count: number;
+  objective_count: number;
+  trajectory?: TelemetryTrajectoryFrame | null;
+  action_trace: TelemetryActionTrace[];
+  tool_calls: TelemetryToolCallTrace[];
+}
+
+export interface TickTelemetryFrame {
+  tick: number;
+  agents: TelemetryAgentFrame[];
+}
+
+export interface EntityDrift {
+  entity_id: number;
+  position_error: number;
+  velocity_error: number;
+  rotation_error: number;
+  health_error?: number | null;
+  max_health_error?: number | null;
+  movement_speed_error?: number | null;
+}
+
+export interface RecoveryRequestState {
+  awaiting_full_snapshot: boolean;
+  request_attempts: number;
+  last_request_server_tick?: number | null;
+  last_request_digest?: number | null;
+  next_retry_tick?: number | null;
+}
+
+export interface CatchUpDiagnostics {
+  authoritative_tick?: number | null;
+  authoritative_digest?: number | null;
+  predicted_tick?: number | null;
+  predicted_digest?: number | null;
+  presentation_tick?: number | null;
+  desired_presentation_tick?: number | null;
+  presentation_drift_ticks?: number | null;
+  history_snapshots: number;
+  oldest_authoritative_tick?: number | null;
+  latest_authoritative_tick?: number | null;
+  pending_action_batches: number;
+  replayed_action_count: number;
+  controlled_entity_drift?: EntityDrift | null;
+  recovery: RecoveryRequestState;
+}
+
+export interface TickTelemetryEnvelope {
+  tickTelemetry: TickTelemetryFrame;
+  recovery?: CatchUpDiagnostics | null;
+}
+
+export function parseTickTelemetryEnvelope(
+  frame: string | TickTelemetryFrame | TickTelemetryEnvelope
+): TickTelemetryEnvelope {
+  const parsed =
+    typeof frame === "string"
+      ? (JSON.parse(frame) as TickTelemetryFrame | TickTelemetryEnvelope)
+      : frame;
+
+  if ("agents" in parsed) {
+    return { tickTelemetry: parsed };
+  }
+
+  if ("tickTelemetry" in parsed) {
+    return parsed;
+  }
+
+  const snakeCase = parsed as {
+    tick_telemetry?: TickTelemetryFrame;
+    recovery?: CatchUpDiagnostics | null;
+  };
+  if (snakeCase.tick_telemetry) {
+    return {
+      tickTelemetry: snakeCase.tick_telemetry,
+      recovery: snakeCase.recovery ?? null
+    };
+  }
+
+  throw new Error("Invalid tick telemetry payload");
 }
 
 export function legacyFrameToThreeJsFrame(frame: RenderFrame): ThreeJsWebGpuFrame {

--- a/apps/pod-web/src/main.ts
+++ b/apps/pod-web/src/main.ts
@@ -1,15 +1,31 @@
-import { parseRenderFrame, parseThreeJsWebGpuFrame } from "./contracts";
+import {
+  parseRenderFrame,
+  parseThreeJsWebGpuFrame,
+  parseTickTelemetryEnvelope
+} from "./contracts";
 import { PodThreeWorldRenderer } from "./renderer";
 import { createDemoFrame } from "./sample-frame";
+import {
+  applyTickTelemetry,
+  createTelemetryOverlayState,
+  cycleTelemetrySelection,
+  resetTelemetry,
+  selectedTrajectorySamples,
+  setTelemetryEnabled,
+  telemetryStats
+} from "./telemetry";
 
 declare global {
   interface Window {
     podRender: {
       render: (frame: string) => void;
       renderThreeJsWebGpuFrame: (frame: string) => void;
+      renderTickTelemetry: (frame: string) => void;
+      resetTelemetry: () => void;
       resetDemo: () => void;
       getBackend: () => string;
       getStats: () => ReturnType<PodThreeWorldRenderer["getStats"]>;
+      getTelemetryStats: () => ReturnType<typeof telemetryStats>;
     };
   }
 }
@@ -19,18 +35,71 @@ const backendLabel = document.querySelector<HTMLElement>("#backend-label");
 const frameSourceLabel = document.querySelector<HTMLElement>("#frame-source");
 const qualityLabel = document.querySelector<HTMLElement>("#quality-label");
 const statsLabel = document.querySelector<HTMLElement>("#stats-label");
+const telemetryToggle = document.querySelector<HTMLButtonElement>("#telemetry-toggle");
+const telemetrySelectionLabel =
+  document.querySelector<HTMLElement>("#telemetry-selection");
+const telemetryTrailLabel = document.querySelector<HTMLElement>("#telemetry-trail");
+const telemetryActionsLabel =
+  document.querySelector<HTMLElement>("#telemetry-actions");
+const telemetryToolsLabel = document.querySelector<HTMLElement>("#telemetry-tools");
+const telemetryRecoveryLabel =
+  document.querySelector<HTMLElement>("#telemetry-recovery");
+const telemetrySummaryLabel =
+  document.querySelector<HTMLElement>("#telemetry-summary");
+const telemetryPanel = document.querySelector<HTMLElement>("#telemetry-panel");
+const telemetryPrev = document.querySelector<HTMLButtonElement>("#telemetry-prev");
+const telemetryNext = document.querySelector<HTMLButtonElement>("#telemetry-next");
 
-if (!canvas || !backendLabel || !frameSourceLabel || !qualityLabel || !statsLabel) {
+if (
+  !canvas ||
+  !backendLabel ||
+  !frameSourceLabel ||
+  !qualityLabel ||
+  !statsLabel ||
+  !telemetryToggle ||
+  !telemetrySelectionLabel ||
+  !telemetryTrailLabel ||
+  !telemetryActionsLabel ||
+  !telemetryToolsLabel ||
+  !telemetryRecoveryLabel ||
+  !telemetrySummaryLabel ||
+  !telemetryPanel ||
+  !telemetryPrev ||
+  !telemetryNext
+) {
   throw new Error("pod-web bootstrap failed: required DOM nodes are missing");
 }
+
+const telemetryToggleButton = telemetryToggle;
+const telemetrySelectionNode = telemetrySelectionLabel;
+const telemetryTrailNode = telemetryTrailLabel;
+const telemetryActionsNode = telemetryActionsLabel;
+const telemetryToolsNode = telemetryToolsLabel;
+const telemetryRecoveryNode = telemetryRecoveryLabel;
+const telemetrySummaryNode = telemetrySummaryLabel;
+const telemetryPanelNode = telemetryPanel;
+const telemetryPrevButton = telemetryPrev;
+const telemetryNextButton = telemetryNext;
 
 const renderer = await PodThreeWorldRenderer.create(canvas);
 backendLabel.textContent = renderer.backend;
 qualityLabel.textContent = renderer.quality.preset;
 const runtimeStatsLabel = statsLabel;
+const telemetryState = createTelemetryOverlayState(300);
 
 let liveFrameSource: "demo" | "legacy" | "threejs" = "demo";
 let latestFrameJson: string | null = null;
+let lastTelemetryRevision = -1;
+
+telemetryToggleButton.addEventListener("click", () => {
+  setTelemetryEnabled(telemetryState, !telemetryState.enabled);
+});
+telemetryPrevButton.addEventListener("click", () => {
+  cycleTelemetrySelection(telemetryState, -1);
+});
+telemetryNextButton.addEventListener("click", () => {
+  cycleTelemetrySelection(telemetryState, 1);
+});
 
 window.podRender = {
   render(frame: string) {
@@ -43,6 +112,13 @@ window.podRender = {
     liveFrameSource = "threejs";
     frameSourceLabel.textContent = "Three.js WebGPU frame";
   },
+  renderTickTelemetry(frame: string) {
+    applyTickTelemetry(telemetryState, parseTickTelemetryEnvelope(frame));
+  },
+  resetTelemetry() {
+    resetTelemetry(telemetryState);
+    renderer.clearTelemetryTrail();
+  },
   resetDemo() {
     latestFrameJson = null;
     liveFrameSource = "demo";
@@ -53,10 +129,25 @@ window.podRender = {
   },
   getStats() {
     return renderer.getStats();
+  },
+  getTelemetryStats() {
+    return telemetryStats(telemetryState);
   }
 };
 
 async function tick(timestamp: number): Promise<void> {
+  if (lastTelemetryRevision !== telemetryState.revision) {
+    const samples = telemetryState.enabled
+      ? selectedTrajectorySamples(telemetryState)
+      : [];
+    if (samples.length > 1) {
+      renderer.setTelemetryTrail(samples);
+    } else {
+      renderer.clearTelemetryTrail();
+    }
+    lastTelemetryRevision = telemetryState.revision;
+  }
+
   if (latestFrameJson) {
     if (liveFrameSource === "threejs") {
       await renderer.applyFrame(parseThreeJsWebGpuFrame(latestFrameJson));
@@ -71,10 +162,33 @@ async function tick(timestamp: number): Promise<void> {
   runtimeStatsLabel.textContent = `${stats.drawCalls} calls · ${stats.triangles} tris · ${stats.pixelRatio.toFixed(
     2
   )}x DPR · ${stats.frameMs.toFixed(1)}ms`;
+  renderTelemetryHud();
 
   requestAnimationFrame((nextTimestamp) => {
     void tick(nextTimestamp);
   });
+}
+
+function renderTelemetryHud(): void {
+  const stats = telemetryStats(telemetryState);
+  telemetryToggleButton.textContent = stats.enabled ? "Disable Telemetry" : "Enable Telemetry";
+  telemetryPanelNode.dataset.telemetryEnabled = String(stats.enabled);
+  telemetrySelectionNode.textContent = stats.selectedLabel;
+  telemetryTrailNode.textContent = `${stats.trajectorySamples} samples · ${stats.trajectoryDistance.toFixed(
+    2
+  )}u`;
+  telemetryActionsNode.textContent = `submitted ${stats.submittedActions} · executed ${stats.executedActions} · rejected ${stats.rejectedActions}`;
+  telemetryToolsNode.textContent = stats.lastToolStatus
+    ? `${stats.lastToolStatus} · ${stats.lastToolLatencyMs ?? 0}ms · ${stats.toolErrors}/${stats.toolCalls} errors`
+    : "No tool calls";
+  telemetryRecoveryNode.textContent =
+    stats.nextRetryTick == null
+      ? stats.recoverySummary
+      : `${stats.recoverySummary} · retry @ ${stats.nextRetryTick}`;
+  telemetrySummaryNode.textContent =
+    stats.tick == null
+      ? "Waiting for authoritative telemetry."
+      : `tick ${stats.tick} · ${stats.visibleEntities} visible · ${stats.audibleEvents} audible · ${stats.messages} messages`;
 }
 
 void tick(performance.now());

--- a/apps/pod-web/src/renderer.ts
+++ b/apps/pod-web/src/renderer.ts
@@ -20,6 +20,7 @@ import {
   legacyFrameToThreeJsFrame,
   type RenderCommand,
   type RenderFrame,
+  type TelemetryTrajectorySample,
   type ThreeJsWebGpuFrame
 } from "./contracts";
 import {
@@ -100,6 +101,8 @@ export class PodThreeWorldRenderer {
   private adaptivePixelRatio: number;
   private smoothedFrameMs = 16.7;
   private adjustmentCooldown = 0;
+  private telemetryTrail: THREE.Line<THREE.BufferGeometry, THREE.LineBasicMaterial> | null =
+    null;
 
   constructor(
     private readonly canvas: HTMLCanvasElement,
@@ -177,6 +180,7 @@ export class PodThreeWorldRenderer {
     }
 
     this.clearOverlay();
+    this.clearTelemetryTrail();
     this.renderer.dispose();
   }
 
@@ -423,6 +427,44 @@ export class PodThreeWorldRenderer {
       disposeObject(object);
     }
     this.overlayObjects.length = 0;
+  }
+
+  setTelemetryTrail(samples: TelemetryTrajectorySample[]): void {
+    this.clearTelemetryTrail();
+    if (samples.length < 2) {
+      return;
+    }
+
+    const points = samples.map(
+      (sample, index) =>
+        new THREE.Vector3(
+          sample.position[0],
+          0.22 + index * 0.0035,
+          sample.position[1]
+        )
+    );
+    const geometry = new THREE.BufferGeometry().setFromPoints(points);
+    const material = new THREE.LineBasicMaterial({
+      color: new THREE.Color(0.54, 0.96, 0.81),
+      transparent: true,
+      opacity: 0.9,
+      depthWrite: false
+    });
+    const line = new THREE.Line(geometry, material);
+    line.renderOrder = 10_000;
+    line.frustumCulled = false;
+    this.scene.add(line);
+    this.telemetryTrail = line;
+  }
+
+  clearTelemetryTrail(): void {
+    if (!this.telemetryTrail) {
+      return;
+    }
+    this.scene.remove(this.telemetryTrail);
+    this.telemetryTrail.geometry.dispose();
+    this.telemetryTrail.material.dispose();
+    this.telemetryTrail = null;
   }
 
   private async renderFrame(): Promise<void> {

--- a/apps/pod-web/src/telemetry.test.ts
+++ b/apps/pod-web/src/telemetry.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from "bun:test";
+
+import type { TickTelemetryEnvelope } from "./contracts";
+import {
+  applyTickTelemetry,
+  createTelemetryOverlayState,
+  cycleTelemetrySelection,
+  selectedTrajectorySamples,
+  setTelemetryEnabled,
+  telemetryStats
+} from "./telemetry";
+
+function telemetryFrame(
+  tick: number,
+  {
+    agentId = "agent-a",
+    entityId = 1001,
+    position = tick,
+    rejected = 0,
+    toolStatus = "Succeeded"
+  }: {
+    agentId?: string;
+    entityId?: number;
+    position?: number;
+    rejected?: number;
+    toolStatus?: string;
+  } = {}
+): TickTelemetryEnvelope {
+  return {
+    tickTelemetry: {
+      tick,
+      agents: [
+        {
+          tick,
+          agent_id: agentId,
+          entity_id: entityId,
+          runtime_profile: {
+            role: "Player",
+            agent_type: "Human",
+            capabilities: {}
+          },
+          visible_entity_count: 6,
+          audible_event_count: 2,
+          message_count: 1,
+          available_action_count: 4,
+          objective_count: 1,
+          trajectory: {
+            start: {
+              tick,
+              elapsed_secs: tick / 60,
+              position: [position, position],
+              velocity: [1, 0],
+              rotation: 0
+            },
+            end: {
+              tick,
+              elapsed_secs: (tick + 1) / 60,
+              position: [position + 1, position + 0.5],
+              velocity: [1, 0.5],
+              rotation: 0.1
+            },
+            displacement: [1, 0.5],
+            distance_travelled: 1.12
+          },
+          action_trace: [
+            { source: "ExternalSubmission", stage: "Submitted", action: { Idle: null } },
+            { source: "ExternalSubmission", stage: "Executed", action: { Idle: null } },
+            ...new Array(rejected).fill(null).map(() => ({
+              source: "ExternalSubmission",
+              stage: "Rejected",
+              action: { Idle: null },
+              rejection_reason: "cooldown"
+            }))
+          ],
+          tool_calls: [
+            {
+              tick,
+              tool_name: "llm.complete",
+              provider: "qwen",
+              status: toolStatus,
+              latency_ms: 48,
+              request_units: 120,
+              response_units: 40,
+              error_message: toolStatus === "Succeeded" ? null : "timeout"
+            }
+          ]
+        }
+      ]
+    },
+    recovery: {
+      authoritative_tick: tick,
+      authoritative_digest: 42,
+      predicted_tick: tick,
+      predicted_digest: 42,
+      presentation_tick: tick,
+      desired_presentation_tick: tick,
+      presentation_drift_ticks: 0.25,
+      history_snapshots: 4,
+      oldest_authoritative_tick: tick - 3,
+      latest_authoritative_tick: tick,
+      pending_action_batches: 1,
+      replayed_action_count: 2,
+      controlled_entity_drift: null,
+      recovery: {
+        awaiting_full_snapshot: false,
+        request_attempts: 0,
+        last_request_server_tick: null,
+        last_request_digest: null,
+        next_retry_tick: null
+      }
+    }
+  };
+}
+
+describe("telemetry overlay state", () => {
+  test("retains trajectory history and computes selected-agent stats", () => {
+    const state = createTelemetryOverlayState(3);
+    setTelemetryEnabled(state, true);
+    applyTickTelemetry(state, telemetryFrame(10, { position: 10 }));
+    applyTickTelemetry(state, telemetryFrame(11, { position: 11 }));
+    applyTickTelemetry(state, telemetryFrame(12, { position: 12, rejected: 1, toolStatus: "TimedOut" }));
+    applyTickTelemetry(state, telemetryFrame(13, { position: 13 }));
+
+    const trajectory = selectedTrajectorySamples(state);
+    const stats = telemetryStats(state);
+
+    expect(trajectory).toHaveLength(3);
+    expect(trajectory[0]?.position).toEqual([12, 11.5]);
+    expect(trajectory.at(-1)?.position).toEqual([14, 13.5]);
+    expect(stats.retainedTicks).toBe(3);
+    expect(stats.rejectedActions).toBe(0);
+    expect(stats.lastToolStatus).toBe("Succeeded");
+    expect(stats.trajectoryDistance).toBeGreaterThan(3);
+  });
+
+  test("cycles between latest telemetry targets", () => {
+    const state = createTelemetryOverlayState(4);
+    applyTickTelemetry(state, {
+      tickTelemetry: {
+        tick: 1,
+        agents: [
+          telemetryFrame(1, { agentId: "agent-a", entityId: 1001 }).tickTelemetry.agents[0]!,
+          telemetryFrame(1, { agentId: "agent-b", entityId: 1002 }).tickTelemetry.agents[0]!
+        ]
+      }
+    });
+
+    expect(telemetryStats(state).selectedEntityId).toBe(1001);
+    cycleTelemetrySelection(state, 1);
+    expect(telemetryStats(state).selectedEntityId).toBe(1002);
+  });
+
+  test("surfaces recovery and tool-call failures in the HUD summary", () => {
+    const state = createTelemetryOverlayState(4);
+    applyTickTelemetry(state, {
+      ...telemetryFrame(22, {
+        rejected: 2,
+        toolStatus: "TimedOut"
+      }),
+      recovery: {
+        authoritative_tick: 22,
+        authoritative_digest: 99,
+        predicted_tick: 21,
+        predicted_digest: 77,
+        presentation_tick: 20.5,
+        desired_presentation_tick: 20,
+        presentation_drift_ticks: 2.5,
+        history_snapshots: 8,
+        oldest_authoritative_tick: 14,
+        latest_authoritative_tick: 22,
+        pending_action_batches: 2,
+        replayed_action_count: 4,
+        controlled_entity_drift: null,
+        recovery: {
+          awaiting_full_snapshot: true,
+          request_attempts: 3,
+          last_request_server_tick: 22,
+          last_request_digest: 99,
+          next_retry_tick: 26
+        }
+      }
+    });
+
+    const stats = telemetryStats(state);
+    expect(stats.toolErrors).toBe(1);
+    expect(stats.recoverySummary).toContain("Awaiting full snapshot");
+    expect(stats.nextRetryTick).toBe(26);
+  });
+});

--- a/apps/pod-web/src/telemetry.ts
+++ b/apps/pod-web/src/telemetry.ts
@@ -1,0 +1,293 @@
+import type {
+  CatchUpDiagnostics,
+  TelemetryAgentFrame,
+  TelemetryTrajectorySample,
+  TickTelemetryEnvelope
+} from "./contracts";
+
+export interface PodTelemetryStats {
+  enabled: boolean;
+  retainedTicks: number;
+  tick: number | null;
+  selectedAgentId: string | null;
+  selectedEntityId: number | null;
+  selectedLabel: string;
+  trajectorySamples: number;
+  trajectoryDistance: number;
+  submittedActions: number;
+  executedActions: number;
+  rejectedActions: number;
+  toolCalls: number;
+  toolErrors: number;
+  toolErrorRate: number;
+  lastToolStatus: string | null;
+  lastToolLatencyMs: number | null;
+  lastToolError: string | null;
+  visibleEntities: number;
+  audibleEvents: number;
+  messages: number;
+  recoverySummary: string;
+  recoveryAttempts: number;
+  nextRetryTick: number | null;
+}
+
+export interface PodTelemetryOverlayState {
+  enabled: boolean;
+  maxSamples: number;
+  revision: number;
+  history: TickTelemetryEnvelope[];
+  selectedAgentId: string | null;
+  selectedEntityId: number | null;
+}
+
+interface TelemetryTarget {
+  agentId: string;
+  entityId: number | null;
+  label: string;
+}
+
+export function createTelemetryOverlayState(
+  maxSamples: number
+): PodTelemetryOverlayState {
+  return {
+    enabled: false,
+    maxSamples: Math.max(maxSamples, 1),
+    revision: 0,
+    history: [],
+    selectedAgentId: null,
+    selectedEntityId: null
+  };
+}
+
+export function applyTickTelemetry(
+  state: PodTelemetryOverlayState,
+  frame: TickTelemetryEnvelope
+): void {
+  state.history.push(frame);
+  if (state.history.length > state.maxSamples) {
+    state.history.splice(0, state.history.length - state.maxSamples);
+  }
+  syncTelemetrySelection(state);
+  state.revision += 1;
+}
+
+export function resetTelemetry(state: PodTelemetryOverlayState): void {
+  state.history = [];
+  state.selectedAgentId = null;
+  state.selectedEntityId = null;
+  state.revision += 1;
+}
+
+export function setTelemetryEnabled(
+  state: PodTelemetryOverlayState,
+  enabled: boolean
+): void {
+  if (state.enabled === enabled) {
+    return;
+  }
+  state.enabled = enabled;
+  state.revision += 1;
+}
+
+export function cycleTelemetrySelection(
+  state: PodTelemetryOverlayState,
+  direction: -1 | 1
+): void {
+  const targets = telemetryTargets(state);
+  if (targets.length === 0) {
+    state.selectedAgentId = null;
+    state.selectedEntityId = null;
+    return;
+  }
+
+  const currentIndex = targets.findIndex(
+    (target) =>
+      target.agentId === state.selectedAgentId &&
+      target.entityId === state.selectedEntityId
+  );
+  const baseIndex = currentIndex === -1 ? 0 : currentIndex;
+  const nextIndex =
+    (baseIndex + direction + targets.length) % targets.length;
+  const next = targets[nextIndex];
+  if (!next) {
+    return;
+  }
+
+  state.selectedAgentId = next.agentId;
+  state.selectedEntityId = next.entityId;
+  state.revision += 1;
+}
+
+export function selectedTrajectorySamples(
+  state: PodTelemetryOverlayState
+): TelemetryTrajectorySample[] {
+  const selected = selectedAgentHistory(state);
+  const samples: TelemetryTrajectorySample[] = [];
+
+  for (const agent of selected) {
+    const trajectory = agent.trajectory;
+    if (!trajectory) {
+      continue;
+    }
+    if (samples.length === 0) {
+      samples.push(trajectory.start);
+    }
+    samples.push(trajectory.end);
+  }
+
+  if (samples.length <= state.maxSamples) {
+    return samples;
+  }
+
+  return samples.slice(samples.length - state.maxSamples);
+}
+
+export function telemetryStats(
+  state: PodTelemetryOverlayState
+): PodTelemetryStats {
+  const latest = latestEnvelope(state);
+  const selected = selectedAgentFrame(state);
+  const trajectory = selectedTrajectorySamples(state);
+  const submittedActions =
+    selected?.action_trace.filter((trace) => trace.stage === "Submitted").length ??
+    0;
+  const executedActions =
+    selected?.action_trace.filter((trace) => trace.stage === "Executed").length ??
+    0;
+  const rejectedActions =
+    selected?.action_trace.filter((trace) => trace.stage === "Rejected").length ??
+    0;
+  const toolCalls = selected?.tool_calls.length ?? 0;
+  const toolErrors =
+    selected?.tool_calls.filter(
+      (trace) => trace.status !== "Succeeded" && trace.status !== "Requested"
+    ).length ?? 0;
+  const lastTool = selected?.tool_calls.at(-1) ?? null;
+  const recovery = latest?.recovery ?? null;
+
+  return {
+    enabled: state.enabled,
+    retainedTicks: state.history.length,
+    tick: latest?.tickTelemetry.tick ?? null,
+    selectedAgentId: state.selectedAgentId,
+    selectedEntityId: state.selectedEntityId,
+    selectedLabel: selectedTelemetryLabel(state),
+    trajectorySamples: trajectory.length,
+    trajectoryDistance: Number(
+      selectedAgentHistory(state)
+        .reduce(
+          (distance, frame) =>
+            distance + (frame.trajectory?.distance_travelled ?? 0),
+          0
+        )
+        .toFixed(2)
+    ),
+    submittedActions,
+    executedActions,
+    rejectedActions,
+    toolCalls,
+    toolErrors,
+    toolErrorRate: toolCalls === 0 ? 0 : Number((toolErrors / toolCalls).toFixed(3)),
+    lastToolStatus: lastTool?.status ?? null,
+    lastToolLatencyMs: lastTool?.latency_ms ?? null,
+    lastToolError: lastTool?.error_message ?? null,
+    visibleEntities: selected?.visible_entity_count ?? 0,
+    audibleEvents: selected?.audible_event_count ?? 0,
+    messages: selected?.message_count ?? 0,
+    recoverySummary: formatRecoverySummary(recovery),
+    recoveryAttempts: recovery?.recovery.request_attempts ?? 0,
+    nextRetryTick: recovery?.recovery.next_retry_tick ?? null
+  };
+}
+
+function selectedAgentHistory(
+  state: PodTelemetryOverlayState
+): TelemetryAgentFrame[] {
+  const agentId = state.selectedAgentId;
+  if (!agentId) {
+    return [];
+  }
+
+  return state.history
+    .map((entry) =>
+      entry.tickTelemetry.agents.find((agent) => agent.agent_id === agentId)
+    )
+    .filter((agent): agent is TelemetryAgentFrame => Boolean(agent));
+}
+
+function selectedAgentFrame(
+  state: PodTelemetryOverlayState
+): TelemetryAgentFrame | null {
+  return selectedAgentHistory(state).at(-1) ?? null;
+}
+
+function latestEnvelope(
+  state: PodTelemetryOverlayState
+): TickTelemetryEnvelope | null {
+  return state.history.at(-1) ?? null;
+}
+
+function telemetryTargets(state: PodTelemetryOverlayState): TelemetryTarget[] {
+  const latest = latestEnvelope(state);
+  if (!latest) {
+    return [];
+  }
+
+  return latest.tickTelemetry.agents.map((agent) => ({
+    agentId: agent.agent_id,
+    entityId: agent.entity_id ?? null,
+    label: `${agent.runtime_profile.role} · ${
+      agent.entity_id == null ? agent.agent_id.slice(0, 8) : `E(${agent.entity_id})`
+    }`
+  }));
+}
+
+function syncTelemetrySelection(state: PodTelemetryOverlayState): void {
+  const targets = telemetryTargets(state);
+  if (targets.length === 0) {
+    state.selectedAgentId = null;
+    state.selectedEntityId = null;
+    return;
+  }
+
+  const current = targets.find(
+    (target) =>
+      target.agentId === state.selectedAgentId &&
+      target.entityId === state.selectedEntityId
+  );
+  if (current) {
+    return;
+  }
+
+  const next = targets[0];
+  if (!next) {
+    return;
+  }
+  state.selectedAgentId = next.agentId;
+  state.selectedEntityId = next.entityId;
+}
+
+function selectedTelemetryLabel(state: PodTelemetryOverlayState): string {
+  const selected = telemetryTargets(state).find(
+    (target) =>
+      target.agentId === state.selectedAgentId &&
+      target.entityId === state.selectedEntityId
+  );
+  return selected?.label ?? "No agent selected";
+}
+
+function formatRecoverySummary(recovery: CatchUpDiagnostics | null): string {
+  if (!recovery) {
+    return "No recovery telemetry";
+  }
+
+  if (recovery.recovery.awaiting_full_snapshot) {
+    return `Awaiting full snapshot · ${recovery.recovery.request_attempts} request(s)`;
+  }
+
+  if (recovery.presentation_drift_ticks != null) {
+    return `Presentation drift ${recovery.presentation_drift_ticks.toFixed(2)} ticks`;
+  }
+
+  return "Authority aligned";
+}

--- a/crates/pod-core/src/app.rs
+++ b/crates/pod-core/src/app.rs
@@ -9,7 +9,7 @@ use crate::component::{
 };
 use crate::contract::{VersionedAgentAction, VersionedObservation, VersionedTickTelemetry};
 use crate::observation::Observation;
-use crate::telemetry::{TelemetryArchive, TickTelemetryFrame};
+use crate::telemetry::{TelemetryArchive, TelemetryConfig, TickTelemetryFrame};
 use crate::tick::TickResult;
 use crate::World;
 
@@ -168,7 +168,11 @@ impl App {
             broadcast: Vec::new(),
         };
         app.register_core_types();
-        let _ = app.resources.insert(TelemetryArchive::default());
+        let telemetry_config = TelemetryConfig::default();
+        let _ = app.resources.insert(telemetry_config);
+        let _ = app.resources.insert(TelemetryArchive::with_capacity(
+            telemetry_config.core_archive_ticks,
+        ));
         app
     }
 
@@ -315,13 +319,15 @@ impl App {
             .register_contract::<VersionedTickTelemetry>("VersionedTickTelemetry");
         self.types
             .register_resource::<TelemetryArchive>("TelemetryArchive");
+        self.types
+            .register_resource::<TelemetryConfig>("TelemetryConfig");
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::{App, LastTickResult, Plugin, RegisteredTypeCategory, SchedulePhase};
-    use crate::telemetry::TelemetryArchive;
+    use crate::telemetry::{TelemetryArchive, TelemetryConfig};
 
     struct TracePlugin;
 
@@ -413,6 +419,11 @@ mod tests {
             .get::<TelemetryArchive>()
             .expect("telemetry archive resource");
         assert!(archive.latest().is_none());
+        let telemetry_config = app
+            .resources()
+            .get::<TelemetryConfig>()
+            .expect("telemetry config resource");
+        assert_eq!(telemetry_config.core_archive_ticks, 600);
     }
 
     #[test]

--- a/crates/pod-core/src/lib.rs
+++ b/crates/pod-core/src/lib.rs
@@ -72,7 +72,8 @@ pub use orchestrator::{AgentBatch, AgentOrchestrator, DecisionFreshness, Priorit
 pub use replay::{DecisionTrace, ReplayFile, ReplayHeader, ReplayPlayer, ReplayRecorder};
 pub use telemetry::{
     ActionLifecycleStage, ActionSource, AgentActionTrace, AgentTelemetryFrame, AgentToolCallTrace,
-    AgentTrajectoryFrame, TelemetryArchive, TickTelemetryFrame, ToolCallStatus, TrajectorySample,
+    AgentTrajectoryFrame, TelemetryArchive, TelemetryConfig, TickTelemetryFrame, ToolCallStatus,
+    TrajectorySample,
 };
 pub use world::World;
 

--- a/crates/pod-core/src/telemetry.rs
+++ b/crates/pod-core/src/telemetry.rs
@@ -7,6 +7,25 @@ use crate::action::Action;
 use crate::contract::AgentRuntimeProfile;
 use crate::id::{AgentId, EntityId};
 
+/// Shared retention defaults for telemetry consumers across runtime, browser,
+/// and editor tooling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TelemetryConfig {
+    pub core_archive_ticks: usize,
+    pub browser_overlay_samples: usize,
+    pub editor_timeline_ticks: usize,
+}
+
+impl Default for TelemetryConfig {
+    fn default() -> Self {
+        Self {
+            core_archive_ticks: 600,
+            browser_overlay_samples: 300,
+            editor_timeline_ticks: 600,
+        }
+    }
+}
+
 /// Single trajectory sample for one agent at a specific simulation boundary.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct TrajectorySample {
@@ -263,7 +282,7 @@ pub struct TelemetryArchive {
 
 impl Default for TelemetryArchive {
     fn default() -> Self {
-        Self::with_capacity(256)
+        Self::with_capacity(TelemetryConfig::default().core_archive_ticks)
     }
 }
 
@@ -318,9 +337,17 @@ mod tests {
     use crate::contract::{AgentCapabilities, AgentRole};
 
     use super::{
-        AgentTelemetryFrame, AgentToolCallTrace, TelemetryArchive, TickTelemetryFrame,
-        ToolCallStatus, TrajectorySample,
+        AgentTelemetryFrame, AgentToolCallTrace, TelemetryArchive, TelemetryConfig,
+        TickTelemetryFrame, ToolCallStatus, TrajectorySample,
     };
+
+    #[test]
+    fn telemetry_config_defaults_match_debug_surface_plan() {
+        let config = TelemetryConfig::default();
+        assert_eq!(config.core_archive_ticks, 600);
+        assert_eq!(config.browser_overlay_samples, 300);
+        assert_eq!(config.editor_timeline_ticks, 600);
+    }
 
     #[test]
     fn trajectory_frame_tracks_distance() {
@@ -399,5 +426,20 @@ mod tests {
             archive.latest().expect("latest frame").agents[0].tool_calls[0].status,
             ToolCallStatus::TimedOut
         );
+    }
+
+    #[test]
+    fn telemetry_archive_respects_max_frame_capacity() {
+        let mut archive = TelemetryArchive::with_capacity(2);
+        archive.record_tick(TickTelemetryFrame::empty(1));
+        archive.record_tick(TickTelemetryFrame::empty(2));
+        archive.record_tick(TickTelemetryFrame::empty(3));
+
+        let ticks = archive
+            .frames()
+            .iter()
+            .map(|frame| frame.tick)
+            .collect::<Vec<_>>();
+        assert_eq!(ticks, vec![2, 3]);
     }
 }

--- a/crates/pod-editor/Cargo.toml
+++ b/crates/pod-editor/Cargo.toml
@@ -12,3 +12,4 @@ serde.workspace = true
 serde_json.workspace = true
 
 [dev-dependencies]
+glam.workspace = true

--- a/crates/pod-editor/src/lib.rs
+++ b/crates/pod-editor/src/lib.rs
@@ -11,8 +11,12 @@
 
 use eframe::{App, Frame};
 use egui::{CentralPanel, Context, SidePanel, TopBottomPanel, Ui};
+use pod_core::{
+    ActionLifecycleStage, AgentTelemetryFrame, AgentType, TelemetryConfig, TickTelemetryFrame,
+    ToolCallStatus, TrajectorySample,
+};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -33,6 +37,7 @@ pub enum EditorPanel {
     BehaviorTree,
     FiniteStateMachine,
     LlmAgentConfig,
+    Telemetry,
     SpacetimeDashboard,
 }
 
@@ -53,6 +58,7 @@ impl EditorPanel {
             Self::BehaviorTree => "Behavior Tree",
             Self::FiniteStateMachine => "FSM",
             Self::LlmAgentConfig => "LLM Agent",
+            Self::Telemetry => "Telemetry",
             Self::SpacetimeDashboard => "SpacetimeDB",
         }
     }
@@ -70,6 +76,7 @@ impl EditorPanel {
             Self::BehaviorTree => DockRegion::Left,
             Self::FiniteStateMachine => DockRegion::Left,
             Self::LlmAgentConfig => DockRegion::Right,
+            Self::Telemetry => DockRegion::Right,
             Self::SpacetimeDashboard => DockRegion::Right,
             Self::Viewport => DockRegion::Center,
         }
@@ -159,6 +166,7 @@ pub struct DockLayout {
     pub behavior_tree: DockRegion,
     pub finite_state_machine: DockRegion,
     pub llm_agent_config: DockRegion,
+    pub telemetry: DockRegion,
     pub spacetime_dashboard: DockRegion,
     pub left_width: f32,
     pub right_width: f32,
@@ -175,6 +183,7 @@ impl Default for DockLayout {
             behavior_tree: EditorPanel::BehaviorTree.default_dock_region(),
             finite_state_machine: EditorPanel::FiniteStateMachine.default_dock_region(),
             llm_agent_config: EditorPanel::LlmAgentConfig.default_dock_region(),
+            telemetry: EditorPanel::Telemetry.default_dock_region(),
             spacetime_dashboard: EditorPanel::SpacetimeDashboard.default_dock_region(),
             left_width: 230.0,
             right_width: 250.0,
@@ -194,6 +203,7 @@ impl DockLayout {
             EditorPanel::BehaviorTree => self.behavior_tree,
             EditorPanel::FiniteStateMachine => self.finite_state_machine,
             EditorPanel::LlmAgentConfig => self.llm_agent_config,
+            EditorPanel::Telemetry => self.telemetry,
             EditorPanel::SpacetimeDashboard => self.spacetime_dashboard,
         }
     }
@@ -208,6 +218,7 @@ impl DockLayout {
             EditorPanel::BehaviorTree => self.behavior_tree = region,
             EditorPanel::FiniteStateMachine => self.finite_state_machine = region,
             EditorPanel::LlmAgentConfig => self.llm_agent_config = region,
+            EditorPanel::Telemetry => self.telemetry = region,
             EditorPanel::SpacetimeDashboard => self.spacetime_dashboard = region,
         }
     }
@@ -241,7 +252,7 @@ impl DockLayout {
         self.bottom_height = height.clamp(90.0, 300.0);
     }
 
-    pub fn panels_for() -> [EditorPanel; 8] {
+    pub fn panels_for() -> [EditorPanel; 9] {
         [
             EditorPanel::Hierarchy,
             EditorPanel::Inspector,
@@ -250,6 +261,7 @@ impl DockLayout {
             EditorPanel::BehaviorTree,
             EditorPanel::FiniteStateMachine,
             EditorPanel::LlmAgentConfig,
+            EditorPanel::Telemetry,
             EditorPanel::SpacetimeDashboard,
         ]
     }
@@ -526,10 +538,25 @@ impl Default for LlmAgentConfig {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TelemetryAgentSummary {
+    pub agent_id: String,
+    pub entity_id: Option<u64>,
+    pub role: String,
+    pub trajectory_distance: f32,
+    pub rejected_actions: usize,
+    pub tool_errors: usize,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SpacetimeDashboardState {
-    pub world_tick: u64,
+    pub latest_tick: u64,
     pub connected_players: u32,
-    pub pending_events: u32,
+    pub action_rejection_rate: f32,
+    pub tool_call_error_rate: f32,
+    pub agent_summaries: Vec<TelemetryAgentSummary>,
+    pub visible_entity_count: usize,
+    pub audible_event_count: usize,
+    pub message_count: usize,
     pub last_reducer_call: String,
     pub reducer_calls: u32,
 }
@@ -537,9 +564,14 @@ pub struct SpacetimeDashboardState {
 impl Default for SpacetimeDashboardState {
     fn default() -> Self {
         Self {
-            world_tick: 0,
+            latest_tick: 0,
             connected_players: 0,
-            pending_events: 0,
+            action_rejection_rate: 0.0,
+            tool_call_error_rate: 0.0,
+            agent_summaries: Vec::new(),
+            visible_entity_count: 0,
+            audible_event_count: 0,
+            message_count: 0,
             last_reducer_call: "none".to_string(),
             reducer_calls: 0,
         }
@@ -550,12 +582,174 @@ impl SpacetimeDashboardState {
     pub fn record_reducer_call(&mut self, name: impl Into<String>) {
         self.last_reducer_call = name.into();
         self.reducer_calls = self.reducer_calls.saturating_add(1);
-        self.world_tick = self.world_tick.saturating_add(1);
-        self.pending_events = self.pending_events.saturating_sub(1);
     }
 
     pub fn apply_connect(&mut self, connected: bool) {
         self.connected_players = if connected { 1 } else { 0 };
+    }
+
+    pub fn record_tick_telemetry(&mut self, frame: &TickTelemetryFrame) {
+        self.latest_tick = frame.tick;
+        self.connected_players = frame
+            .agents
+            .iter()
+            .filter(|agent| agent.runtime_profile.agent_type == AgentType::Human)
+            .count() as u32;
+        self.visible_entity_count = frame
+            .agents
+            .iter()
+            .map(|agent| agent.visible_entity_count)
+            .sum();
+        self.audible_event_count = frame
+            .agents
+            .iter()
+            .map(|agent| agent.audible_event_count)
+            .sum();
+        self.message_count = frame.agents.iter().map(|agent| agent.message_count).sum();
+
+        let total_actions = frame
+            .agents
+            .iter()
+            .map(|agent| agent.action_trace.len())
+            .sum::<usize>();
+        let rejected_actions = frame
+            .agents
+            .iter()
+            .flat_map(|agent| agent.action_trace.iter())
+            .filter(|trace| trace.stage == ActionLifecycleStage::Rejected)
+            .count();
+        self.action_rejection_rate = if total_actions == 0 {
+            0.0
+        } else {
+            rejected_actions as f32 / total_actions as f32
+        };
+
+        let total_tool_calls = frame
+            .agents
+            .iter()
+            .map(|agent| agent.tool_calls.len())
+            .sum::<usize>();
+        let tool_errors = frame
+            .agents
+            .iter()
+            .flat_map(|agent| agent.tool_calls.iter())
+            .filter(|trace| {
+                !matches!(
+                    trace.status,
+                    ToolCallStatus::Requested | ToolCallStatus::Succeeded
+                )
+            })
+            .count();
+        self.tool_call_error_rate = if total_tool_calls == 0 {
+            0.0
+        } else {
+            tool_errors as f32 / total_tool_calls as f32
+        };
+
+        self.agent_summaries = frame
+            .agents
+            .iter()
+            .map(|agent| TelemetryAgentSummary {
+                agent_id: agent.agent_id.to_string(),
+                entity_id: agent.entity_id.map(|entity_id| entity_id.0),
+                role: format!("{:?}", agent.runtime_profile.role),
+                trajectory_distance: agent
+                    .trajectory
+                    .as_ref()
+                    .map(|trajectory| trajectory.distance_travelled)
+                    .unwrap_or_default(),
+                rejected_actions: agent
+                    .action_trace
+                    .iter()
+                    .filter(|trace| trace.stage == ActionLifecycleStage::Rejected)
+                    .count(),
+                tool_errors: agent
+                    .tool_calls
+                    .iter()
+                    .filter(|trace| {
+                        !matches!(
+                            trace.status,
+                            ToolCallStatus::Requested | ToolCallStatus::Succeeded
+                        )
+                    })
+                    .count(),
+            })
+            .collect();
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TelemetryPanelState {
+    pub max_ticks: usize,
+    pub timeline: VecDeque<TickTelemetryFrame>,
+}
+
+impl Default for TelemetryPanelState {
+    fn default() -> Self {
+        Self::with_capacity(TelemetryConfig::default().editor_timeline_ticks)
+    }
+}
+
+impl TelemetryPanelState {
+    pub fn with_capacity(max_ticks: usize) -> Self {
+        Self {
+            max_ticks: max_ticks.max(1),
+            timeline: VecDeque::with_capacity(max_ticks.max(1)),
+        }
+    }
+
+    pub fn record_tick(&mut self, frame: TickTelemetryFrame) {
+        if self.timeline.len() >= self.max_ticks {
+            self.timeline.pop_front();
+        }
+        self.timeline.push_back(frame);
+    }
+
+    pub fn latest(&self) -> Option<&TickTelemetryFrame> {
+        self.timeline.back()
+    }
+
+    pub fn latest_agent_for_entity(&self, entity_id: u64) -> Option<&AgentTelemetryFrame> {
+        self.timeline.iter().rev().find_map(|frame| {
+            frame
+                .agents
+                .iter()
+                .find(|agent| agent.entity_id.map(|id| id.0) == Some(entity_id))
+        })
+    }
+
+    pub fn trajectory_for_entity(&self, entity_id: u64) -> Vec<TrajectorySample> {
+        let mut samples = Vec::new();
+        for frame in &self.timeline {
+            if let Some(agent) = frame
+                .agents
+                .iter()
+                .find(|agent| agent.entity_id.map(|id| id.0) == Some(entity_id))
+            {
+                if let Some(trajectory) = &agent.trajectory {
+                    if samples.is_empty() {
+                        samples.push(trajectory.start);
+                    }
+                    samples.push(trajectory.end);
+                }
+            }
+        }
+        samples
+    }
+
+    pub fn trajectory_distance_for_entity(&self, entity_id: u64) -> f32 {
+        self.timeline
+            .iter()
+            .flat_map(|frame| frame.agents.iter())
+            .filter(|agent| agent.entity_id.map(|id| id.0) == Some(entity_id))
+            .map(|agent| {
+                agent
+                    .trajectory
+                    .as_ref()
+                    .map(|trajectory| trajectory.distance_travelled)
+                    .unwrap_or_default()
+            })
+            .sum()
     }
 }
 
@@ -1030,6 +1224,7 @@ pub struct EditorState {
     pub behavior_tree: BehaviorTree,
     pub fsm: FiniteStateMachine,
     pub llm_agent_config: LlmAgentConfig,
+    pub telemetry: TelemetryPanelState,
     pub spacetime_dashboard: SpacetimeDashboardState,
 }
 
@@ -1061,6 +1256,7 @@ impl Default for EditorState {
             behavior_tree: BehaviorTree::default(),
             fsm: FiniteStateMachine::default(),
             llm_agent_config: LlmAgentConfig::default(),
+            telemetry: TelemetryPanelState::default(),
             spacetime_dashboard: SpacetimeDashboardState::default(),
         }
     }
@@ -1349,6 +1545,11 @@ impl PodEditorApp {
             .record_reducer_call(name.into());
     }
 
+    pub fn record_tick_telemetry(&mut self, frame: TickTelemetryFrame) {
+        self.state.telemetry.record_tick(frame.clone());
+        self.state.spacetime_dashboard.record_tick_telemetry(&frame);
+    }
+
     pub fn selected_entity_transform(&mut self) -> Option<&mut Transform2D> {
         self.state
             .selected_entity
@@ -1399,6 +1600,7 @@ impl PodEditorApp {
             EditorPanel::BehaviorTree,
             EditorPanel::FiniteStateMachine,
             EditorPanel::LlmAgentConfig,
+            EditorPanel::Telemetry,
             EditorPanel::SpacetimeDashboard,
         ] {
             let region = self.state.layout.region_for_panel(panel);
@@ -1779,16 +1981,26 @@ impl PodEditorApp {
     fn render_spacetime_panel(&mut self, ui: &mut Ui) {
         ui.heading("SpacetimeDB Dashboard");
         ui.label(format!(
-            "World tick: {}",
-            self.state.spacetime_dashboard.world_tick
+            "Latest tick: {}",
+            self.state.spacetime_dashboard.latest_tick
         ));
         ui.label(format!(
             "Connected players: {}",
             self.state.spacetime_dashboard.connected_players
         ));
         ui.label(format!(
-            "Pending events: {}",
-            self.state.spacetime_dashboard.pending_events
+            "Action rejection rate: {:.1}%",
+            self.state.spacetime_dashboard.action_rejection_rate * 100.0
+        ));
+        ui.label(format!(
+            "Tool-call error rate: {:.1}%",
+            self.state.spacetime_dashboard.tool_call_error_rate * 100.0
+        ));
+        ui.label(format!(
+            "Visible/audible/messages: {}/{}/{}",
+            self.state.spacetime_dashboard.visible_entity_count,
+            self.state.spacetime_dashboard.audible_event_count,
+            self.state.spacetime_dashboard.message_count
         ));
         ui.label(format!(
             "Last reducer call: {}",
@@ -1799,8 +2011,100 @@ impl PodEditorApp {
             self.state.spacetime_dashboard.reducer_calls
         ));
         ui.separator();
+        ui.label("Per-agent trajectory distance");
+        if self.state.spacetime_dashboard.agent_summaries.is_empty() {
+            ui.label("No authoritative telemetry recorded yet.");
+        } else {
+            for summary in &self.state.spacetime_dashboard.agent_summaries {
+                ui.label(format!(
+                    "{} · {} · {:.2}u · {} rejected · {} tool errors",
+                    summary.role,
+                    summary
+                        .entity_id
+                        .map(|entity_id| format!("E({entity_id})"))
+                        .unwrap_or_else(|| summary.agent_id.clone()),
+                    summary.trajectory_distance,
+                    summary.rejected_actions,
+                    summary.tool_errors
+                ));
+            }
+        }
+        ui.separator();
         if ui.button("Simulate reducer").clicked() {
             self.set_spacetime_reducer_call("manual_reducer");
+        }
+    }
+
+    fn render_telemetry_panel(&mut self, ui: &mut Ui) {
+        ui.heading("Telemetry");
+        ui.label(format!(
+            "Retained ticks: {} / {}",
+            self.state.telemetry.timeline.len(),
+            self.state.telemetry.max_ticks
+        ));
+        if let Some(entity_id) = self.state.selected_entity {
+            ui.label(format!("Selected entity: #{entity_id}"));
+            let trajectory = self.state.telemetry.trajectory_for_entity(entity_id);
+            let total_distance = self
+                .state
+                .telemetry
+                .trajectory_distance_for_entity(entity_id);
+            ui.label(format!(
+                "Trajectory samples: {} · distance {:.2}u",
+                trajectory.len(),
+                total_distance
+            ));
+
+            if let Some(agent) = self.state.telemetry.latest_agent_for_entity(entity_id) {
+                let submitted = agent
+                    .action_trace
+                    .iter()
+                    .filter(|trace| trace.stage == ActionLifecycleStage::Submitted)
+                    .count();
+                let executed = agent
+                    .action_trace
+                    .iter()
+                    .filter(|trace| trace.stage == ActionLifecycleStage::Executed)
+                    .count();
+                let rejected = agent
+                    .action_trace
+                    .iter()
+                    .filter(|trace| trace.stage == ActionLifecycleStage::Rejected)
+                    .count();
+                ui.label(format!(
+                    "Actions: submitted {} · executed {} · rejected {}",
+                    submitted, executed, rejected
+                ));
+                ui.label(format!(
+                    "Observations: {} visible · {} audible · {} messages",
+                    agent.visible_entity_count, agent.audible_event_count, agent.message_count
+                ));
+                if let Some(tool) = agent.tool_calls.last() {
+                    ui.label(format!(
+                        "Tool call: {} via {} · {:?} · {}ms",
+                        tool.tool_name, tool.provider, tool.status, tool.latency_ms
+                    ));
+                    if let Some(error) = &tool.error_message {
+                        ui.label(format!("Last tool error: {error}"));
+                    }
+                } else {
+                    ui.label("Tool calls: none");
+                }
+                if let Some(trajectory) = &agent.trajectory {
+                    ui.label(format!(
+                        "Latest segment: ({:.2}, {:.2}) → ({:.2}, {:.2})",
+                        trajectory.start.position.x,
+                        trajectory.start.position.y,
+                        trajectory.end.position.x,
+                        trajectory.end.position.y
+                    ));
+                }
+            } else {
+                ui.label("No telemetry recorded for the selected entity yet.");
+            }
+        } else {
+            ui.label("No entity selected.");
+            ui.label("Selection stays synced with the hierarchy and inspector.");
         }
     }
 
@@ -2034,6 +2338,7 @@ impl PodEditorApp {
                             EditorPanel::Console => self.render_console(ui),
                             EditorPanel::FiniteStateMachine => self.render_fsm_editor(ui),
                             EditorPanel::LlmAgentConfig => self.render_llm_agent_panel(ui),
+                            EditorPanel::Telemetry => self.render_telemetry_panel(ui),
                             EditorPanel::SpacetimeDashboard => self.render_spacetime_panel(ui),
                             EditorPanel::Viewport => {}
                         }
@@ -2056,6 +2361,7 @@ impl PodEditorApp {
                             EditorPanel::BehaviorTree => self.render_behavior_tree_editor(ui),
                             EditorPanel::FiniteStateMachine => self.render_fsm_editor(ui),
                             EditorPanel::LlmAgentConfig => self.render_llm_agent_panel(ui),
+                            EditorPanel::Telemetry => self.render_telemetry_panel(ui),
                             EditorPanel::SpacetimeDashboard => self.render_spacetime_panel(ui),
                             EditorPanel::Console => self.render_console(ui),
                             EditorPanel::Viewport => {}
@@ -2079,6 +2385,7 @@ impl PodEditorApp {
                             EditorPanel::BehaviorTree => self.render_behavior_tree_editor(ui),
                             EditorPanel::FiniteStateMachine => self.render_fsm_editor(ui),
                             EditorPanel::LlmAgentConfig => self.render_llm_agent_panel(ui),
+                            EditorPanel::Telemetry => self.render_telemetry_panel(ui),
                             EditorPanel::SpacetimeDashboard => self.render_spacetime_panel(ui),
                             EditorPanel::Viewport => {}
                         }
@@ -2101,6 +2408,7 @@ impl PodEditorApp {
                         EditorPanel::BehaviorTree => self.render_behavior_tree_editor(ui),
                         EditorPanel::FiniteStateMachine => self.render_fsm_editor(ui),
                         EditorPanel::LlmAgentConfig => self.render_llm_agent_panel(ui),
+                        EditorPanel::Telemetry => self.render_telemetry_panel(ui),
                         EditorPanel::SpacetimeDashboard => self.render_spacetime_panel(ui),
                         EditorPanel::Viewport => self.render_viewport(ui),
                     }
@@ -2138,6 +2446,7 @@ impl App for PodEditorApp {
                     EditorPanel::BehaviorTree,
                     EditorPanel::FiniteStateMachine,
                     EditorPanel::LlmAgentConfig,
+                    EditorPanel::Telemetry,
                     EditorPanel::SpacetimeDashboard,
                 ] {
                     if ui
@@ -2208,6 +2517,75 @@ pub fn launch_headless_editor() -> Result<(), eframe::Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pod_core::{
+        Action, ActionLifecycleStage, ActionSource, AgentCapabilities, AgentId, AgentRole,
+        AgentRuntimeProfile, AgentTelemetryFrame, AgentToolCallTrace, EntityId, TickTelemetryFrame,
+        ToolCallStatus,
+    };
+
+    fn sample_tick_telemetry(tick: u64, entity_id: u64) -> TickTelemetryFrame {
+        let runtime_profile = AgentRuntimeProfile {
+            role: AgentRole::Player,
+            agent_type: AgentType::Human,
+            capabilities: AgentCapabilities::player_default(),
+        };
+        let mut agent = AgentTelemetryFrame::new(
+            tick,
+            AgentId::new(),
+            Some(EntityId(entity_id)),
+            runtime_profile,
+            7,
+            2,
+            1,
+            4,
+            1,
+            Some(TrajectorySample::new(
+                tick,
+                tick as f32 / 60.0,
+                glam::Vec2::new(tick as f32, entity_id as f32 / 1000.0),
+                glam::Vec2::X,
+                0.0,
+            )),
+        );
+        agent.update_trajectory_end(TrajectorySample::new(
+            tick,
+            (tick + 1) as f32 / 60.0,
+            glam::Vec2::new(tick as f32 + 1.0, entity_id as f32 / 1000.0 + 0.5),
+            glam::Vec2::new(1.0, 0.5),
+            0.1,
+        ));
+        agent.record_action(
+            ActionSource::ExternalSubmission,
+            ActionLifecycleStage::Submitted,
+            Action::Idle,
+            None,
+        );
+        agent.record_action(
+            ActionSource::ExternalSubmission,
+            ActionLifecycleStage::Executed,
+            Action::Idle,
+            None,
+        );
+        agent.record_action(
+            ActionSource::ExternalSubmission,
+            ActionLifecycleStage::Rejected,
+            Action::Idle,
+            Some("cooldown".to_string()),
+        );
+        agent.record_tool_call(AgentToolCallTrace::failure(
+            tick,
+            "llm.complete",
+            "qwen",
+            ToolCallStatus::TimedOut,
+            48,
+            "timeout",
+        ));
+
+        TickTelemetryFrame {
+            tick,
+            agents: vec![agent],
+        }
+    }
 
     #[test]
     fn editor_default_state_is_viewport() {
@@ -2406,6 +2784,7 @@ mod tests {
             EditorPanel::BehaviorTree,
             EditorPanel::FiniteStateMachine,
             EditorPanel::LlmAgentConfig,
+            EditorPanel::Telemetry,
             EditorPanel::SpacetimeDashboard,
         ] {
             app.set_dock_region(panel, DockRegion::Left);
@@ -2436,6 +2815,44 @@ mod tests {
                 .expect("entity exists after redo")
                 .x,
             original_x + 1.5
+        );
+    }
+
+    #[test]
+    fn telemetry_panel_tracks_selected_entity_history() {
+        let mut app = PodEditorApp::default();
+        app.record_tick_telemetry(sample_tick_telemetry(10, 1001));
+        app.record_tick_telemetry(sample_tick_telemetry(11, 1001));
+
+        let samples = app.state.telemetry.trajectory_for_entity(1001);
+        assert_eq!(samples.len(), 3);
+        assert_eq!(app.selected_entity(), Some(1001));
+        assert_eq!(
+            app.state
+                .telemetry
+                .latest_agent_for_entity(1001)
+                .expect("selected entity telemetry")
+                .message_count,
+            1
+        );
+    }
+
+    #[test]
+    fn spacetime_dashboard_aggregates_authoritative_telemetry() {
+        let mut app = PodEditorApp::default();
+        app.record_tick_telemetry(sample_tick_telemetry(12, 1001));
+
+        assert_eq!(app.state.spacetime_dashboard.latest_tick, 12);
+        assert_eq!(app.state.spacetime_dashboard.connected_players, 1);
+        assert_eq!(app.state.spacetime_dashboard.visible_entity_count, 7);
+        assert_eq!(app.state.spacetime_dashboard.audible_event_count, 2);
+        assert_eq!(app.state.spacetime_dashboard.message_count, 1);
+        assert!(app.state.spacetime_dashboard.action_rejection_rate > 0.0);
+        assert!(app.state.spacetime_dashboard.tool_call_error_rate > 0.0);
+        assert_eq!(app.state.spacetime_dashboard.agent_summaries.len(), 1);
+        assert_eq!(
+            app.state.spacetime_dashboard.agent_summaries[0].entity_id,
+            Some(1001)
         );
     }
 
@@ -2526,7 +2943,7 @@ mod tests {
         app.set_spacetime_reducer_call("tick");
         assert_eq!(app.state.spacetime_dashboard.reducer_calls, start + 1);
         assert_eq!(app.state.spacetime_dashboard.last_reducer_call, "tick");
-        assert_eq!(app.state.spacetime_dashboard.world_tick, 1);
+        assert_eq!(app.state.spacetime_dashboard.latest_tick, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add shared telemetry retention config in pod-core and size the archive from it
- add pod-web debug telemetry contract, HUD, trajectory trails, and toon-material coverage for stylized opaque geometry
- add pod-editor telemetry panel plus telemetry-aware Spacetime dashboard aggregation

## Validation
- cargo test -p pod-core --lib
- cargo test -p pod-editor --lib
- bun test
- bun run typecheck
- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added telemetry panel in the browser UI with agent statistics, trajectory visualization, and recovery diagnostics
- Integrated telemetry panel in the editor displaying agent behavior, actions, and tool execution metrics
- Added toon shading support for stylized rendering of world geometry

**Tests**
- Added test coverage for telemetry overlay behavior and material rendering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->