### PR TITLE
Export debug telemetry through pod-net and pod-stdb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3775,6 +3775,7 @@ version = "0.1.0"
 dependencies = [
  "eframe",
  "egui",
+ "glam",
  "log",
  "pod-core",
  "serde",

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -494,5 +494,22 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `bun run typecheck`
   - `bun run build`
 
-**Last updated**: Iteration 58
-**Current focus**: Iteration 59 authority export for direct-connect and SpacetimeDB telemetry, then provider/tool-call instrumentation for embedded agents
+### Iteration 59 — Authority Telemetry Export and Toon Lookup Correction
+
+- [x] Added opt-in direct-connect telemetry protocol support in `pod-net` with `ClientMessage::SetDebugTelemetry { enabled }` and `ServerMessage::TickTelemetry { frame_json }`.
+- [x] Extended the native QUIC and browser WebSocket clients with debug telemetry toggles plus cached access to the most recent authoritative telemetry payload.
+- [x] Decoupled debug telemetry delivery from gameplay state-delta emission so debug/editor clients still receive per-tick telemetry on idle world ticks with no replicated state changes.
+- [x] Added SpacetimeDB telemetry subscription surfaces, event variants, and adapter bridging so editor/debug consumers can subscribe to `agent_telemetry_tick`, `agent_tool_call_event`, and `agent_tick_rollup`, while `pod-net` emits `TickTelemetry` messages from those rows.
+- [x] Added initial SpacetimeDB telemetry table definitions for transient per-agent tick rows, tool/provider event rows, and aggregate rollups.
+- [x] Corrected the Three.js toon lookup texture path to keep the gradient map in a non-color data space instead of sRGB color-managed sampling.
+- [x] Added deterministic coverage for direct-connect debug telemetry round-tripping, SpacetimeDB telemetry subscription helpers/events, adapter forwarding of telemetry rows, and the toon gradient lookup color-space contract.
+- [x] Validated touched targets:
+  - `cargo test -p pod-net --lib`
+  - `cargo test -p pod-net --features spacetimedb --lib`
+  - `cargo test -p pod-stdb --no-default-features --features client`
+  - `cargo check -p pod-net --target wasm32-unknown-unknown --lib`
+  - `bun test`
+  - `bun run typecheck`
+
+**Last updated**: Iteration 59
+**Current focus**: Iteration 60 embedded-agent tool/runtime instrumentation, replay/training export, and MMO operational telemetry on top of the new authority export path

--- a/apps/pod-web/src/assets.test.ts
+++ b/apps/pod-web/src/assets.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { NoColorSpace } from "three";
 
 import { createMeshMaterial } from "./assets";
 import type { ThreeJsMeshBatch } from "./contracts";
@@ -36,6 +37,9 @@ describe("createMeshMaterial", () => {
   test("uses toon shading for stylized opaque world geometry", () => {
     const material = createMeshMaterial(meshBatch(), 0, QUALITY);
     expect(material.type).toBe("MeshToonMaterial");
+    expect((material as { gradientMap?: { colorSpace?: string } }).gradientMap?.colorSpace).toBe(
+      NoColorSpace
+    );
   });
 
   test("keeps transparent glass surfaces on the standard material path", () => {

--- a/apps/pod-web/src/assets.ts
+++ b/apps/pod-web/src/assets.ts
@@ -10,6 +10,7 @@ import {
   MeshToonMaterial,
   MeshStandardMaterial,
   NearestFilter,
+  NoColorSpace,
   PlaneGeometry,
   RepeatWrapping,
   SRGBColorSpace,
@@ -236,7 +237,7 @@ function getToonGradientMap(): Texture {
   ]);
   const texture = new DataTexture(gradient, 4, 1);
   texture.needsUpdate = true;
-  texture.colorSpace = SRGBColorSpace;
+  texture.colorSpace = NoColorSpace;
   texture.minFilter = NearestFilter;
   texture.magFilter = NearestFilter;
   texture.generateMipmaps = false;

--- a/crates/pod-net/src/client_native.rs
+++ b/crates/pod-net/src/client_native.rs
@@ -62,6 +62,8 @@ pub struct NativeClient {
     reconnect_token: Option<ReconnectToken>,
     /// Last authoritative reconciliation outcome.
     last_reconciliation: Option<ReconciliationReport>,
+    /// Most recent debug telemetry payload received from the server.
+    last_debug_telemetry_json: Option<String>,
     /// Recovery request throttle/telemetry for full-snapshot resync.
     recovery_state: RecoveryRequestState,
     /// Authoritative history for presentation smoothing.
@@ -153,6 +155,7 @@ impl NativeClient {
             last_event_tick: 0,
             reconnect_token: None,
             last_reconciliation: None,
+            last_debug_telemetry_json: None,
             recovery_state: RecoveryRequestState::default(),
             render_buffer: SnapshotInterpolationBuffer::default(),
             render_clock: RenderClock::default(),
@@ -455,6 +458,10 @@ impl NativeClient {
                 true
             }
             ServerMessage::Pong { .. } => true,
+            ServerMessage::TickTelemetry { frame_json } => {
+                self.last_debug_telemetry_json = Some(frame_json.clone());
+                true
+            }
             ServerMessage::Rejected { reason } => {
                 error!("Server rejected request: {}", reason);
                 true
@@ -470,6 +477,12 @@ impl NativeClient {
             .as_millis() as u64;
 
         self.send_message(ClientMessage::Ping { timestamp }).await
+    }
+
+    /// Opt-in to raw debug telemetry from the authoritative server.
+    pub async fn set_debug_telemetry_enabled(&mut self, enabled: bool) -> Result<(), ClientError> {
+        self.send_message(ClientMessage::SetDebugTelemetry { enabled })
+            .await
     }
 
     /// Disconnect from the server
@@ -494,6 +507,7 @@ impl NativeClient {
             reason.unwrap_or("Disconnect").as_bytes(),
         );
         self.recovery_state.clear();
+        self.last_debug_telemetry_json = None;
         self.clear_presentation_state();
 
         info!("Disconnected from server");
@@ -533,6 +547,10 @@ impl NativeClient {
     /// Get the most recent reconciliation report.
     pub fn last_reconciliation(&self) -> Option<&ReconciliationReport> {
         self.last_reconciliation.as_ref()
+    }
+
+    pub fn last_debug_telemetry_json(&self) -> Option<&str> {
+        self.last_debug_telemetry_json.as_deref()
     }
 
     /// Inspect the local rollback/replay path from a chosen authoritative tick.
@@ -875,6 +893,7 @@ mod tests {
             last_event_tick: 20,
             reconnect_token: None,
             last_reconciliation: None,
+            last_debug_telemetry_json: None,
             recovery_state: RecoveryRequestState::default(),
             render_buffer,
             render_clock,
@@ -920,6 +939,7 @@ mod tests {
             last_event_tick: 0,
             reconnect_token: None,
             last_reconciliation: None,
+            last_debug_telemetry_json: None,
             recovery_state: RecoveryRequestState::default(),
             render_buffer: SnapshotInterpolationBuffer::default(),
             render_clock: RenderClock::default(),
@@ -927,5 +947,49 @@ mod tests {
 
         client.request_full_snapshot_without_connection_is_safe();
         assert_eq!(client.recovery_state, RecoveryRequestState::default());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_tick_telemetry_updates_debug_cache() {
+        let endpoint = Endpoint::client("0.0.0.0:0".parse().unwrap()).unwrap();
+        let (tx, rx) = mpsc::channel(1);
+        let mut client = NativeClient {
+            config: ProtoClientConfig {
+                server_addr: "localhost".into(),
+                server_port: 5000,
+                player_name: "Tester".into(),
+                timeout_ms: 1000,
+            },
+            client_id: None,
+            connection: None,
+            endpoint,
+            rx,
+            tx,
+            reader_task: None,
+            pending_updates: Vec::new(),
+            authoritative_snapshot: None,
+            local_snapshot: None,
+            controlled_entity: None,
+            pending_actions: Vec::new(),
+            prediction_history: Vec::new(),
+            last_server_tick: 0,
+            last_acknowledged_action_tick: None,
+            last_event_tick: 0,
+            reconnect_token: None,
+            last_reconciliation: None,
+            last_debug_telemetry_json: None,
+            recovery_state: RecoveryRequestState::default(),
+            render_buffer: SnapshotInterpolationBuffer::default(),
+            render_clock: RenderClock::default(),
+        };
+
+        let message = ServerMessage::TickTelemetry {
+            frame_json: "{\"tick_telemetry\":{\"tick\":4,\"agents\":[]}}".into(),
+        };
+        assert!(client.apply_server_message(&message));
+        assert_eq!(
+            client.last_debug_telemetry_json(),
+            Some("{\"tick_telemetry\":{\"tick\":4,\"agents\":[]}}")
+        );
     }
 }

--- a/crates/pod-net/src/client_stdb.rs
+++ b/crates/pod-net/src/client_stdb.rs
@@ -74,6 +74,8 @@ enum SubscriptionProfile {
     Spectator,
     /// Editor/dashboards: all world state without transient events.
     Editor,
+    /// Editor/dashboards with debug telemetry streams enabled.
+    EditorDebug,
     /// Player mode for a single controlled entity + public events.
     Player(u64),
     /// Caller-supplied custom query set.
@@ -102,6 +104,10 @@ impl SpacetimeSubscriptionManager {
 
     fn set_editor(&mut self) -> bool {
         self.set_profile(SubscriptionProfile::Editor)
+    }
+
+    fn set_editor_debug(&mut self) -> bool {
+        self.set_profile(SubscriptionProfile::EditorDebug)
     }
 
     fn set_player(&mut self, entity_id: u64) -> bool {
@@ -161,6 +167,7 @@ impl SpacetimeSubscriptionManager {
                 .into_iter()
                 .map(ToString::to_string)
                 .collect(),
+            SubscriptionProfile::EditorDebug => Subscriptions::editor_with_debug_telemetry(),
             SubscriptionProfile::Player(entity_id) => Subscriptions::player_agent(*entity_id)
                 .into_iter()
                 .collect(),
@@ -388,6 +395,7 @@ pub struct SpacetimeDBClient {
     reconnect_token: ReconnectToken,
     pending_actions: Vec<Action>,
     local_snapshot: Option<WorldSnapshot>,
+    last_debug_telemetry_json: Option<String>,
     render_buffer: SnapshotInterpolationBuffer,
     render_clock: RenderClock,
     welcome_sent: bool,
@@ -404,6 +412,7 @@ impl SpacetimeDBClient {
             reconnect_token: ReconnectToken::new(),
             pending_actions: Vec::new(),
             local_snapshot: None,
+            last_debug_telemetry_json: None,
             render_buffer: SnapshotInterpolationBuffer::default(),
             render_clock: RenderClock::default(),
             welcome_sent: false,
@@ -682,6 +691,10 @@ impl SpacetimeDBClient {
                         });
                     }
                 }
+                StdbEvent::AgentTelemetryTickReceived { frame_json, .. } => {
+                    self.last_debug_telemetry_json = Some(frame_json.clone());
+                    messages.push(ServerMessage::TickTelemetry { frame_json });
+                }
 
                 // ── Tick advancement ──
                 StdbEvent::TickAdvanced { new_tick, .. } => {
@@ -702,6 +715,8 @@ impl SpacetimeDBClient {
 
                 // ── Internal events (no ServerMessage equivalent) ──
                 StdbEvent::ObservationReceived { .. }
+                | StdbEvent::AgentToolCallEventReceived { .. }
+                | StdbEvent::AgentTickRollupReceived { .. }
                 | StdbEvent::ReducerCallSuccess { .. }
                 | StdbEvent::ReducerCallError { .. } => {}
             }
@@ -716,6 +731,7 @@ impl SpacetimeDBClient {
         self.client_id = None;
         self.welcome_sent = false;
         self.last_emitted_tick = 0;
+        self.last_debug_telemetry_json = None;
         self.subscriptions.reset_connection();
         self.clear_presentation_state();
     }
@@ -736,6 +752,13 @@ impl SpacetimeDBClient {
     /// applied once a connection is established.
     pub fn subscribe_as_editor(&mut self) -> Result<bool, StdbClientError> {
         self.subscriptions.set_editor();
+        self.subscriptions
+            .ensure_subscriptions_applied(&mut self.inner)
+    }
+
+    /// Configure subscriptions for editor dashboards with raw debug telemetry.
+    pub fn subscribe_as_editor_with_debug_telemetry(&mut self) -> Result<bool, StdbClientError> {
+        self.subscriptions.set_editor_debug();
         self.subscriptions
             .ensure_subscriptions_applied(&mut self.inner)
     }
@@ -837,6 +860,10 @@ impl SpacetimeDBClient {
     /// Current presentation tick after interpolation/catch-up correction.
     pub fn presentation_tick(&self) -> Option<f32> {
         self.render_clock.current_tick()
+    }
+
+    pub fn last_debug_telemetry_json(&self) -> Option<&str> {
+        self.last_debug_telemetry_json.as_deref()
     }
 
     /// Inspect the local rollback/replay path from a chosen retained tick.
@@ -1517,6 +1544,44 @@ mod tests {
         assert!(queries.iter().any(|query| query.contains("FROM entity")));
         assert!(queries.iter().any(|query| query.contains("combat_event")));
         assert!(client.subscriptions.active_queries().is_empty());
+    }
+
+    #[test]
+    fn test_editor_debug_profile_includes_telemetry_queries() {
+        let mut client = SpacetimeDBClient::new(SpacetimeDBClientConfig::default());
+        client.subscriptions.set_editor_debug();
+        let queries = client.subscriptions.queries_for_profile();
+
+        assert!(queries
+            .iter()
+            .any(|query| query.contains("agent_telemetry_tick")));
+        assert!(queries
+            .iter()
+            .any(|query| query.contains("agent_tool_call_event")));
+        assert!(queries
+            .iter()
+            .any(|query| query.contains("agent_tick_rollup")));
+    }
+
+    #[test]
+    fn test_poll_updates_emits_tick_telemetry_from_stdb_events() {
+        let mut client = SpacetimeDBClient::new(SpacetimeDBClientConfig::default());
+        client.inner_mut().receive_agent_telemetry_tick(
+            12,
+            44,
+            "{\"tick_telemetry\":{\"tick\":12,\"agents\":[]}}".into(),
+        );
+
+        let messages = client.poll_updates();
+        assert!(messages.iter().any(|message| matches!(
+            message,
+            ServerMessage::TickTelemetry { frame_json }
+                if frame_json.contains("\"tick\":12")
+        )));
+        assert_eq!(
+            client.last_debug_telemetry_json(),
+            Some("{\"tick_telemetry\":{\"tick\":12,\"agents\":[]}}")
+        );
     }
 
     #[test]

--- a/crates/pod-net/src/client_web.rs
+++ b/crates/pod-net/src/client_web.rs
@@ -58,6 +58,8 @@ pub struct WebClient {
     reconnect_token: Option<ReconnectToken>,
     /// Last authoritative reconciliation outcome.
     last_reconciliation: Option<ReconciliationReport>,
+    /// Most recent debug telemetry payload received from the server.
+    last_debug_telemetry_json: Option<String>,
     /// Recovery request throttle/telemetry for full-snapshot resync.
     recovery_state: RecoveryRequestState,
     /// Authoritative history for presentation smoothing.
@@ -90,6 +92,7 @@ impl WebClient {
             last_event_tick: 0,
             reconnect_token: None,
             last_reconciliation: None,
+            last_debug_telemetry_json: None,
             recovery_state: RecoveryRequestState::default(),
             render_buffer: SnapshotInterpolationBuffer::default(),
             render_clock: RenderClock::default(),
@@ -377,6 +380,10 @@ impl WebClient {
                 true
             }
             ServerMessage::Pong { .. } => true,
+            ServerMessage::TickTelemetry { frame_json } => {
+                self.last_debug_telemetry_json = Some(frame_json.clone());
+                true
+            }
             ServerMessage::Rejected { reason } => {
                 web_sys::console::error_1(&format!("Server rejected request: {reason}").into());
                 true
@@ -414,6 +421,11 @@ impl WebClient {
         self.send_message(ClientMessage::Ping { timestamp })
     }
 
+    /// Opt-in to raw debug telemetry from the authoritative server.
+    pub fn set_debug_telemetry_enabled(&self, enabled: bool) -> Result<(), ClientError> {
+        self.send_message(ClientMessage::SetDebugTelemetry { enabled })
+    }
+
     /// Disconnect from the server
     pub fn disconnect(&mut self, reason: Option<&str>) -> Result<(), ClientError> {
         let msg = ClientMessage::Disconnect {
@@ -430,6 +442,7 @@ impl WebClient {
         self.websocket = None;
         self.connected = false;
         self.recovery_state.clear();
+        self.last_debug_telemetry_json = None;
         self.clear_presentation_state();
         Ok(())
     }
@@ -467,6 +480,10 @@ impl WebClient {
     /// Get the most recent reconciliation report.
     pub fn last_reconciliation(&self) -> Option<&ReconciliationReport> {
         self.last_reconciliation.as_ref()
+    }
+
+    pub fn last_debug_telemetry_json(&self) -> Option<&str> {
+        self.last_debug_telemetry_json.as_deref()
     }
 
     /// Inspect the local rollback/replay path from a chosen authoritative tick.

--- a/crates/pod-net/src/protocol.rs
+++ b/crates/pod-net/src/protocol.rs
@@ -65,6 +65,9 @@ pub enum ClientMessage {
         last_known_digest: Option<u64>,
     },
 
+    /// Enable or disable debug-only cross-agent telemetry streaming.
+    SetDebugTelemetry { enabled: bool },
+
     /// Ping request — measures round-trip time
     Ping { timestamp: u64 },
 }
@@ -109,6 +112,9 @@ pub enum ServerMessage {
 
     /// Batch of game events
     EventBatch { tick: u64, events: Vec<GameEvent> },
+
+    /// Raw authoritative telemetry payload for debug/editor consumers.
+    TickTelemetry { frame_json: String },
 
     /// Response to ping request
     Pong { client_ts: u64, server_ts: u64 },
@@ -254,6 +260,18 @@ mod tests {
     }
 
     #[test]
+    fn test_set_debug_telemetry_roundtrip() {
+        let msg = ClientMessage::SetDebugTelemetry { enabled: true };
+        let encoded = msg.encode().unwrap();
+        let decoded = ClientMessage::decode(&encoded).unwrap();
+
+        match decoded {
+            ClientMessage::SetDebugTelemetry { enabled } => assert!(enabled),
+            other => panic!("Wrong message type: {other:?}"),
+        }
+    }
+
+    #[test]
     fn test_server_message_json() {
         let _config = ServerConfig::default();
         let snapshot = crate::WorldSnapshot::default();
@@ -280,6 +298,22 @@ mod tests {
                 assert_eq!(controlled_entity, Some(42));
             }
             _ => panic!("Wrong message type"),
+        }
+    }
+
+    #[test]
+    fn test_tick_telemetry_json_roundtrip() {
+        let msg = ServerMessage::TickTelemetry {
+            frame_json: "{\"tick_telemetry\":{\"tick\":7,\"agents\":[]}}".into(),
+        };
+        let json = msg.encode_json().unwrap();
+        let decoded = ServerMessage::decode_json(&json).unwrap();
+
+        match decoded {
+            ServerMessage::TickTelemetry { frame_json } => {
+                assert!(frame_json.contains("\"tick\":7"));
+            }
+            other => panic!("Wrong message type: {other:?}"),
         }
     }
 }

--- a/crates/pod-net/src/server.rs
+++ b/crates/pod-net/src/server.rs
@@ -14,6 +14,7 @@ use quinn::Endpoint;
 use tokio::sync::{mpsc, RwLock};
 
 use pod_core::{Action, IdleAgent, World};
+use serde_json::json;
 
 use crate::protocol::{
     ClientId, ClientMessage, ReconnectToken, ServerConfig as ProtoServerConfig, ServerMessage,
@@ -32,6 +33,7 @@ struct ClientSession {
     reconnect_token: ReconnectToken,
     last_action_tick: Option<u64>,
     last_processed_action_tick: Option<u64>,
+    debug_telemetry_enabled: bool,
 }
 
 impl ClientSession {
@@ -44,6 +46,7 @@ impl ClientSession {
             reconnect_token: ReconnectToken::new(),
             last_action_tick: None,
             last_processed_action_tick: None,
+            debug_telemetry_enabled: false,
         }
     }
 }
@@ -89,6 +92,8 @@ pub struct GameServer {
     last_snapshot_tick: u64,
     /// Last full snapshot for delta computation.
     last_snapshot: Option<WorldSnapshot>,
+    /// Latest authoritative telemetry payload for debug/editor clients.
+    last_tick_telemetry_json: Option<String>,
 }
 
 impl GameServer {
@@ -106,6 +111,7 @@ impl GameServer {
             tick: 0,
             last_snapshot_tick: 0,
             last_snapshot: None,
+            last_tick_telemetry_json: None,
         }
     }
 
@@ -212,7 +218,11 @@ impl GameServer {
         }
 
         // Step the world
-        self.world.step();
+        let tick_result = self.world.step();
+        self.last_tick_telemetry_json = Some(
+            serde_json::to_string(&json!({ "tick_telemetry": tick_result.telemetry }))
+                .expect("tick telemetry should serialize"),
+        );
 
         debug!(
             "Tick {}: {} entities, {} agents",
@@ -432,6 +442,12 @@ impl GameServer {
                         );
                         self.send_full_snapshot_to_client(client_id).await;
                     }
+                    ClientMessage::SetDebugTelemetry { enabled } => {
+                        let mut clients = self.clients.write().await;
+                        if let Some(session) = clients.get_mut(&client_id) {
+                            session.debug_telemetry_enabled = enabled;
+                        }
+                    }
                     ClientMessage::Ping { timestamp } => {
                         self.send_to_client(
                             client_id,
@@ -483,31 +499,57 @@ impl GameServer {
             )
         };
 
-        if !should_snapshot && delta.change_count() == 0 {
+        let has_state_update = should_snapshot || delta.change_count() > 0;
+        let clients = self.clients.read().await;
+        let has_debug_subscribers = clients
+            .values()
+            .any(|session| session.debug_telemetry_enabled);
+
+        if !has_state_update && !has_debug_subscribers {
             return Ok(());
         }
 
-        let clients = self.clients.read().await;
-
         for (client_id, session) in clients.iter() {
-            let msg = ServerMessage::StateDelta {
-                tick: self.tick,
-                acknowledged_action_tick: session.last_processed_action_tick,
-                authoritative_digest,
-                is_full_snapshot,
-                delta: delta.clone(),
-            };
-            if let Some(tx) = self.client_tx.read().await.get(client_id) {
-                if let Err(e) = tx.send(msg).await {
-                    error!("Failed to send update to client {}: {}", client_id.0, e);
+            if has_state_update {
+                let msg = ServerMessage::StateDelta {
+                    tick: self.tick,
+                    acknowledged_action_tick: session.last_processed_action_tick,
+                    authoritative_digest,
+                    is_full_snapshot,
+                    delta: delta.clone(),
+                };
+                if let Some(tx) = self.client_tx.read().await.get(client_id) {
+                    if let Err(e) = tx.send(msg).await {
+                        error!("Failed to send update to client {}: {}", client_id.0, e);
+                    }
+                }
+            }
+
+            if session.debug_telemetry_enabled {
+                if let Some(frame_json) = &self.last_tick_telemetry_json {
+                    if let Some(tx) = self.client_tx.read().await.get(client_id) {
+                        if let Err(e) = tx
+                            .send(ServerMessage::TickTelemetry {
+                                frame_json: frame_json.clone(),
+                            })
+                            .await
+                        {
+                            error!(
+                                "Failed to send debug telemetry to client {}: {}",
+                                client_id.0, e
+                            );
+                        }
+                    }
                 }
             }
         }
 
-        if is_full_snapshot {
+        if has_state_update && is_full_snapshot {
             self.last_snapshot_tick = self.tick;
         }
-        self.last_snapshot = Some(current_snapshot);
+        if has_state_update {
+            self.last_snapshot = Some(current_snapshot);
+        }
 
         Ok(())
     }
@@ -605,6 +647,7 @@ impl GameServer {
                         session.agent_id = prev.agent_id;
                         session.last_action_tick = prev.last_action_tick;
                         session.last_processed_action_tick = prev.last_processed_action_tick;
+                        session.debug_telemetry_enabled = prev.debug_telemetry_enabled;
                         session.pending_actions.clear();
                     } else if session.player_name.is_none() {
                         session.player_name = Some(player_name.clone());
@@ -772,5 +815,43 @@ mod tests {
             }
             other => panic!("unexpected message: {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_broadcast_updates_emits_tick_telemetry_for_debug_clients_only() {
+        let config = ProtoServerConfig::default();
+        let world = World::new(42);
+        let mut server = GameServer::new(config, world);
+        let client_id = ClientId::new();
+        let (tx, mut rx) = mpsc::channel(8);
+        server.client_tx.write().await.insert(client_id, tx);
+        server.clients.write().await.insert(
+            client_id,
+            ClientSession {
+                player_name: Some("debug".into()),
+                agent_id: None,
+                pending_actions: Vec::new(),
+                reconnect_token: ReconnectToken::new(),
+                last_action_tick: None,
+                last_processed_action_tick: None,
+                debug_telemetry_enabled: true,
+            },
+        );
+
+        server.step_tick().await.unwrap();
+        server.broadcast_updates().await.unwrap();
+
+        let mut saw_tick_telemetry = false;
+        while let Ok(message) = rx.try_recv() {
+            match message {
+                ServerMessage::TickTelemetry { frame_json } => {
+                    saw_tick_telemetry = true;
+                    assert!(frame_json.contains("\"tick_telemetry\""));
+                }
+                _ => {}
+            }
+        }
+
+        assert!(saw_tick_telemetry);
     }
 }

--- a/crates/pod-net/tests/networking_integration.rs
+++ b/crates/pod-net/tests/networking_integration.rs
@@ -16,9 +16,18 @@ fn integration_connect_stages_default_subscriptions_without_network() {
     let mut client = SpacetimeDBClient::new(SpacetimeDBClientConfig::default());
 
     assert!(!client.is_connected());
-    assert!(!client.subscribe_as_spectator().expect("staging spectator subscriptions"));
-    assert!(!client.subscribe_as_editor().expect("staging editor subscriptions"));
-    assert!(!client.subscribe_for_player(7).expect("staging player subscriptions"));
+    assert!(!client
+        .subscribe_as_spectator()
+        .expect("staging spectator subscriptions"));
+    assert!(!client
+        .subscribe_as_editor()
+        .expect("staging editor subscriptions"));
+    assert!(!client
+        .subscribe_as_editor_with_debug_telemetry()
+        .expect("staging editor debug telemetry subscriptions"));
+    assert!(!client
+        .subscribe_for_player(7)
+        .expect("staging player subscriptions"));
     assert!(!client
         .subscribe_for_player_with_interest(7, 100.0, 200.0, 50.0)
         .expect("staging interest query subscriptions"));
@@ -34,11 +43,16 @@ fn integration_connect_stages_default_subscriptions_without_network() {
 fn integration_connect_guard_and_rejects_duplicate_connect_attempt() {
     let mut client = SpacetimeDBClient::new(SpacetimeDBClientConfig::default());
 
-    client.connect().expect("initial connect should move to connecting");
+    client
+        .connect()
+        .expect("initial connect should move to connecting");
     assert!(!client.is_connected());
 
     let second_connect = client.connect();
-    assert!(matches!(second_connect, Err(StdbClientError::InvalidState(_))));
+    assert!(matches!(
+        second_connect,
+        Err(StdbClientError::InvalidState(_))
+    ));
 
     // Connection is asynchronous in this layer, so polling should not panic and should
     // not emit any synthetic server messages in stub mode.
@@ -49,7 +63,9 @@ fn integration_connect_guard_and_rejects_duplicate_connect_attempt() {
 fn integration_send_actions_guarded_by_connection_and_spectator_profile() {
     let mut client = SpacetimeDBClient::new(SpacetimeDBClientConfig::default());
 
-    client.subscribe_as_spectator().expect("staging spectator profile");
+    client
+        .subscribe_as_spectator()
+        .expect("staging spectator profile");
     client.queue_action(Action::Move {
         direction: Vec2::new(1.0, 0.0),
     });

--- a/crates/pod-stdb/src/client.rs
+++ b/crates/pod-stdb/src/client.rs
@@ -226,6 +226,28 @@ pub enum StdbEvent {
         secondary_entity_id: Option<u64>,
         data_json: String,
     },
+    /// Per-agent authoritative telemetry row received for debug/editor consumers.
+    AgentTelemetryTickReceived {
+        tick: u64,
+        agent_entity_id: u64,
+        frame_json: String,
+    },
+    /// Detailed tool/provider side-effect row received for debug/editor consumers.
+    AgentToolCallEventReceived {
+        tick: u64,
+        agent_entity_id: u64,
+        tool_name: String,
+        provider: String,
+        status: String,
+        data_json: String,
+    },
+    /// Durable aggregate telemetry rollup received for dashboards/analytics.
+    AgentTickRollupReceived {
+        tick_start: u64,
+        tick_end: u64,
+        agent_entity_id: u64,
+        rollup_json: String,
+    },
 
     // ── Reducer acknowledgments ──
     /// A reducer call was acknowledged by the server.
@@ -573,6 +595,9 @@ impl Subscriptions {
             "SELECT * FROM combat_event",
             "SELECT * FROM speech_event",
             "SELECT * FROM world_event",
+            "SELECT * FROM agent_telemetry_tick",
+            "SELECT * FROM agent_tool_call_event",
+            "SELECT * FROM agent_tick_rollup",
             "SELECT * FROM match_queue",
             "SELECT * FROM game_match",
             "SELECT * FROM match_participant",
@@ -640,6 +665,27 @@ impl Subscriptions {
             "SELECT * FROM script",
             "SELECT * FROM connected_agent",
         ]
+    }
+
+    /// Subscribe to debug-only telemetry tables.
+    pub fn debug_telemetry() -> Vec<&'static str> {
+        vec![
+            "SELECT * FROM agent_telemetry_tick",
+            "SELECT * FROM agent_tool_call_event",
+            "SELECT * FROM agent_tick_rollup",
+        ]
+    }
+
+    /// Subscribe to editor world state plus debug telemetry streams.
+    pub fn editor_with_debug_telemetry() -> Vec<String> {
+        let mut queries = Self::editor()
+            .into_iter()
+            .map(str::to_string)
+            .collect::<Vec<String>>();
+        queries.extend(Self::debug_telemetry().into_iter().map(str::to_string));
+        queries.sort_unstable();
+        queries.dedup();
+        queries
     }
 
     /// Subscribe to lobby tables only.
@@ -1807,6 +1853,61 @@ impl StdbClient {
         });
         self.events_received += 1;
     }
+
+    /// Store a received per-agent telemetry row for debug/editor subscriptions.
+    pub fn receive_agent_telemetry_tick(
+        &mut self,
+        tick: u64,
+        agent_entity_id: u64,
+        frame_json: String,
+    ) {
+        self.events
+            .push_back(StdbEvent::AgentTelemetryTickReceived {
+                tick,
+                agent_entity_id,
+                frame_json,
+            });
+        self.events_received += 1;
+    }
+
+    /// Store a received tool/provider telemetry row for debug/editor subscriptions.
+    pub fn receive_agent_tool_call_event(
+        &mut self,
+        tick: u64,
+        agent_entity_id: u64,
+        tool_name: String,
+        provider: String,
+        status: String,
+        data_json: String,
+    ) {
+        self.events
+            .push_back(StdbEvent::AgentToolCallEventReceived {
+                tick,
+                agent_entity_id,
+                tool_name,
+                provider,
+                status,
+                data_json,
+            });
+        self.events_received += 1;
+    }
+
+    /// Store a received aggregate telemetry rollup for debug/editor subscriptions.
+    pub fn receive_agent_tick_rollup(
+        &mut self,
+        tick_start: u64,
+        tick_end: u64,
+        agent_entity_id: u64,
+        rollup_json: String,
+    ) {
+        self.events.push_back(StdbEvent::AgentTickRollupReceived {
+            tick_start,
+            tick_end,
+            agent_entity_id,
+            rollup_json,
+        });
+        self.events_received += 1;
+    }
 }
 
 impl std::fmt::Debug for StdbClient {
@@ -1973,6 +2074,7 @@ mod tests {
     fn test_subscription_queries() {
         let all = Subscriptions::all_tables();
         assert!(all.len() >= 15);
+        assert!(all.iter().any(|q| q.contains("agent_telemetry_tick")));
 
         let player = Subscriptions::player_agent(42);
         assert!(player.iter().any(|q| q.contains("observation_event")));
@@ -1983,6 +2085,57 @@ mod tests {
 
         let editor = Subscriptions::editor();
         assert!(editor.iter().any(|q| q.contains("agent_constraints")));
+
+        let editor_debug = Subscriptions::editor_with_debug_telemetry();
+        assert!(editor_debug
+            .iter()
+            .any(|q| q.contains("agent_telemetry_tick")));
+        assert!(editor_debug
+            .iter()
+            .any(|q| q.contains("agent_tool_call_event")));
+        assert!(editor_debug.iter().any(|q| q.contains("agent_tick_rollup")));
+    }
+
+    #[test]
+    fn test_receive_debug_telemetry_events() {
+        let mut client = StdbClient::new(StdbClientConfig::default());
+        client.receive_agent_telemetry_tick(8, 41, "{\"tick_telemetry\":{\"tick\":8}}".into());
+        client.receive_agent_tool_call_event(
+            8,
+            41,
+            "llm.complete".into(),
+            "qwen".into(),
+            "Succeeded".into(),
+            "{\"latency_ms\":12}".into(),
+        );
+        client.receive_agent_tick_rollup(1, 60, 41, "{\"distance\":42.0}".into());
+
+        let events: Vec<StdbEvent> = client.drain_events().collect();
+        assert!(matches!(
+            &events[0],
+            StdbEvent::AgentTelemetryTickReceived {
+                tick: 8,
+                agent_entity_id: 41,
+                ..
+            }
+        ));
+        assert!(matches!(
+            &events[1],
+            StdbEvent::AgentToolCallEventReceived {
+                tick: 8,
+                agent_entity_id: 41,
+                ..
+            }
+        ));
+        assert!(matches!(
+            &events[2],
+            StdbEvent::AgentTickRollupReceived {
+                tick_start: 1,
+                tick_end: 60,
+                agent_entity_id: 41,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/pod-stdb/src/events.rs
+++ b/crates/pod-stdb/src/events.rs
@@ -9,8 +9,8 @@
 //! Events are cleared at the start of each tick before new events are generated.
 //! Clients subscribe to these tables to receive real-time game events.
 
-use spacetimedb::Identity;
 use crate::types::*;
+use spacetimedb::Identity;
 
 // ============================================================
 // ROW-LEVEL SECURITY — OBSERVATION VISIBILITY
@@ -34,7 +34,7 @@ mod rls {
 
     #[client_visibility_filter]
     const OBSERVATION_FILTER: Filter = Filter::Sql(
-        "SELECT * FROM observation_event WHERE observation_event.owner_identity = :sender"
+        "SELECT * FROM observation_event WHERE observation_event.owner_identity = :sender",
     );
 }
 
@@ -122,4 +122,68 @@ pub struct WorldEventRow {
     pub secondary_entity_id: Option<u64>,
     /// JSON-encoded event-specific data for extensibility
     pub data_json: String,
+}
+
+// ============================================================
+// DEBUG TELEMETRY EVENTS
+// ============================================================
+
+/// Per-agent authoritative telemetry row for editor/debug consumers.
+///
+/// These rows are transient and intended for short-lived tooling subscriptions.
+/// The detailed payload stays JSON-encoded so client tooling can evolve without
+/// forcing a second flattened schema for every new telemetry field.
+#[spacetimedb::table(name = agent_telemetry_tick, public)]
+pub struct AgentTelemetryTickRow {
+    #[primary_key]
+    #[auto_inc]
+    pub row_id: u64,
+    pub tick: u64,
+    pub agent_entity_id: u64,
+    pub visible_entity_count: u32,
+    pub audible_event_count: u32,
+    pub message_count: u32,
+    pub submitted_action_count: u32,
+    pub executed_action_count: u32,
+    pub rejected_action_count: u32,
+    pub trajectory_start_x: f32,
+    pub trajectory_start_y: f32,
+    pub trajectory_end_x: f32,
+    pub trajectory_end_y: f32,
+    pub frame_json: String,
+}
+
+/// Tool/provider telemetry event for embedded agent runtimes.
+#[spacetimedb::table(name = agent_tool_call_event, public)]
+pub struct AgentToolCallEventRow {
+    #[primary_key]
+    #[auto_inc]
+    pub row_id: u64,
+    pub tick: u64,
+    pub agent_entity_id: u64,
+    pub tool_name: String,
+    pub provider: String,
+    pub status: String,
+    pub latency_ms: u32,
+    pub request_units: u32,
+    pub response_units: u32,
+    pub data_json: String,
+}
+
+/// Durable aggregate telemetry rollup for dashboards and offline analytics.
+#[spacetimedb::table(name = agent_tick_rollup, public)]
+pub struct AgentTickRollupRow {
+    #[primary_key]
+    #[auto_inc]
+    pub row_id: u64,
+    pub tick_start: u64,
+    pub tick_end: u64,
+    pub agent_entity_id: u64,
+    pub total_distance: f32,
+    pub submitted_action_count: u32,
+    pub executed_action_count: u32,
+    pub rejected_action_count: u32,
+    pub tool_call_count: u32,
+    pub tool_error_count: u32,
+    pub rollup_json: String,
 }

--- a/crates/pod-stdb/tests/client_integration.rs
+++ b/crates/pod-stdb/tests/client_integration.rs
@@ -37,9 +37,15 @@ fn default_config_has_expected_values() {
     assert!(config.auth_token.is_none());
     assert_eq!(config.player_name, "Player");
     #[cfg(debug_assertions)]
-    assert!(matches!(config.connection_mode, StdbConnectionMode::Emulated));
+    assert!(matches!(
+        config.connection_mode,
+        StdbConnectionMode::Emulated
+    ));
     #[cfg(not(debug_assertions))]
-    assert!(matches!(config.connection_mode, StdbConnectionMode::Generated));
+    assert!(matches!(
+        config.connection_mode,
+        StdbConnectionMode::Generated
+    ));
 }
 
 #[test]
@@ -115,6 +121,47 @@ fn new_client_has_no_events() {
 }
 
 #[test]
+fn telemetry_subscription_helpers_include_debug_queries() {
+    let queries = Subscriptions::editor_with_debug_telemetry();
+    assert!(queries
+        .iter()
+        .any(|query| query.contains("agent_telemetry_tick")));
+    assert!(queries
+        .iter()
+        .any(|query| query.contains("agent_tool_call_event")));
+    assert!(queries
+        .iter()
+        .any(|query| query.contains("agent_tick_rollup")));
+}
+
+#[test]
+fn telemetry_events_are_constructible() {
+    let tick = StdbEvent::AgentTelemetryTickReceived {
+        tick: 12,
+        agent_entity_id: 7,
+        frame_json: "{\"tick_telemetry\":{\"tick\":12}}".into(),
+    };
+    let tool = StdbEvent::AgentToolCallEventReceived {
+        tick: 12,
+        agent_entity_id: 7,
+        tool_name: "llm.complete".into(),
+        provider: "qwen".into(),
+        status: "Succeeded".into(),
+        data_json: "{\"request_units\":128}".into(),
+    };
+    let rollup = StdbEvent::AgentTickRollupReceived {
+        tick_start: 1,
+        tick_end: 60,
+        agent_entity_id: 7,
+        rollup_json: "{\"distance\":84.0}".into(),
+    };
+
+    assert!(matches!(tick, StdbEvent::AgentTelemetryTickReceived { .. }));
+    assert!(matches!(tool, StdbEvent::AgentToolCallEventReceived { .. }));
+    assert!(matches!(rollup, StdbEvent::AgentTickRollupReceived { .. }));
+}
+
+#[test]
 fn config_accessor_returns_original_config() {
     let config = StdbClientConfig {
         host: "http://test:1234".into(),
@@ -165,7 +212,9 @@ fn connect_generated_mode_requires_runtime_bindings() {
         connection_mode: StdbConnectionMode::Generated,
         ..StdbClientConfig::default()
     });
-    let err = client.connect().expect_err("generated mode should require runtime");
+    let err = client
+        .connect()
+        .expect_err("generated mode should require runtime");
     assert!(matches!(err, StdbError::ConnectionFailed(_)));
 }
 
@@ -316,7 +365,9 @@ fn all_reducers_fail_when_only_connecting() {
     assert!(client
         .call_connect_agent(1, AgentType::LlmAgent, "Bot".into())
         .is_err());
-    assert!(client.call_submit_action(&SubmittedAction::idle(1)).is_err());
+    assert!(client
+        .call_submit_action(&SubmittedAction::idle(1))
+        .is_err());
     assert!(client
         .call_create_lobby("arena".into(), 1, 4, false)
         .is_err());
@@ -624,9 +675,9 @@ fn action_clone_and_debug() {
 // ============================================================
 
 #[test]
-fn subscription_all_tables_has_25_queries() {
+fn subscription_all_tables_has_28_queries() {
     let queries = Subscriptions::all_tables();
-    assert_eq!(queries.len(), 25);
+    assert_eq!(queries.len(), 28);
 }
 
 #[test]
@@ -805,7 +856,7 @@ fn stdb_error_clone_and_debug() {
 // ============================================================
 
 #[test]
-fn stdb_event_all_15_variants_constructible() {
+fn stdb_event_all_18_variants_constructible() {
     // Verify all StdbEvent variants can be created without panicking.
     // This ensures the public API surface matches our expectations.
     let events: Vec<StdbEvent> = vec![
@@ -862,6 +913,25 @@ fn stdb_event_all_15_variants_constructible() {
             secondary_entity_id: None,
             data_json: "{}".into(),
         },
+        StdbEvent::AgentTelemetryTickReceived {
+            tick: 1,
+            agent_entity_id: 5,
+            frame_json: "{\"tick_telemetry\":{\"tick\":1}}".into(),
+        },
+        StdbEvent::AgentToolCallEventReceived {
+            tick: 1,
+            agent_entity_id: 5,
+            tool_name: "llm.complete".into(),
+            provider: "qwen".into(),
+            status: "Succeeded".into(),
+            data_json: "{\"request_units\":42}".into(),
+        },
+        StdbEvent::AgentTickRollupReceived {
+            tick_start: 1,
+            tick_end: 60,
+            agent_entity_id: 5,
+            rollup_json: "{\"distance\":128.0}".into(),
+        },
         // Reducer acknowledgments
         StdbEvent::ReducerCallSuccess {
             reducer_name: "create_world".into(),
@@ -872,7 +942,7 @@ fn stdb_event_all_15_variants_constructible() {
         },
     ];
 
-    assert_eq!(events.len(), 15);
+    assert_eq!(events.len(), 18);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add opt-in direct-connect debug telemetry transport for pod-net clients and server
- add SpacetimeDB debug telemetry subscription/events plus adapter forwarding into pod-net
- keep the toon gradient lookup texture in data color space for the stylized web renderer

## Validation
- cargo test -p pod-net --lib
- cargo test -p pod-net --features spacetimedb --lib
- cargo test -p pod-stdb --no-default-features --features client
- cargo check -p pod-net --target wasm32-unknown-unknown --lib
- cd apps/pod-web && bun test && bun run typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in debug telemetry support enabling clients to receive and access real-time agent performance data
  * Introduced three new telemetry data tables for tracking agent tick metrics, tool call events, and rollup aggregations
  * Added editor subscription mode with integrated debug telemetry

* **Bug Fixes**
  * Fixed color-space rendering for toon shading materials

* **Documentation**
  * Updated implementation plan for Iteration 59

<!-- end of auto-generated comment: release notes by coderabbit.ai -->