### PR TITLE
Add embedded tool telemetry and replay plumbing

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -511,5 +511,21 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `bun test`
   - `bun run typecheck`
 
-**Last updated**: Iteration 59
-**Current focus**: Iteration 60 embedded-agent tool/runtime instrumentation, replay/training export, and MMO operational telemetry on top of the new authority export path
+### Iteration 60 — Embedded Tool Contracts, Replay Preservation, and MMO Server Telemetry
+
+- [x] Added first-class embedded tool/runtime contracts to `pod-core`: `ToolDefinition`, `ToolCatalog`, `ToolPolicy`, `ToolBudget`, `ToolInvocationRequest`, and `ToolInvocationResult`, and registered them in the runtime type registry alongside the existing action/observation/telemetry contracts.
+- [x] Expanded `ToolCallStatus` with explicit `RateLimited`, `ParseError`, `ApiError`, and `BudgetExceeded` states so agent-side provider telemetry can distinguish transport, provider, parser, and budget failures.
+- [x] Added `Agent::drain_tool_calls()` to the shared agent trait and wired authoritative tick execution to record drained tool-call traces into `TickTelemetryFrame`, so the telemetry spine now carries real embedded-agent side effects instead of empty placeholders.
+- [x] Instrumented `LlmAgent` and `HybridAgent` provider calls with canonical `llm.complete` tool traces, including success usage units, parse failures, provider failures, and pre-flight budget rejections.
+- [x] Fixed `LlmAgent`'s ready-action memory recording path so completed observations are no longer dropped before they can be persisted to conversation memory.
+- [x] Extended replay artifacts so `DecisionTrace` preserves `tool_calls`, and added optional embedded `telemetry_windows` support on `ReplayFile` for authoritative telemetry bundling.
+- [x] Updated `DecisionLogger::to_replay_file()` so tool-call telemetry survives conversion into replay/debug artifacts.
+- [x] Upgraded `apps/pod-server` runtime stats to consume the shared telemetry spine, tracking rejection rate, tool-call error/latency metrics, average agent trajectory distance, tick-budget overruns, and MMO-loop capture/summon/gather/loot counts.
+- [x] Added deterministic coverage for tool-contract serialization, agent tool-trace draining into authoritative tick telemetry, provider error-status mapping, LLM/hybrid tool-call instrumentation, replay preservation of tool calls, replay telemetry embedding, and server telemetry rollups.
+- [x] Validated touched targets:
+  - `cargo test -p pod-core --lib`
+  - `cargo test -p pod-agents --lib`
+  - `cargo test -p pod-server --bin pod-server`
+
+**Last updated**: Iteration 60
+**Current focus**: Iteration 61 training/export helpers plus flagship MMO acceptance harness on top of the authoritative telemetry and replay spine

--- a/apps/pod-server/src/main.rs
+++ b/apps/pod-server/src/main.rs
@@ -46,8 +46,8 @@ mod config {
         pub fn from_env() -> Self {
             // In a real application, you'd parse command-line args or env vars.
             // For now, use defaults or simple environment variable override.
-            let bind_address = std::env::var("POD_BIND_ADDRESS")
-                .unwrap_or_else(|_| "0.0.0.0:7777".to_string());
+            let bind_address =
+                std::env::var("POD_BIND_ADDRESS").unwrap_or_else(|_| "0.0.0.0:7777".to_string());
 
             let tick_rate = std::env::var("POD_TICK_RATE")
                 .ok()
@@ -64,10 +64,9 @@ mod config {
                 .and_then(|s| s.parse().ok())
                 .unwrap_or(42);
 
-            let map_name = std::env::var("POD_MAP_NAME")
-                .unwrap_or_else(|_| "default".to_string());
-            let runtime_mode = std::env::var("POD_RUNTIME_MODE")
-                .unwrap_or_else(|_| "network".to_string());
+            let map_name = std::env::var("POD_MAP_NAME").unwrap_or_else(|_| "default".to_string());
+            let runtime_mode =
+                std::env::var("POD_RUNTIME_MODE").unwrap_or_else(|_| "network".to_string());
 
             ServerConfig {
                 bind_address,
@@ -169,6 +168,8 @@ mod map {
 
 #[allow(dead_code)]
 mod stats {
+    use pod_core::action::Action;
+    use pod_core::telemetry::ToolCallStatus;
     use std::time::Instant;
 
     /// Server statistics tracker
@@ -179,8 +180,19 @@ mod stats {
         pub last_second_start: Instant,
         pub ticks_this_second: u32,
         pub total_actions: usize,
+        pub total_actions_rejected: usize,
         pub peak_entity_count: usize,
         pub peak_agent_count: usize,
+        pub tick_budget_overruns: u64,
+        pub total_tool_calls: usize,
+        pub total_tool_call_errors: usize,
+        pub total_tool_latency_ms: u64,
+        pub total_trajectory_distance: f32,
+        pub total_agents_sampled: usize,
+        pub capture_actions: usize,
+        pub summon_actions: usize,
+        pub gather_actions: usize,
+        pub loot_actions: usize,
     }
 
     impl ServerStats {
@@ -192,21 +204,110 @@ mod stats {
                 last_second_start: Instant::now(),
                 ticks_this_second: 0,
                 total_actions: 0,
+                total_actions_rejected: 0,
                 peak_entity_count: 0,
                 peak_agent_count: 0,
+                tick_budget_overruns: 0,
+                total_tool_calls: 0,
+                total_tool_call_errors: 0,
+                total_tool_latency_ms: 0,
+                total_trajectory_distance: 0.0,
+                total_agents_sampled: 0,
+                capture_actions: 0,
+                summon_actions: 0,
+                gather_actions: 0,
+                loot_actions: 0,
             }
         }
 
         /// Record a completed tick
-        pub fn record_tick(&mut self, entity_count: usize, actions_processed: usize) {
+        pub fn record_tick(
+            &mut self,
+            tick_result: &pod_core::tick::TickResult,
+            agent_count: usize,
+            tick_over_budget: bool,
+        ) {
             self.ticks_completed += 1;
             self.ticks_this_second += 1;
-            self.total_actions += actions_processed;
-            self.peak_entity_count = self.peak_entity_count.max(entity_count);
+            self.total_actions += tick_result.actions_processed;
+            self.total_actions_rejected += tick_result.actions_rejected;
+            self.peak_entity_count = self.peak_entity_count.max(tick_result.entity_count);
+            self.peak_agent_count = self.peak_agent_count.max(agent_count);
+            if tick_over_budget {
+                self.tick_budget_overruns += 1;
+            }
+
+            for agent in &tick_result.telemetry.agents {
+                self.total_agents_sampled += 1;
+                if let Some(trajectory) = &agent.trajectory {
+                    self.total_trajectory_distance += trajectory.distance_travelled;
+                }
+
+                for trace in &agent.tool_calls {
+                    self.total_tool_calls += 1;
+                    self.total_tool_latency_ms += trace.latency_ms as u64;
+                    if !matches!(
+                        trace.status,
+                        ToolCallStatus::Succeeded | ToolCallStatus::Requested
+                    ) {
+                        self.total_tool_call_errors += 1;
+                    }
+                }
+
+                for trace in &agent.action_trace {
+                    if !matches!(trace.stage, pod_core::ActionLifecycleStage::Executed) {
+                        continue;
+                    }
+
+                    match &trace.action {
+                        Action::CaptureCreature { .. } => self.capture_actions += 1,
+                        Action::SummonCompanion { .. } => self.summon_actions += 1,
+                        Action::GatherResource { .. } => self.gather_actions += 1,
+                        Action::Loot { .. } => self.loot_actions += 1,
+                        _ => {}
+                    }
+                }
+            }
+        }
+
+        pub fn action_rejection_rate(&self) -> f32 {
+            let total = self.total_actions + self.total_actions_rejected;
+            if total == 0 {
+                return 0.0;
+            }
+            self.total_actions_rejected as f32 / total as f32
+        }
+
+        pub fn tool_call_error_rate(&self) -> f32 {
+            if self.total_tool_calls == 0 {
+                return 0.0;
+            }
+            self.total_tool_call_errors as f32 / self.total_tool_calls as f32
+        }
+
+        pub fn average_tool_latency_ms(&self) -> f32 {
+            if self.total_tool_calls == 0 {
+                return 0.0;
+            }
+            self.total_tool_latency_ms as f32 / self.total_tool_calls as f32
+        }
+
+        pub fn average_trajectory_distance(&self) -> f32 {
+            if self.total_agents_sampled == 0 {
+                return 0.0;
+            }
+            self.total_trajectory_distance / self.total_agents_sampled as f32
+        }
+
+        pub fn tick_budget_overrun_rate(&self) -> f32 {
+            if self.ticks_completed == 0 {
+                return 0.0;
+            }
+            self.tick_budget_overruns as f32 / self.ticks_completed as f32
         }
 
         /// Print periodic stats (called once per second)
-        pub fn print_periodic(&self, world: &pod_core::World) {
+        pub fn print_periodic(&mut self, world: &pod_core::World) {
             use log::info;
 
             let elapsed = self.last_second_start.elapsed().as_secs_f32();
@@ -215,15 +316,26 @@ mod stats {
             let efficiency = (tps / target * 100.0).min(100.0);
 
             info!(
-                "[STATS] Tick: {:<10} | TPS: {:.1}/{:.0} ({:.0}%) | Entities: {:<4} | Agents: {:<2} | Actions: {:<5}",
+                "[STATS] Tick: {:<10} | TPS: {:.1}/{:.0} ({:.0}%) | Entities: {:<4} | Agents: {:<2} | Actions: {:<5} | Reject: {:.1}% | ToolErr: {:.1}% | ToolMs: {:.1} | Path: {:.2} | MMO C/S/G/L: {}/{}/{}/{}",
                 world.tick,
                 tps,
                 target,
                 efficiency,
                 world.entity_count(),
                 world.agent_count(),
-                self.total_actions
+                self.total_actions,
+                self.action_rejection_rate() * 100.0,
+                self.tool_call_error_rate() * 100.0,
+                self.average_tool_latency_ms(),
+                self.average_trajectory_distance(),
+                self.capture_actions,
+                self.summon_actions,
+                self.gather_actions,
+                self.loot_actions,
             );
+
+            self.last_second_start = Instant::now();
+            self.ticks_this_second = 0;
         }
 
         /// Print final shutdown stats
@@ -235,10 +347,131 @@ mod stats {
             info!("═══════════════════════════════════════════════════════════");
             info!("Total ticks:          {}", self.ticks_completed);
             info!("Total actions:        {}", self.total_actions);
+            info!("Rejected actions:     {}", self.total_actions_rejected);
             info!("Peak entity count:    {}", self.peak_entity_count);
             info!("Peak agent count:     {}", self.peak_agent_count);
             info!("Target tick rate:     {} Hz", self.target_tick_rate);
+            info!(
+                "Tick overruns:        {} ({:.1}%)",
+                self.tick_budget_overruns,
+                self.tick_budget_overrun_rate() * 100.0
+            );
+            info!(
+                "Tool calls/errors:    {}/{} ({:.1}%)",
+                self.total_tool_calls,
+                self.total_tool_call_errors,
+                self.tool_call_error_rate() * 100.0
+            );
+            info!(
+                "Avg tool latency:     {:.1} ms",
+                self.average_tool_latency_ms()
+            );
+            info!(
+                "Avg path distance:    {:.2}",
+                self.average_trajectory_distance()
+            );
+            info!(
+                "MMO loop C/S/G/L:     {}/{}/{}/{}",
+                self.capture_actions, self.summon_actions, self.gather_actions, self.loot_actions
+            );
             info!("═══════════════════════════════════════════════════════════");
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::ServerStats;
+        use glam::Vec2;
+        use pod_core::action::Action;
+        use pod_core::agent::AgentType;
+        use pod_core::contract::AgentRuntimeProfile;
+        use pod_core::id::AgentId;
+        use pod_core::telemetry::{
+            ActionLifecycleStage, ActionSource, AgentTelemetryFrame, AgentToolCallTrace,
+            TickTelemetryFrame, ToolCallStatus, TrajectorySample,
+        };
+
+        fn sample_tick() -> pod_core::tick::TickResult {
+            let agent_id = AgentId::new();
+            let mut agent = AgentTelemetryFrame::new(
+                7,
+                agent_id,
+                None,
+                AgentRuntimeProfile::for_agent_type(AgentType::LlmAgent),
+                3,
+                1,
+                2,
+                4,
+                1,
+                Some(TrajectorySample::new(7, 0.0, Vec2::ZERO, Vec2::ZERO, 0.0)),
+            );
+            agent.update_trajectory_end(TrajectorySample::new(
+                7,
+                1.0 / 60.0,
+                Vec2::new(3.0, 4.0),
+                Vec2::ZERO,
+                0.0,
+            ));
+            agent.record_action(
+                ActionSource::AgentDecision,
+                ActionLifecycleStage::Executed,
+                Action::CaptureCreature {
+                    target: pod_core::EntityId(9),
+                    tool_slot: Some(0),
+                },
+                None,
+            );
+            agent.record_action(
+                ActionSource::AgentDecision,
+                ActionLifecycleStage::Executed,
+                Action::GatherResource {
+                    target: pod_core::EntityId(10),
+                    skill: pod_core::component::SkillKind::Mining,
+                },
+                None,
+            );
+            agent.record_tool_call(AgentToolCallTrace::new(
+                7,
+                "llm.complete",
+                "mock",
+                ToolCallStatus::ParseError,
+                42,
+                120,
+                0,
+                Some("bad json".into()),
+            ));
+
+            pod_core::tick::TickResult {
+                tick: 7,
+                events: vec![],
+                entity_count: 12,
+                actions_processed: 3,
+                actions_rejected: 1,
+                telemetry: TickTelemetryFrame {
+                    tick: 7,
+                    agents: vec![agent],
+                },
+            }
+        }
+
+        #[test]
+        fn record_tick_accumulates_mmo_and_tool_metrics() {
+            let mut stats = ServerStats::new(60);
+            let tick = sample_tick();
+            stats.record_tick(&tick, 5, true);
+
+            assert_eq!(stats.total_actions, 3);
+            assert_eq!(stats.total_actions_rejected, 1);
+            assert_eq!(stats.peak_entity_count, 12);
+            assert_eq!(stats.peak_agent_count, 5);
+            assert_eq!(stats.tick_budget_overruns, 1);
+            assert_eq!(stats.total_tool_calls, 1);
+            assert_eq!(stats.total_tool_call_errors, 1);
+            assert_eq!(stats.capture_actions, 1);
+            assert_eq!(stats.gather_actions, 1);
+            assert!((stats.average_trajectory_distance() - 5.0).abs() < f32::EPSILON);
+            assert!(stats.action_rejection_rate() > 0.0);
+            assert!(stats.tool_call_error_rate() > 0.0);
         }
     }
 }
@@ -358,7 +591,9 @@ async fn run_game_loop(
         broadcast_local_tick_update(&tick_result);
 
         // ====== PHASE 4: RECORD STATS ======
-        stats.record_tick(tick_result.entity_count, tick_result.actions_processed);
+        let tick_elapsed = tick_start.elapsed();
+        let tick_over_budget = tick_elapsed > tick_duration;
+        stats.record_tick(&tick_result, world.agent_count(), tick_over_budget);
 
         // ====== PHASE 5: PERIODIC LOGGING ======
         if last_stats_print.elapsed() >= Duration::from_secs(1) {
@@ -367,15 +602,14 @@ async fn run_game_loop(
         }
 
         // ====== PHASE 6: SLEEP TO MAINTAIN TICK RATE ======
-        let elapsed = tick_start.elapsed();
-        if elapsed < tick_duration {
-            tokio::time::sleep(tick_duration - elapsed).await;
+        if tick_elapsed < tick_duration {
+            tokio::time::sleep(tick_duration - tick_elapsed).await;
         } else {
             warn!(
                 "Tick {} took {:.2}ms (over budget by {:.2}ms)",
                 world.tick,
-                elapsed.as_secs_f32() * 1000.0,
-                (elapsed - tick_duration).as_secs_f32() * 1000.0
+                tick_elapsed.as_secs_f32() * 1000.0,
+                (tick_elapsed - tick_duration).as_secs_f32() * 1000.0
             );
         }
     }
@@ -418,7 +652,9 @@ async fn run_network_server(
     Ok(())
 }
 
-fn parse_bind_target(bind: &str) -> Result<(String, u16), Box<dyn std::error::Error + Send + Sync>> {
+fn parse_bind_target(
+    bind: &str,
+) -> Result<(String, u16), Box<dyn std::error::Error + Send + Sync>> {
     let mut parts = bind.split(':');
     let host = parts.next().unwrap_or("0.0.0.0").to_string();
     let port = parts

--- a/crates/pod-agents/src/decision_log.rs
+++ b/crates/pod-agents/src/decision_log.rs
@@ -598,11 +598,16 @@ impl DecisionLogger {
                 prompt_sent,
                 raw_response,
                 actions_taken: entry.actions_produced.clone(),
+                tool_calls: entry.tool_calls.clone(),
                 latency_ms,
             });
         }
 
-        ReplayFile { header, traces }
+        ReplayFile {
+            header,
+            traces,
+            telemetry_windows: vec![],
+        }
     }
 
     // ── Utility ───────────────────────────────────────────────────────────────
@@ -843,6 +848,7 @@ mod tests {
         assert_eq!(replay.header.world_seed, 99);
         assert_eq!(replay.header.tick_count, 2); // ticks 0 and 1 → count = max+1 = 2
         assert_eq!(replay.header.agent_count, 2);
+        assert!(replay.telemetry_windows.is_empty());
 
         // Tick 0 should have two traces
         assert_eq!(replay.traces[0].len(), 2);
@@ -980,5 +986,32 @@ mod tests {
         assert_eq!(stored[0].tool_calls.len(), 1);
         assert_eq!(stored[0].tool_calls[0].tool_name, "pathfind");
         assert_eq!(stored[0].tool_calls[0].provider, "openai");
+    }
+
+    #[test]
+    fn replay_conversion_preserves_tool_calls() {
+        let mut logger = DecisionLogger::new();
+        let agent_id = AgentId::new();
+        let mut entry = make_llm_entry(2, agent_id);
+        entry.tool_calls.push(AgentToolCallTrace::new(
+            2,
+            "llm.complete",
+            "mock",
+            pod_core::ToolCallStatus::ParseError,
+            18,
+            120,
+            0,
+            Some("bad json".into()),
+        ));
+
+        logger.log(entry);
+
+        let replay = logger.to_replay_file("tool-calls", 5);
+        assert_eq!(replay.traces[2].len(), 1);
+        assert_eq!(replay.traces[2][0].tool_calls.len(), 1);
+        assert_eq!(
+            replay.traces[2][0].tool_calls[0].status,
+            pod_core::ToolCallStatus::ParseError
+        );
     }
 }

--- a/crates/pod-agents/src/hybrid_agent.rs
+++ b/crates/pod-agents/src/hybrid_agent.rs
@@ -51,8 +51,11 @@
 
 use glam::Vec2;
 use log::{debug, info, warn};
+use pod_core::{AgentToolCallTrace, ToolCallStatus};
 use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
 use std::sync::{mpsc, Arc};
+use std::time::Instant;
 
 use pod_core::action::{Action, AgentConstraints};
 use pod_core::agent::{Agent, AgentIntrospection, AgentType};
@@ -60,7 +63,10 @@ use pod_core::id::AgentId;
 use pod_core::observation::{Observation, Relationship};
 
 use crate::conversation_memory::{ConversationMemory, MemoryConfig};
-use crate::llm_provider::{CompletionRequest, LlmProvider, MockProvider, TokenBudget};
+use crate::llm_provider::{
+    failed_tool_call_trace, success_tool_call_trace, CompletionRequest, LlmProvider, MockProvider,
+    TokenBudget, LLM_COMPLETE_TOOL_NAME,
+};
 use crate::scripted_agent::{
     attack_nearest as _attack_nearest, chase_nearest_hostile as _chase_nearest_hostile,
     flee_from as _flee_from, guard as _guard, patrol as _patrol, wander as _wander, BehaviorNode,
@@ -281,6 +287,7 @@ Respond ONLY with the JSON object, no other text."#
 struct StrategyResult {
     directive: StrategyDirective,
     tick: u64,
+    tool_calls: Vec<AgentToolCallTrace>,
 }
 
 // ============================================================
@@ -316,6 +323,7 @@ pub struct HybridAgent {
 
     // --- Current observation cache ---
     last_observation: Option<Observation>,
+    recent_tool_calls: VecDeque<AgentToolCallTrace>,
 }
 
 impl HybridAgent {
@@ -341,6 +349,7 @@ impl HybridAgent {
             last_hostile_count: 0,
             last_health_fraction: 1.0,
             last_observation: None,
+            recent_tool_calls: VecDeque::new(),
         }
     }
 
@@ -370,6 +379,10 @@ impl HybridAgent {
     /// Access the behavior tree blackboard (read-only).
     pub fn blackboard(&self) -> &Blackboard {
         &self.tree.blackboard
+    }
+
+    pub fn recent_tool_calls(&self) -> &VecDeque<AgentToolCallTrace> {
+        &self.recent_tool_calls
     }
 
     // ----------------------------------------------------------------
@@ -458,6 +471,18 @@ impl HybridAgent {
                 "HybridAgent {}: token budget exceeded, skipping strategy re-plan",
                 self.id
             );
+            self.recent_tool_calls.push_back(AgentToolCallTrace::new(
+                obs.tick,
+                LLM_COMPLETE_TOOL_NAME,
+                self.provider.name(),
+                ToolCallStatus::BudgetExceeded,
+                0,
+                estimated,
+                0,
+                Some(format!(
+                    "Token budget exceeded before provider call (estimated {estimated} units)"
+                )),
+            ));
             return;
         }
 
@@ -477,27 +502,45 @@ impl HybridAgent {
         self.strategy_in_flight = true;
         self.ticks_since_strategy = 0;
 
-        std::thread::spawn(move || match provider.complete(&request) {
-            Ok(completion) => {
-                let directive = StrategyDirective::parse(&completion.content);
-                debug!(
-                    "HybridAgent {}: new strategy = {:?}",
-                    agent_id, directive.strategy
-                );
-                let _ = tx.send(StrategyResult { directive, tick });
-            }
-            Err(e) => {
-                warn!(
-                    "HybridAgent {}: LLM error: {}, keeping current strategy",
-                    agent_id, e
-                );
-                let _ = tx.send(StrategyResult {
-                    directive: StrategyDirective {
-                        reasoning: format!("LLM error: {}", e),
-                        ..Default::default()
-                    },
-                    tick,
-                });
+        std::thread::spawn(move || {
+            let started_at = Instant::now();
+            match provider.complete(&request) {
+                Ok(completion) => {
+                    let directive = StrategyDirective::parse(&completion.content);
+                    debug!(
+                        "HybridAgent {}: new strategy = {:?}",
+                        agent_id, directive.strategy
+                    );
+                    let _ = tx.send(StrategyResult {
+                        directive,
+                        tick,
+                        tool_calls: vec![success_tool_call_trace(
+                            tick,
+                            provider.name(),
+                            started_at.elapsed(),
+                            &completion.usage,
+                        )],
+                    });
+                }
+                Err(e) => {
+                    warn!(
+                        "HybridAgent {}: LLM error: {}, keeping current strategy",
+                        agent_id, e
+                    );
+                    let _ = tx.send(StrategyResult {
+                        directive: StrategyDirective {
+                            reasoning: format!("LLM error: {}", e),
+                            ..Default::default()
+                        },
+                        tick,
+                        tool_calls: vec![failed_tool_call_trace(
+                            tick,
+                            provider.name(),
+                            started_at.elapsed(),
+                            &e,
+                        )],
+                    });
+                }
             }
         });
     }
@@ -573,6 +616,7 @@ impl Agent for HybridAgent {
         if self.strategy_in_flight {
             if let Ok(result) = self.strategy_rx.try_recv() {
                 self.strategy_in_flight = false;
+                self.recent_tool_calls.extend(result.tool_calls);
                 if self.config.debug_logging {
                     info!(
                         "HybridAgent {} [tick {}]: strategy = {} (urgency={:.2}): {}",
@@ -639,6 +683,10 @@ impl Agent for HybridAgent {
     }
     fn constraints_mut(&mut self) -> &mut AgentConstraints {
         &mut self.constraints
+    }
+
+    fn drain_tool_calls(&mut self) -> Vec<AgentToolCallTrace> {
+        self.recent_tool_calls.drain(..).collect()
     }
 
     fn introspect(&self) -> AgentIntrospection {
@@ -878,6 +926,7 @@ mod tests {
     use super::*;
     use glam::Vec2;
     use pod_core::observation::{Observation, SelfState, VisibleEntity};
+    use std::time::Duration;
 
     fn make_obs_with_hostile(health_pct: f32, hostile_distance: Option<f32>) -> Observation {
         let mut obs = Observation::default();
@@ -1085,5 +1134,38 @@ mod tests {
         let s = format_observation_for_strategy(&obs);
         assert!(s.contains("hp="));
         assert!(s.contains("enemies=1"));
+    }
+
+    #[test]
+    fn successful_strategy_requests_emit_tool_call_traces() {
+        let mut agent = HybridAgent::new(HybridAgentConfig {
+            strategy_interval_ticks: 0,
+            ..Default::default()
+        });
+        agent.observe(make_obs_with_hostile(1.0, Some(80.0)));
+        std::thread::sleep(Duration::from_millis(50));
+        agent.observe(make_obs_with_hostile(1.0, Some(80.0)));
+
+        let tool_calls = agent.drain_tool_calls();
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].tool_name, LLM_COMPLETE_TOOL_NAME);
+        assert_eq!(tool_calls[0].status, ToolCallStatus::Succeeded);
+    }
+
+    #[test]
+    fn budget_exceeded_strategy_request_emits_tool_trace_immediately() {
+        let mut agent =
+            HybridAgent::new(HybridAgentConfig::default()).with_budget(TokenBudget::new(1, 1));
+        agent.budget.record_usage(&crate::llm_provider::TokenUsage {
+            prompt_tokens: 1,
+            completion_tokens: 0,
+            total_tokens: 1,
+        });
+
+        agent.spawn_strategy_request(&make_obs_with_hostile(1.0, Some(40.0)));
+
+        let tool_calls = agent.drain_tool_calls();
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].status, ToolCallStatus::BudgetExceeded);
     }
 }

--- a/crates/pod-agents/src/llm_agent.rs
+++ b/crates/pod-agents/src/llm_agent.rs
@@ -15,6 +15,7 @@ use pod_core::action::{Action, AgentConstraints};
 use pod_core::agent::{Agent, AgentType};
 use pod_core::id::AgentId;
 use pod_core::observation::Observation;
+use pod_core::{AgentToolCallTrace, ToolCallStatus};
 use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
 use std::sync::{mpsc, Arc};
@@ -22,7 +23,10 @@ use std::time::{Duration, Instant};
 
 use crate::action_parser::{ActionParser, FallbackParser};
 use crate::conversation_memory::{ConversationMemory, MemoryConfig};
-use crate::llm_provider::{CompletionRequest, LlmProvider, MockProvider, TokenBudget, TokenUsage};
+use crate::llm_provider::{
+    failed_tool_call_trace, parse_failed_tool_call_trace, success_tool_call_trace,
+    CompletionRequest, LlmProvider, MockProvider, TokenBudget, TokenUsage, LLM_COMPLETE_TOOL_NAME,
+};
 #[cfg(test)]
 use crate::prompt_template::CompactTemplate;
 use crate::prompt_template::{PromptTemplate, ToonTemplate};
@@ -72,6 +76,7 @@ pub struct DecisionTrace {
     pub llm_response: String,
     pub parsed_actions: Vec<Action>,
     pub reasoning: String,
+    pub tool_calls: Vec<AgentToolCallTrace>,
 }
 
 // ============================================================
@@ -87,6 +92,7 @@ struct LlmResult {
     raw_response: String,
     usage: Option<TokenUsage>,
     trace: Option<DecisionTrace>,
+    tool_calls: Vec<AgentToolCallTrace>,
 }
 
 /// Pending decision waiting for reaction delay to elapse.
@@ -140,6 +146,7 @@ pub struct LlmAgent {
     // --- Decision double buffer ---
     decision_buffer: DecisionBuffer,
     decision_traces: VecDeque<DecisionTrace>,
+    recent_tool_calls: VecDeque<AgentToolCallTrace>,
 
     // --- Stale action replay ---
     last_action: Option<Action>,
@@ -173,6 +180,7 @@ impl LlmAgent {
                 pending: None,
             },
             decision_traces: VecDeque::new(),
+            recent_tool_calls: VecDeque::new(),
             last_action: None,
             stale_action_decay: 1.0,
             ticks_since_last_decision: 0,
@@ -227,6 +235,7 @@ impl LlmAgent {
                 pending: None,
             },
             decision_traces: VecDeque::new(),
+            recent_tool_calls: VecDeque::new(),
             last_action: None,
             stale_action_decay: 1.0,
             ticks_since_last_decision: 0,
@@ -241,6 +250,10 @@ impl LlmAgent {
     /// Clear decision traces (to free memory).
     pub fn clear_traces(&mut self) {
         self.decision_traces.clear();
+    }
+
+    pub fn recent_tool_calls(&self) -> &VecDeque<AgentToolCallTrace> {
+        &self.recent_tool_calls
     }
 
     /// Access the conversation memory.
@@ -301,6 +314,18 @@ impl LlmAgent {
                 "LLM agent {} skipping request: token budget exceeded ({} estimated, budget full)",
                 self.id, estimated_tokens
             );
+            self.recent_tool_calls.push_back(AgentToolCallTrace::new(
+                observation.tick,
+                LLM_COMPLETE_TOOL_NAME,
+                self.provider.name(),
+                ToolCallStatus::BudgetExceeded,
+                0,
+                estimated_tokens,
+                0,
+                Some(format!(
+                    "Token budget exceeded before provider call (estimated {estimated_tokens} units)"
+                )),
+            ));
             return;
         }
 
@@ -323,28 +348,48 @@ impl LlmAgent {
         self.request_in_flight = true;
 
         std::thread::spawn(move || {
+            let started_at = Instant::now();
             match provider.complete(&request) {
                 Ok(completion) => {
+                    let elapsed = started_at.elapsed();
                     // Parse the LLM response into actions
-                    let (actions, reasoning, raw) = match parser.parse(&completion.content) {
-                        Ok(result) => {
-                            for w in &result.warnings {
-                                warn!("LLM agent {} parse warning: {}", agent_id, w);
+                    let (actions, reasoning, raw, tool_calls) =
+                        match parser.parse(&completion.content) {
+                            Ok(result) => {
+                                for w in &result.warnings {
+                                    warn!("LLM agent {} parse warning: {}", agent_id, w);
+                                }
+                                (
+                                    result.actions,
+                                    result.reasoning,
+                                    result.raw_response,
+                                    vec![success_tool_call_trace(
+                                        tick,
+                                        provider.name(),
+                                        elapsed,
+                                        &completion.usage,
+                                    )],
+                                )
                             }
-                            (result.actions, result.reasoning, result.raw_response)
-                        }
-                        Err(e) => {
-                            warn!(
-                                "LLM agent {} parse failed ({}), falling back to Idle",
-                                agent_id, e
-                            );
-                            (
-                                vec![Action::Idle],
-                                "Parse error fallback".to_string(),
-                                completion.content.clone(),
-                            )
-                        }
-                    };
+                            Err(e) => {
+                                warn!(
+                                    "LLM agent {} parse failed ({}), falling back to Idle",
+                                    agent_id, e
+                                );
+                                (
+                                    vec![Action::Idle],
+                                    "Parse error fallback".to_string(),
+                                    completion.content.clone(),
+                                    vec![parse_failed_tool_call_trace(
+                                        tick,
+                                        provider.name(),
+                                        elapsed,
+                                        &completion.usage,
+                                        e.to_string(),
+                                    )],
+                                )
+                            }
+                        };
 
                     let trace = if enable_trace {
                         Some(DecisionTrace {
@@ -357,6 +402,7 @@ impl LlmAgent {
                             llm_response: raw.clone(),
                             parsed_actions: actions.clone(),
                             reasoning: reasoning.clone(),
+                            tool_calls: tool_calls.clone(),
                         })
                     } else {
                         None
@@ -368,6 +414,7 @@ impl LlmAgent {
                         raw_response: raw,
                         usage: Some(completion.usage),
                         trace,
+                        tool_calls,
                     };
 
                     debug!(
@@ -378,6 +425,7 @@ impl LlmAgent {
                     let _ = tx.send(result);
                 }
                 Err(e) => {
+                    let elapsed = started_at.elapsed();
                     error!("LLM request failed for agent {}: {}", agent_id, e);
                     // Send an Idle fallback so the agent doesn't hang
                     let _ = tx.send(LlmResult {
@@ -386,6 +434,12 @@ impl LlmAgent {
                         raw_response: String::new(),
                         usage: None,
                         trace: None,
+                        tool_calls: vec![failed_tool_call_trace(
+                            tick,
+                            provider.name(),
+                            elapsed,
+                            &e,
+                        )],
                     });
                 }
             }
@@ -437,6 +491,7 @@ impl LlmAgent {
             self.decision_buffer.ready_actions = Some(result.actions);
             self.decision_buffer.ready_reasoning = result.reasoning;
             self.decision_buffer.trace = result.trace;
+            self.recent_tool_calls.extend(result.tool_calls);
         }
     }
 }
@@ -485,7 +540,7 @@ impl Agent for LlmAgent {
 
         // Check if reaction delay is complete
         if let Some(ready_actions) = self.check_reaction_delay() {
-            self.decision_buffer.pending = None;
+            let pending = self.decision_buffer.pending.take();
 
             if !ready_actions.is_empty() {
                 // Record last action for decay
@@ -493,7 +548,7 @@ impl Agent for LlmAgent {
 
                 // Record to conversation memory
                 let reasoning = self.decision_buffer.ready_reasoning.clone();
-                if let Some(pending) = &self.decision_buffer.pending {
+                if let Some(pending) = &pending {
                     self.memory
                         .record(&pending.observation, &ready_actions, &reasoning);
                 }
@@ -531,6 +586,10 @@ impl Agent for LlmAgent {
 
     fn constraints_mut(&mut self) -> &mut AgentConstraints {
         &mut self.constraints
+    }
+
+    fn drain_tool_calls(&mut self) -> Vec<AgentToolCallTrace> {
+        self.recent_tool_calls.drain(..).collect()
     }
 }
 
@@ -691,6 +750,8 @@ reasoning[1]{
             .back()
             .expect("a decision trace should be recorded");
         assert_eq!(trace.reasoning, "Default smoke test");
+        assert_eq!(trace.tool_calls.len(), 1);
+        assert_eq!(trace.tool_calls[0].tool_name, LLM_COMPLETE_TOOL_NAME);
     }
 
     #[test]
@@ -818,9 +879,81 @@ reasoning[1]{
             llm_response: String::new(),
             parsed_actions: vec![],
             reasoning: String::new(),
+            tool_calls: vec![],
         });
         assert_eq!(agent.decision_traces().len(), 1);
         agent.clear_traces();
         assert!(agent.decision_traces().is_empty());
+    }
+
+    #[test]
+    fn successful_llm_requests_emit_tool_call_traces() {
+        let mut agent = LlmAgent::new(LlmAgentConfig {
+            reaction_time_ms: 0,
+            ..Default::default()
+        });
+        let obs = make_obs(5, true);
+        agent.observe(obs);
+        std::thread::sleep(Duration::from_millis(50));
+        let _ = agent.decide();
+
+        let tool_calls = agent.drain_tool_calls();
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].tool_name, LLM_COMPLETE_TOOL_NAME);
+        assert_eq!(tool_calls[0].status, ToolCallStatus::Succeeded);
+        assert!(tool_calls[0].request_units > 0);
+    }
+
+    #[test]
+    fn parse_failures_emit_parse_error_tool_trace() {
+        let provider = Arc::new(MockProvider::new("not valid action syntax".into()));
+        let mut agent = LlmAgent::with_components(
+            LlmAgentConfig {
+                reaction_time_ms: 0,
+                ..Default::default()
+            },
+            provider,
+            Arc::new(CompactTemplate::default()),
+            Arc::new(crate::action_parser::JsonActionParser),
+            MemoryConfig::default(),
+            TokenBudget::unlimited(),
+        );
+
+        agent.observe(make_obs(6, false));
+        std::thread::sleep(Duration::from_millis(50));
+        let _ = agent.decide();
+
+        let tool_calls = agent.drain_tool_calls();
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].status, ToolCallStatus::ParseError);
+        assert!(tool_calls[0]
+            .error_message
+            .as_deref()
+            .expect("parse error")
+            .contains("Invalid format"));
+    }
+
+    #[test]
+    fn budget_rejections_emit_budget_exceeded_tool_trace_without_request() {
+        let mut agent = LlmAgent::with_components(
+            LlmAgentConfig::default(),
+            Arc::new(MockProvider::idle()),
+            Arc::new(CompactTemplate::default()),
+            Arc::new(FallbackParser::default_chain()),
+            MemoryConfig::default(),
+            TokenBudget::new(1, 1),
+        );
+
+        agent.budget.record_usage(&TokenUsage {
+            prompt_tokens: 1,
+            completion_tokens: 0,
+            total_tokens: 1,
+        });
+        agent.spawn_llm_request(&make_obs(7, false));
+
+        assert!(!agent.request_in_flight);
+        let tool_calls = agent.drain_tool_calls();
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].status, ToolCallStatus::BudgetExceeded);
     }
 }

--- a/crates/pod-agents/src/llm_provider.rs
+++ b/crates/pod-agents/src/llm_provider.rs
@@ -4,8 +4,12 @@
 //! All providers implement the blocking `LlmProvider` trait, called from
 //! the LlmAgent's decision thread.
 
+use pod_core::{AgentToolCallTrace, ToolCallStatus};
 use serde::{Deserialize, Serialize};
 use std::fmt;
+use std::time::Duration;
+
+pub const LLM_COMPLETE_TOOL_NAME: &str = "llm.complete";
 
 // ============================================================
 // ERROR TYPES
@@ -44,6 +48,74 @@ impl fmt::Display for LlmError {
 }
 
 impl std::error::Error for LlmError {}
+
+pub fn tool_call_status_for_error(error: &LlmError) -> ToolCallStatus {
+    match error {
+        LlmError::Timeout => ToolCallStatus::TimedOut,
+        LlmError::RateLimited { .. } => ToolCallStatus::RateLimited,
+        LlmError::Parse(_) => ToolCallStatus::ParseError,
+        LlmError::Api { .. } => ToolCallStatus::ApiError,
+        LlmError::BudgetExceeded { .. } => ToolCallStatus::BudgetExceeded,
+        LlmError::Network(_) => ToolCallStatus::Failed,
+    }
+}
+
+fn latency_ms(duration: Duration) -> u32 {
+    duration.as_millis().min(u128::from(u32::MAX)) as u32
+}
+
+pub fn success_tool_call_trace(
+    tick: u64,
+    provider_name: &str,
+    elapsed: Duration,
+    usage: &TokenUsage,
+) -> AgentToolCallTrace {
+    AgentToolCallTrace::success(
+        tick,
+        LLM_COMPLETE_TOOL_NAME,
+        provider_name,
+        latency_ms(elapsed),
+        usage.prompt_tokens,
+        usage.completion_tokens,
+    )
+}
+
+pub fn failed_tool_call_trace(
+    tick: u64,
+    provider_name: &str,
+    elapsed: Duration,
+    error: &LlmError,
+) -> AgentToolCallTrace {
+    AgentToolCallTrace::new(
+        tick,
+        LLM_COMPLETE_TOOL_NAME,
+        provider_name,
+        tool_call_status_for_error(error),
+        latency_ms(elapsed),
+        0,
+        0,
+        Some(error.to_string()),
+    )
+}
+
+pub fn parse_failed_tool_call_trace(
+    tick: u64,
+    provider_name: &str,
+    elapsed: Duration,
+    usage: &TokenUsage,
+    error_message: impl Into<String>,
+) -> AgentToolCallTrace {
+    AgentToolCallTrace::new(
+        tick,
+        LLM_COMPLETE_TOOL_NAME,
+        provider_name,
+        ToolCallStatus::ParseError,
+        latency_ms(elapsed),
+        usage.prompt_tokens,
+        usage.completion_tokens,
+        Some(error_message.into()),
+    )
+}
 
 // ============================================================
 // REQUEST / RESPONSE TYPES
@@ -231,7 +303,9 @@ impl OpenAiProvider {
             });
         }
 
-        let resp: AnthropicResponse = response.json().map_err(|e| LlmError::Parse(e.to_string()))?;
+        let resp: AnthropicResponse = response
+            .json()
+            .map_err(|e| LlmError::Parse(e.to_string()))?;
 
         let content = resp
             .content
@@ -320,7 +394,9 @@ impl LlmProvider for OpenAiProvider {
             });
         }
 
-        let resp: ChatResponse = response.json().map_err(|e| LlmError::Parse(e.to_string()))?;
+        let resp: ChatResponse = response
+            .json()
+            .map_err(|e| LlmError::Parse(e.to_string()))?;
 
         let content = resp
             .choices
@@ -504,9 +580,8 @@ mod tests {
     #[test]
     fn test_mock_provider_queued() {
         let provider = MockProvider::idle();
-        provider.queue_response(
-            r#"{"actions": ["Attack"], "reasoning": "Enemy nearby"}"#.to_string(),
-        );
+        provider
+            .queue_response(r#"{"actions": ["Attack"], "reasoning": "Enemy nearby"}"#.to_string());
 
         let request = CompletionRequest {
             model: "test".to_string(),
@@ -559,5 +634,37 @@ mod tests {
             retry_after_ms: 5000,
         };
         assert!(format!("{}", err).contains("5000"));
+    }
+
+    #[test]
+    fn tool_call_status_mapping_is_specific() {
+        assert_eq!(
+            tool_call_status_for_error(&LlmError::Timeout),
+            ToolCallStatus::TimedOut
+        );
+        assert_eq!(
+            tool_call_status_for_error(&LlmError::RateLimited {
+                retry_after_ms: 100
+            }),
+            ToolCallStatus::RateLimited
+        );
+        assert_eq!(
+            tool_call_status_for_error(&LlmError::Parse("bad".into())),
+            ToolCallStatus::ParseError
+        );
+        assert_eq!(
+            tool_call_status_for_error(&LlmError::Api {
+                status: 500,
+                message: "boom".into(),
+            }),
+            ToolCallStatus::ApiError
+        );
+        assert_eq!(
+            tool_call_status_for_error(&LlmError::BudgetExceeded {
+                requested: 4,
+                remaining: 1,
+            }),
+            ToolCallStatus::BudgetExceeded
+        );
     }
 }

--- a/crates/pod-core/src/agent.rs
+++ b/crates/pod-core/src/agent.rs
@@ -2,6 +2,7 @@ use crate::action::{Action, AgentConstraints};
 use crate::contract::AgentRuntimeProfile;
 use crate::id::{AgentId, EntityId};
 use crate::observation::Observation;
+use crate::telemetry::AgentToolCallTrace;
 use serde::{Deserialize, Serialize};
 
 /// The type of agent — used for logging/analytics only.
@@ -56,6 +57,12 @@ pub trait Agent: Send {
 
     /// Mutable access to constraints (for status effects, etc.)
     fn constraints_mut(&mut self) -> &mut AgentConstraints;
+
+    /// Drain any non-gameplay tool/runtime side effects produced while deciding.
+    /// Defaults to empty so non-tool-using agents do not need to implement it.
+    fn drain_tool_calls(&mut self) -> Vec<AgentToolCallTrace> {
+        Vec::new()
+    }
 
     /// Called when the agent joins the game
     fn on_join(&mut self) {}

--- a/crates/pod-core/src/app.rs
+++ b/crates/pod-core/src/app.rs
@@ -7,7 +7,10 @@ use crate::component::{
     Health, Inventory, Label, LootContainer, Movement, Perception, ResourceNode, Script, SkillBook,
     Sprite, Transform, Transform3D, Velocity,
 };
-use crate::contract::{VersionedAgentAction, VersionedObservation, VersionedTickTelemetry};
+use crate::contract::{
+    ToolBudget, ToolCatalog, ToolDefinition, ToolInvocationRequest, ToolInvocationResult,
+    ToolPolicy, VersionedAgentAction, VersionedObservation, VersionedTickTelemetry,
+};
 use crate::observation::Observation;
 use crate::telemetry::{TelemetryArchive, TelemetryConfig, TickTelemetryFrame};
 use crate::tick::TickResult;
@@ -309,6 +312,15 @@ impl App {
             .register_component::<LootContainer>("LootContainer");
         self.types.register_contract::<Observation>("Observation");
         self.types.register_contract::<AgentAction>("AgentAction");
+        self.types
+            .register_contract::<ToolDefinition>("ToolDefinition");
+        self.types.register_contract::<ToolCatalog>("ToolCatalog");
+        self.types.register_contract::<ToolPolicy>("ToolPolicy");
+        self.types.register_contract::<ToolBudget>("ToolBudget");
+        self.types
+            .register_contract::<ToolInvocationRequest>("ToolInvocationRequest");
+        self.types
+            .register_contract::<ToolInvocationResult>("ToolInvocationResult");
         self.types
             .register_contract::<TickTelemetryFrame>("TickTelemetryFrame");
         self.types

--- a/crates/pod-core/src/contract.rs
+++ b/crates/pod-core/src/contract.rs
@@ -2,8 +2,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::action::AgentAction;
 use crate::agent::AgentType;
+use crate::id::AgentId;
 use crate::observation::Observation;
-use crate::telemetry::TickTelemetryFrame;
+use crate::telemetry::{TickTelemetryFrame, ToolCallStatus};
 
 pub const RUNTIME_CONTRACT_VERSION_V1: u16 = 1;
 
@@ -127,6 +128,128 @@ impl AgentRuntimeProfile {
     }
 }
 
+/// Versioned description of an embedded tool that an agent may call.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolDefinition {
+    pub name: String,
+    pub description: String,
+    pub read_only: bool,
+    pub budget: ToolBudget,
+}
+
+/// Fixed limits applied to tool invocations independent of gameplay actions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolBudget {
+    pub max_calls_per_tick: u32,
+    pub max_calls_per_minute: u32,
+    pub max_request_units_per_tick: u32,
+    pub max_response_units_per_tick: u32,
+}
+
+impl ToolBudget {
+    pub fn disabled() -> Self {
+        Self {
+            max_calls_per_tick: 0,
+            max_calls_per_minute: 0,
+            max_request_units_per_tick: 0,
+            max_response_units_per_tick: 0,
+        }
+    }
+
+    pub fn read_only_default() -> Self {
+        Self {
+            max_calls_per_tick: 1,
+            max_calls_per_minute: 30,
+            max_request_units_per_tick: 8_000,
+            max_response_units_per_tick: 4_000,
+        }
+    }
+}
+
+impl Default for ToolBudget {
+    fn default() -> Self {
+        Self::read_only_default()
+    }
+}
+
+/// Runtime policy for agent-side tool access. Tools may gather data, but any
+/// gameplay mutation must still become a normal validated `Action`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolPolicy {
+    pub enabled: bool,
+    pub allow_external_network: bool,
+    pub allow_write_tools: bool,
+    pub budget: ToolBudget,
+}
+
+impl ToolPolicy {
+    pub fn disabled() -> Self {
+        Self {
+            enabled: false,
+            allow_external_network: false,
+            allow_write_tools: false,
+            budget: ToolBudget::disabled(),
+        }
+    }
+
+    pub fn read_only_default() -> Self {
+        Self {
+            enabled: true,
+            allow_external_network: true,
+            allow_write_tools: false,
+            budget: ToolBudget::read_only_default(),
+        }
+    }
+}
+
+impl Default for ToolPolicy {
+    fn default() -> Self {
+        Self::disabled()
+    }
+}
+
+/// Catalog of embedded tools available to a runtime profile.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolCatalog {
+    pub version: RuntimeContractVersion,
+    pub tools: Vec<ToolDefinition>,
+}
+
+impl ToolCatalog {
+    pub fn new(tools: Vec<ToolDefinition>) -> Self {
+        Self {
+            version: RuntimeContractVersion::V1,
+            tools,
+        }
+    }
+}
+
+/// Request emitted by an embedded tool runtime before a side effect occurs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolInvocationRequest {
+    pub tick: u64,
+    pub agent_id: AgentId,
+    pub tool_name: String,
+    pub provider: String,
+    pub request_units: u32,
+    pub arguments_json: String,
+}
+
+/// Result emitted by the embedded tool runtime after completion or failure.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolInvocationResult {
+    pub tick: u64,
+    pub agent_id: AgentId,
+    pub tool_name: String,
+    pub provider: String,
+    pub status: ToolCallStatus,
+    pub latency_ms: u32,
+    pub request_units: u32,
+    pub response_units: u32,
+    pub output_json: Option<String>,
+    pub error_message: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VersionedAgentAction {
     pub version: RuntimeContractVersion,
@@ -182,10 +305,11 @@ mod tests {
     use crate::agent::AgentType;
     use crate::id::AgentId;
     use crate::observation::Observation;
-    use crate::telemetry::TickTelemetryFrame;
+    use crate::telemetry::{TickTelemetryFrame, ToolCallStatus};
 
     use super::{
-        AgentCapabilities, AgentRole, AgentRuntimeProfile, RuntimeContractVersion,
+        AgentCapabilities, AgentRole, AgentRuntimeProfile, RuntimeContractVersion, ToolBudget,
+        ToolCatalog, ToolDefinition, ToolInvocationRequest, ToolInvocationResult, ToolPolicy,
         VersionedAgentAction, VersionedObservation, VersionedTickTelemetry,
         RUNTIME_CONTRACT_VERSION_V1,
     };
@@ -235,5 +359,56 @@ mod tests {
         let telemetry = TickTelemetryFrame::empty(9);
         let versioned_telemetry = VersionedTickTelemetry::new(telemetry.clone());
         assert_eq!(versioned_telemetry.payload.tick, telemetry.tick);
+    }
+
+    #[test]
+    fn tool_contract_defaults_are_read_only_and_disabled_by_default() {
+        let budget = ToolBudget::default();
+        assert_eq!(budget.max_calls_per_tick, 1);
+        assert_eq!(budget.max_calls_per_minute, 30);
+
+        let policy = ToolPolicy::default();
+        assert!(!policy.enabled);
+        assert_eq!(policy.budget, ToolBudget::disabled());
+    }
+
+    #[test]
+    fn tool_contracts_serialize_runtime_invocations_without_losing_status() {
+        let catalog = ToolCatalog::new(vec![ToolDefinition {
+            name: "llm.complete".into(),
+            description: "Request a provider completion".into(),
+            read_only: true,
+            budget: ToolBudget::read_only_default(),
+        }]);
+        assert_eq!(catalog.version, RuntimeContractVersion::V1);
+        assert_eq!(catalog.tools.len(), 1);
+
+        let request = ToolInvocationRequest {
+            tick: 12,
+            agent_id: AgentId::new(),
+            tool_name: "llm.complete".into(),
+            provider: "openai-compatible".into(),
+            request_units: 320,
+            arguments_json: "{\"prompt\":\"hi\"}".into(),
+        };
+        let result = ToolInvocationResult {
+            tick: request.tick,
+            agent_id: request.agent_id,
+            tool_name: request.tool_name.clone(),
+            provider: request.provider.clone(),
+            status: ToolCallStatus::RateLimited,
+            latency_ms: 1500,
+            request_units: request.request_units,
+            response_units: 0,
+            output_json: None,
+            error_message: Some("retry after 1000ms".into()),
+        };
+
+        let encoded = serde_json::to_string(&result).expect("tool result should serialize");
+        let decoded: ToolInvocationResult =
+            serde_json::from_str(&encoded).expect("tool result should deserialize");
+        assert_eq!(decoded.status, ToolCallStatus::RateLimited);
+        assert_eq!(decoded.request_units, 320);
+        assert!(decoded.output_json.is_none());
     }
 }

--- a/crates/pod-core/src/lib.rs
+++ b/crates/pod-core/src/lib.rs
@@ -58,7 +58,8 @@ pub use constraint::{
     ValidationPipeline,
 };
 pub use contract::{
-    AgentCapabilities, AgentRole, AgentRuntimeProfile, RuntimeContractVersion,
+    AgentCapabilities, AgentRole, AgentRuntimeProfile, RuntimeContractVersion, ToolBudget,
+    ToolCatalog, ToolDefinition, ToolInvocationRequest, ToolInvocationResult, ToolPolicy,
     VersionedAgentAction, VersionedObservation, VersionedTickTelemetry,
     RUNTIME_CONTRACT_VERSION_V1,
 };

--- a/crates/pod-core/src/replay.rs
+++ b/crates/pod-core/src/replay.rs
@@ -12,9 +12,10 @@
 //! - Debugging of specific agent behaviors
 //! - Sharing exact replay scenarios across teams
 
+use crate::action::Action;
 use crate::id::AgentId;
 use crate::observation::Observation;
-use crate::action::Action;
+use crate::telemetry::{AgentToolCallTrace, TickTelemetryFrame};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -34,6 +35,9 @@ pub struct DecisionTrace {
     pub raw_response: String,
     /// The actions the AI decided on (parsed from raw_response)
     pub actions_taken: Vec<Action>,
+    /// Tool/provider side effects associated with the decision.
+    #[serde(default)]
+    pub tool_calls: Vec<AgentToolCallTrace>,
     /// How long the API took to respond (ms)
     pub latency_ms: u32,
 }
@@ -45,6 +49,9 @@ pub struct ReplayFile {
     pub header: ReplayHeader,
     /// Traces indexed by [tick][agent_id]
     pub traces: Vec<Vec<DecisionTrace>>,
+    /// Optional authoritative telemetry windows embedded alongside decision traces.
+    #[serde(default)]
+    pub telemetry_windows: Vec<TickTelemetryFrame>,
 }
 
 /// Metadata about a replay recording
@@ -89,6 +96,7 @@ impl ReplayRecorder {
         prompt_sent: String,
         raw_response: String,
         actions_taken: Vec<Action>,
+        tool_calls: Vec<AgentToolCallTrace>,
         latency_ms: u32,
     ) {
         let observation_hash = hash_observation(observation);
@@ -100,6 +108,7 @@ impl ReplayRecorder {
             prompt_sent,
             raw_response,
             actions_taken,
+            tool_calls,
             latency_ms,
         };
 
@@ -117,6 +126,15 @@ impl ReplayRecorder {
 
     /// Finalize into a ReplayFile
     pub fn finalize(self, header: ReplayHeader) -> ReplayFile {
+        self.finalize_with_telemetry(header, Vec::new())
+    }
+
+    /// Finalize into a `ReplayFile` with embedded authoritative telemetry windows.
+    pub fn finalize_with_telemetry(
+        self,
+        header: ReplayHeader,
+        telemetry_windows: Vec<TickTelemetryFrame>,
+    ) -> ReplayFile {
         // Group traces by tick
         let mut traces_by_tick: HashMap<u64, Vec<DecisionTrace>> = HashMap::new();
         for trace in self.traces {
@@ -135,7 +153,11 @@ impl ReplayRecorder {
             }
         }
 
-        ReplayFile { header, traces }
+        ReplayFile {
+            header,
+            traces,
+            telemetry_windows,
+        }
     }
 }
 
@@ -168,10 +190,7 @@ impl ReplayPlayer {
     /// Returns None if this agent has no recorded decision for this tick
     pub fn get_next_decision(&mut self, agent_id: AgentId) -> Option<DecisionTrace> {
         let traces = self.file.traces.get(self.current_tick as usize)?;
-        traces
-            .iter()
-            .find(|t| t.agent_id == agent_id)
-            .cloned()
+        traces.iter().find(|t| t.agent_id == agent_id).cloned()
     }
 
     /// Advance to the next tick
@@ -208,7 +227,11 @@ fn hash_observation(obs: &Observation) -> u64 {
     obs.tick.hash(&mut hasher);
     obs.self_state.position.x.to_bits().hash(&mut hasher);
     obs.self_state.position.y.to_bits().hash(&mut hasher);
-    obs.self_state.health.unwrap_or(0.0).to_bits().hash(&mut hasher);
+    obs.self_state
+        .health
+        .unwrap_or(0.0)
+        .to_bits()
+        .hash(&mut hasher);
     obs.visible_entities.len().hash(&mut hasher);
 
     // Hash entity IDs to catch world state changes
@@ -247,6 +270,7 @@ mod tests {
             "Move forward".to_string(),
             "Action: Move".to_string(),
             vec![Action::Idle],
+            Vec::new(),
             100,
         );
 
@@ -266,17 +290,25 @@ mod tests {
             notes: String::new(),
         };
 
-        let traces = vec![vec![DecisionTrace {
-            tick: 0,
-            agent_id: AgentId::new(),
-            observation_hash: 0,
-            prompt_sent: String::new(),
-            raw_response: String::new(),
-            actions_taken: vec![],
-            latency_ms: 0,
-        }]; 10];
+        let traces = vec![
+            vec![DecisionTrace {
+                tick: 0,
+                agent_id: AgentId::new(),
+                observation_hash: 0,
+                prompt_sent: String::new(),
+                raw_response: String::new(),
+                actions_taken: vec![],
+                tool_calls: vec![],
+                latency_ms: 0,
+            }];
+            10
+        ];
 
-        let file = ReplayFile { header, traces };
+        let file = ReplayFile {
+            header,
+            traces,
+            telemetry_windows: vec![],
+        };
         let mut player = ReplayPlayer::new(file);
 
         assert_eq!(player.current_tick(), 0);
@@ -284,5 +316,21 @@ mod tests {
 
         player.advance_tick();
         assert_eq!(player.current_tick(), 1);
+    }
+
+    #[test]
+    fn replay_recorder_can_embed_telemetry_windows() {
+        let recorder = ReplayRecorder::new();
+        let header = ReplayHeader {
+            name: "telemetry".into(),
+            timestamp: 0,
+            world_seed: 1,
+            tick_count: 1,
+            agent_count: 0,
+            notes: String::new(),
+        };
+        let file = recorder.finalize_with_telemetry(header, vec![TickTelemetryFrame::empty(0)]);
+        assert_eq!(file.telemetry_windows.len(), 1);
+        assert_eq!(file.telemetry_windows[0].tick, 0);
     }
 }

--- a/crates/pod-core/src/telemetry.rs
+++ b/crates/pod-core/src/telemetry.rs
@@ -124,6 +124,10 @@ pub enum ToolCallStatus {
     Succeeded,
     Failed,
     TimedOut,
+    RateLimited,
+    ParseError,
+    ApiError,
+    BudgetExceeded,
     Rejected,
 }
 
@@ -141,6 +145,28 @@ pub struct AgentToolCallTrace {
 }
 
 impl AgentToolCallTrace {
+    pub fn new(
+        tick: u64,
+        tool_name: impl Into<String>,
+        provider: impl Into<String>,
+        status: ToolCallStatus,
+        latency_ms: u32,
+        request_units: u32,
+        response_units: u32,
+        error_message: Option<String>,
+    ) -> Self {
+        Self {
+            tick,
+            tool_name: tool_name.into(),
+            provider: provider.into(),
+            status,
+            latency_ms,
+            request_units,
+            response_units,
+            error_message,
+        }
+    }
+
     pub fn success(
         tick: u64,
         tool_name: impl Into<String>,
@@ -149,16 +175,16 @@ impl AgentToolCallTrace {
         request_units: u32,
         response_units: u32,
     ) -> Self {
-        Self {
+        Self::new(
             tick,
-            tool_name: tool_name.into(),
-            provider: provider.into(),
-            status: ToolCallStatus::Succeeded,
+            tool_name,
+            provider,
+            ToolCallStatus::Succeeded,
             latency_ms,
             request_units,
             response_units,
-            error_message: None,
-        }
+            None,
+        )
     }
 
     pub fn failure(
@@ -169,16 +195,16 @@ impl AgentToolCallTrace {
         latency_ms: u32,
         error_message: impl Into<String>,
     ) -> Self {
-        Self {
+        Self::new(
             tick,
-            tool_name: tool_name.into(),
-            provider: provider.into(),
+            tool_name,
+            provider,
             status,
             latency_ms,
-            request_units: 0,
-            response_units: 0,
-            error_message: Some(error_message.into()),
-        }
+            0,
+            0,
+            Some(error_message.into()),
+        )
     }
 }
 

--- a/crates/pod-core/src/tick.rs
+++ b/crates/pod-core/src/tick.rs
@@ -87,6 +87,11 @@ pub fn execute_tick(
         telemetry_indices.insert(slot.agent.id(), telemetry_index);
         slot.agent.observe(obs);
         let decisions = slot.agent.decide();
+        if let Some(index) = telemetry_indices.get(&slot.agent.id()).copied() {
+            for trace in slot.agent.drain_tool_calls() {
+                telemetry_frames[index].record_tool_call(trace);
+            }
+        }
         for action in decisions {
             if let Some(index) = telemetry_indices.get(&slot.agent.id()).copied() {
                 telemetry_frames[index].record_action(
@@ -1550,6 +1555,7 @@ mod tests {
     use crate::action::AgentConstraints;
     use crate::agent::{Agent, AgentType};
     use crate::id::{AgentId, EntityId};
+    use crate::telemetry::{AgentToolCallTrace, ToolCallStatus};
     use std::sync::{Arc, Mutex};
 
     struct RecordingAgent {
@@ -1600,6 +1606,50 @@ mod tests {
 
         fn constraints_mut(&mut self) -> &mut AgentConstraints {
             &mut self.constraints
+        }
+    }
+
+    struct ToolTracingAgent {
+        id: AgentId,
+        constraints: AgentConstraints,
+        tool_calls: Vec<AgentToolCallTrace>,
+    }
+
+    impl ToolTracingAgent {
+        fn new(tool_calls: Vec<AgentToolCallTrace>) -> Self {
+            Self {
+                id: AgentId::new(),
+                constraints: AgentConstraints::default(),
+                tool_calls,
+            }
+        }
+    }
+
+    impl Agent for ToolTracingAgent {
+        fn id(&self) -> AgentId {
+            self.id
+        }
+
+        fn agent_type(&self) -> AgentType {
+            AgentType::LlmAgent
+        }
+
+        fn observe(&mut self, _observation: Observation) {}
+
+        fn decide(&mut self) -> Vec<Action> {
+            vec![Action::Idle]
+        }
+
+        fn constraints(&self) -> &AgentConstraints {
+            &self.constraints
+        }
+
+        fn constraints_mut(&mut self) -> &mut AgentConstraints {
+            &mut self.constraints
+        }
+
+        fn drain_tool_calls(&mut self) -> Vec<AgentToolCallTrace> {
+            std::mem::take(&mut self.tool_calls)
         }
     }
 
@@ -2121,6 +2171,52 @@ mod tests {
             .as_deref()
             .expect("rejection reason")
             .contains("magnitude too large"));
+    }
+
+    #[test]
+    fn tick_result_captures_tool_call_traces_from_agents() {
+        let mut ecs = hecs::World::new();
+        let actor_entity = spawn_actor(
+            &mut ecs,
+            Vec2::new(0.0, 0.0),
+            Team::Team(1),
+            Health::new(100.0),
+        );
+
+        let tool_trace = AgentToolCallTrace::new(
+            8,
+            "llm.complete",
+            "mock",
+            ToolCallStatus::ParseError,
+            24,
+            128,
+            64,
+            Some("invalid response".into()),
+        );
+        let mut slot = AgentSlot::new(Box::new(ToolTracingAgent::new(vec![tool_trace])));
+        slot.entity_id = Some(actor_entity);
+        let mut agents = vec![slot];
+        let mut events = EventBus::new();
+        let mut next_entity_id = 1;
+
+        let result = execute_tick(
+            &mut ecs,
+            &mut agents,
+            &mut events,
+            8,
+            vec![],
+            &mut next_entity_id,
+        );
+
+        assert_eq!(result.telemetry.agents.len(), 1);
+        let telemetry = &result.telemetry.agents[0];
+        assert_eq!(telemetry.tool_calls.len(), 1);
+        assert_eq!(telemetry.tool_calls[0].status, ToolCallStatus::ParseError);
+        assert_eq!(telemetry.tool_calls[0].request_units, 128);
+        assert_eq!(
+            telemetry.tool_calls[0].error_message.as_deref(),
+            Some("invalid response")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary\n- add first-class embedded tool/runtime contracts and richer tool-call statuses in pod-core\n- instrument llm and hybrid agents with canonical llm.complete tool-call traces and drain them into authoritative tick telemetry\n- preserve tool-call telemetry in replay exports and surface MMO/server telemetry rollups in pod-server\n\n## Testing\n- cargo test -p pod-core --lib\n- cargo test -p pod-agents --lib\n- cargo test -p pod-server --bin pod-server