### PR TITLE
Add replay training sample exports

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -527,5 +527,18 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cargo test -p pod-agents --lib`
   - `cargo test -p pod-server --bin pod-server`
 
-**Last updated**: Iteration 60
-**Current focus**: Iteration 61 training/export helpers plus flagship MMO acceptance harness on top of the authoritative telemetry and replay spine
+### Iteration 61 — Replay Training Samples and Encounter-Aware Telemetry
+
+- [x] Extended `AgentTelemetryFrame` with authoritative encounter snapshots so replay/debug artifacts can reason about combat/capture state transitions instead of only pathing and action traces.
+- [x] Added replay-side training/export primitives in `pod-core`: `ActionOutcomeSummary`, `EncounterTransition`, and `ReplayTrainingSample`, plus `ReplayFile::training_samples()` for deriving per-agent training rows from embedded telemetry windows.
+- [x] Added optional telemetry embedding to `DecisionLogger` via `to_replay_file_with_telemetry(...)` so authoritative tick windows can ride alongside decision traces in replay/debug exports.
+- [x] Added a neural-agent helper for extracting agent-specific authoritative training samples from replay artifacts.
+- [x] Added deterministic coverage for replay training sample derivation, encounter transition classification, telemetry-aware replay export, neural-agent replay filtering, and the updated editor/server/core telemetry call sites.
+- [x] Validated touched targets:
+  - `cargo test -p pod-core --lib`
+  - `cargo test -p pod-agents --lib`
+  - `cargo test -p pod-server --bin pod-server`
+  - `cargo test -p pod-editor --lib`
+
+**Last updated**: Iteration 61
+**Current focus**: Iteration 62 flagship MMO acceptance harness and shard-scale parity validation on top of the authoritative replay/training telemetry spine

--- a/apps/pod-server/src/main.rs
+++ b/apps/pod-server/src/main.rs
@@ -403,6 +403,7 @@ mod stats {
                 2,
                 4,
                 1,
+                None,
                 Some(TrajectorySample::new(7, 0.0, Vec2::ZERO, Vec2::ZERO, 0.0)),
             );
             agent.update_trajectory_end(TrajectorySample::new(

--- a/crates/pod-agents/src/decision_log.rs
+++ b/crates/pod-agents/src/decision_log.rs
@@ -49,7 +49,7 @@ use serde::{Deserialize, Serialize};
 
 use pod_core::observation::Relationship;
 use pod_core::replay::{DecisionTrace, ReplayFile, ReplayHeader};
-use pod_core::{Action, AgentId, AgentToolCallTrace, AgentType, Observation};
+use pod_core::{Action, AgentId, AgentToolCallTrace, AgentType, Observation, TickTelemetryFrame};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // ObservationSummary
@@ -489,6 +489,17 @@ impl DecisionLogger {
     /// LLM decisions. All other agent types produce a minimal trace so that the
     /// replay file is well-formed and all ticks are represented.
     pub fn to_replay_file(&self, name: &str, world_seed: u64) -> ReplayFile {
+        self.to_replay_file_with_telemetry(name, world_seed, Vec::new())
+    }
+
+    /// Convert the current buffer into a `ReplayFile` and embed authoritative
+    /// telemetry windows when the caller has them available.
+    pub fn to_replay_file_with_telemetry(
+        &self,
+        name: &str,
+        world_seed: u64,
+        telemetry_windows: Vec<TickTelemetryFrame>,
+    ) -> ReplayFile {
         let tick_count = self
             .entries
             .iter()
@@ -606,7 +617,7 @@ impl DecisionLogger {
         ReplayFile {
             header,
             traces,
-            telemetry_windows: vec![],
+            telemetry_windows,
         }
     }
 
@@ -635,7 +646,9 @@ impl DecisionLogger {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pod_core::{Action, AgentId, AgentToolCallTrace, AgentType, Observation};
+    use pod_core::{
+        Action, AgentId, AgentToolCallTrace, AgentType, Observation, TickTelemetryFrame,
+    };
 
     // ── helpers ────────────────────────────────────────────────────────────
 
@@ -1013,5 +1026,20 @@ mod tests {
             replay.traces[2][0].tool_calls[0].status,
             pod_core::ToolCallStatus::ParseError
         );
+    }
+
+    #[test]
+    fn replay_conversion_can_embed_authoritative_telemetry_windows() {
+        let mut logger = DecisionLogger::new();
+        logger.log(make_llm_entry(0, AgentId::new()));
+
+        let replay = logger.to_replay_file_with_telemetry(
+            "telemetry",
+            9,
+            vec![TickTelemetryFrame::empty(0)],
+        );
+
+        assert_eq!(replay.telemetry_windows.len(), 1);
+        assert_eq!(replay.telemetry_windows[0].tick, 0);
     }
 }

--- a/crates/pod-agents/src/neural_agent.rs
+++ b/crates/pod-agents/src/neural_agent.rs
@@ -183,6 +183,18 @@ impl NeuralAgent {
         &self.experience_buffer
     }
 
+    /// Extract authoritative training samples for a specific agent from a replay.
+    pub fn training_samples_from_replay(
+        replay: &pod_core::ReplayFile,
+        agent_id: AgentId,
+    ) -> Vec<pod_core::ReplayTrainingSample> {
+        replay
+            .training_samples()
+            .into_iter()
+            .filter(|sample| sample.agent_id == agent_id)
+            .collect()
+    }
+
     /// Record experience transition (for training)
     pub fn record_experience(
         &mut self,
@@ -403,6 +415,7 @@ impl Agent for NeuralAgent {
 mod tests {
     use super::*;
     use pod_core::component::Team;
+    use pod_core::contract::{AgentCapabilities, AgentRole, AgentRuntimeProfile};
     use pod_core::observation::{SelfState, VisibleEntity};
 
     fn make_test_observation() -> Observation {
@@ -503,5 +516,52 @@ mod tests {
         // Should wrap around
         let wrapped = index_to_action(100 % ACTION_COUNT);
         assert_eq!(format!("{:?}", action_large), format!("{:?}", wrapped));
+    }
+
+    #[test]
+    fn training_samples_from_replay_filter_by_agent() {
+        let agent_id = AgentId::new();
+        let other_agent = AgentId::new();
+        let profile = AgentRuntimeProfile {
+            role: AgentRole::Player,
+            agent_type: AgentType::NeuralAgent,
+            capabilities: AgentCapabilities::player_default(),
+        };
+
+        let first = pod_core::AgentTelemetryFrame::new(
+            0, agent_id, None, profile, 0, 0, 0, 0, 0, None, None,
+        );
+        let second = pod_core::AgentTelemetryFrame::new(
+            0,
+            other_agent,
+            None,
+            profile,
+            0,
+            0,
+            0,
+            0,
+            0,
+            None,
+            None,
+        );
+        let replay = pod_core::ReplayFile {
+            header: pod_core::ReplayHeader {
+                name: "training".into(),
+                timestamp: 0,
+                world_seed: 1,
+                tick_count: 1,
+                agent_count: 2,
+                notes: String::new(),
+            },
+            traces: vec![],
+            telemetry_windows: vec![pod_core::TickTelemetryFrame {
+                tick: 0,
+                agents: vec![first, second],
+            }],
+        };
+
+        let samples = NeuralAgent::training_samples_from_replay(&replay, agent_id);
+        assert_eq!(samples.len(), 1);
+        assert_eq!(samples[0].agent_id, agent_id);
     }
 }

--- a/crates/pod-core/src/lib.rs
+++ b/crates/pod-core/src/lib.rs
@@ -70,7 +70,10 @@ pub use observation_filter::{
     FilteredObservation, ObservationFilter, ObservationHistory, SalienceScore,
 };
 pub use orchestrator::{AgentBatch, AgentOrchestrator, DecisionFreshness, PriorityScore};
-pub use replay::{DecisionTrace, ReplayFile, ReplayHeader, ReplayPlayer, ReplayRecorder};
+pub use replay::{
+    ActionOutcomeSummary, DecisionTrace, EncounterTransition, ReplayFile, ReplayHeader,
+    ReplayPlayer, ReplayRecorder, ReplayTrainingSample,
+};
 pub use telemetry::{
     ActionLifecycleStage, ActionSource, AgentActionTrace, AgentTelemetryFrame, AgentToolCallTrace,
     AgentTrajectoryFrame, TelemetryArchive, TelemetryConfig, TickTelemetryFrame, ToolCallStatus,

--- a/crates/pod-core/src/replay.rs
+++ b/crates/pod-core/src/replay.rs
@@ -13,9 +13,12 @@
 //! - Sharing exact replay scenarios across teams
 
 use crate::action::Action;
+use crate::component::{EncounterKind, EncounterState};
 use crate::id::AgentId;
 use crate::observation::Observation;
-use crate::telemetry::{AgentToolCallTrace, TickTelemetryFrame};
+use crate::telemetry::{
+    ActionLifecycleStage, AgentToolCallTrace, TickTelemetryFrame, ToolCallStatus,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -52,6 +55,153 @@ pub struct ReplayFile {
     /// Optional authoritative telemetry windows embedded alongside decision traces.
     #[serde(default)]
     pub telemetry_windows: Vec<TickTelemetryFrame>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ActionOutcomeSummary {
+    pub submitted: usize,
+    pub executed: usize,
+    pub rejected: usize,
+    pub queued: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum EncounterTransition {
+    Joined {
+        encounter_id: u64,
+        kind: EncounterKind,
+    },
+    Left {
+        encounter_id: u64,
+        kind: EncounterKind,
+    },
+    CombatStateChanged {
+        encounter_id: u64,
+        in_combat: bool,
+    },
+    CaptureAvailabilityChanged {
+        encounter_id: u64,
+        capture_allowed: bool,
+    },
+    TargetChanged {
+        encounter_id: u64,
+        primary_target: Option<crate::id::EntityId>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ReplayTrainingSample {
+    pub tick: u64,
+    pub agent_id: AgentId,
+    pub path_distance: f32,
+    pub action_outcomes: ActionOutcomeSummary,
+    pub encounter_transition: Option<EncounterTransition>,
+    pub tool_call_latency_ms: u32,
+    pub tool_call_error_count: usize,
+}
+
+impl ReplayFile {
+    pub fn training_samples(&self) -> Vec<ReplayTrainingSample> {
+        let mut samples = Vec::new();
+        let mut previous_encounters = HashMap::<AgentId, EncounterState>::new();
+
+        for window in &self.telemetry_windows {
+            for agent in &window.agents {
+                let mut action_outcomes = ActionOutcomeSummary::default();
+                for trace in &agent.action_trace {
+                    match trace.stage {
+                        ActionLifecycleStage::Submitted => action_outcomes.submitted += 1,
+                        ActionLifecycleStage::Executed => action_outcomes.executed += 1,
+                        ActionLifecycleStage::Rejected => action_outcomes.rejected += 1,
+                        ActionLifecycleStage::Queued => action_outcomes.queued += 1,
+                    }
+                }
+
+                let encounter_transition = classify_encounter_transition(
+                    previous_encounters.get(&agent.agent_id),
+                    agent.encounter.as_ref(),
+                );
+                if let Some(encounter) = &agent.encounter {
+                    previous_encounters.insert(agent.agent_id, encounter.clone());
+                } else {
+                    previous_encounters.remove(&agent.agent_id);
+                }
+
+                let tool_call_latency_ms = agent
+                    .tool_calls
+                    .iter()
+                    .map(|trace| trace.latency_ms)
+                    .sum::<u32>();
+                let tool_call_error_count = agent
+                    .tool_calls
+                    .iter()
+                    .filter(|trace| {
+                        !matches!(
+                            trace.status,
+                            ToolCallStatus::Requested | ToolCallStatus::Succeeded
+                        )
+                    })
+                    .count();
+
+                samples.push(ReplayTrainingSample {
+                    tick: window.tick,
+                    agent_id: agent.agent_id,
+                    path_distance: agent
+                        .trajectory
+                        .as_ref()
+                        .map(|trajectory| trajectory.distance_travelled)
+                        .unwrap_or_default(),
+                    action_outcomes,
+                    encounter_transition,
+                    tool_call_latency_ms,
+                    tool_call_error_count,
+                });
+            }
+        }
+
+        samples
+    }
+}
+
+fn classify_encounter_transition(
+    previous: Option<&EncounterState>,
+    current: Option<&EncounterState>,
+) -> Option<EncounterTransition> {
+    match (previous, current) {
+        (None, Some(current)) => Some(EncounterTransition::Joined {
+            encounter_id: current.encounter_id,
+            kind: current.kind,
+        }),
+        (Some(previous), None) => Some(EncounterTransition::Left {
+            encounter_id: previous.encounter_id,
+            kind: previous.kind,
+        }),
+        (Some(previous), Some(current)) if previous.encounter_id != current.encounter_id => {
+            Some(EncounterTransition::Joined {
+                encounter_id: current.encounter_id,
+                kind: current.kind,
+            })
+        }
+        (Some(previous), Some(current)) if previous.in_combat != current.in_combat => {
+            Some(EncounterTransition::CombatStateChanged {
+                encounter_id: current.encounter_id,
+                in_combat: current.in_combat,
+            })
+        }
+        (Some(previous), Some(current)) if previous.capture_allowed != current.capture_allowed => {
+            Some(EncounterTransition::CaptureAvailabilityChanged {
+                encounter_id: current.encounter_id,
+                capture_allowed: current.capture_allowed,
+            })
+        }
+        (Some(previous), Some(current)) if previous.primary_target != current.primary_target => {
+            Some(EncounterTransition::TargetChanged {
+                encounter_id: current.encounter_id,
+                primary_target: current.primary_target,
+            })
+        }
+        _ => None,
+    }
 }
 
 /// Metadata about a replay recording
@@ -246,6 +396,11 @@ fn hash_observation(obs: &Observation) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::contract::{AgentCapabilities, AgentRole, AgentRuntimeProfile};
+    use crate::telemetry::{
+        ActionLifecycleStage, ActionSource, AgentTelemetryFrame, TrajectorySample,
+    };
+    use glam::Vec2;
 
     #[test]
     fn test_replay_recorder() {
@@ -332,5 +487,152 @@ mod tests {
         let file = recorder.finalize_with_telemetry(header, vec![TickTelemetryFrame::empty(0)]);
         assert_eq!(file.telemetry_windows.len(), 1);
         assert_eq!(file.telemetry_windows[0].tick, 0);
+    }
+
+    #[test]
+    fn replay_training_samples_capture_path_action_and_encounter_transitions() {
+        let agent_id = AgentId::new();
+        let profile = AgentRuntimeProfile {
+            role: AgentRole::Player,
+            agent_type: crate::agent::AgentType::LlmAgent,
+            capabilities: AgentCapabilities::player_default(),
+        };
+
+        let mut first = AgentTelemetryFrame::new(
+            0,
+            agent_id,
+            None,
+            profile,
+            0,
+            0,
+            0,
+            0,
+            0,
+            Some(EncounterState {
+                encounter_id: 7,
+                kind: EncounterKind::WildCreature,
+                threat_level: 0.5,
+                primary_target: None,
+                active_turn_owner: None,
+                capture_allowed: false,
+                in_combat: true,
+            }),
+            Some(TrajectorySample::new(0, 0.0, Vec2::ZERO, Vec2::ZERO, 0.0)),
+        );
+        first.update_trajectory_end(TrajectorySample::new(
+            0,
+            1.0 / 60.0,
+            Vec2::new(3.0, 4.0),
+            Vec2::ZERO,
+            0.0,
+        ));
+        first.record_action(
+            ActionSource::AgentDecision,
+            ActionLifecycleStage::Submitted,
+            Action::Attack,
+            None,
+        );
+        first.record_action(
+            ActionSource::AgentDecision,
+            ActionLifecycleStage::Executed,
+            Action::Attack,
+            None,
+        );
+        first.record_tool_call(AgentToolCallTrace::new(
+            0,
+            "llm.complete",
+            "mock",
+            ToolCallStatus::ParseError,
+            12,
+            100,
+            0,
+            Some("bad json".into()),
+        ));
+
+        let mut second = AgentTelemetryFrame::new(
+            1,
+            agent_id,
+            None,
+            profile,
+            0,
+            0,
+            0,
+            0,
+            0,
+            Some(EncounterState {
+                encounter_id: 7,
+                kind: EncounterKind::WildCreature,
+                threat_level: 0.2,
+                primary_target: None,
+                active_turn_owner: None,
+                capture_allowed: true,
+                in_combat: false,
+            }),
+            Some(TrajectorySample::new(
+                1,
+                1.0 / 60.0,
+                Vec2::new(3.0, 4.0),
+                Vec2::ZERO,
+                0.0,
+            )),
+        );
+        second.update_trajectory_end(TrajectorySample::new(
+            1,
+            2.0 / 60.0,
+            Vec2::new(4.0, 4.0),
+            Vec2::ZERO,
+            0.0,
+        ));
+        second.record_action(
+            ActionSource::AgentDecision,
+            ActionLifecycleStage::Rejected,
+            Action::CaptureCreature {
+                target: crate::id::EntityId(9),
+                tool_slot: Some(0),
+            },
+            Some("too healthy".into()),
+        );
+
+        let file = ReplayFile {
+            header: ReplayHeader {
+                name: "training".into(),
+                timestamp: 0,
+                world_seed: 1,
+                tick_count: 2,
+                agent_count: 1,
+                notes: String::new(),
+            },
+            traces: vec![],
+            telemetry_windows: vec![
+                TickTelemetryFrame {
+                    tick: 0,
+                    agents: vec![first],
+                },
+                TickTelemetryFrame {
+                    tick: 1,
+                    agents: vec![second],
+                },
+            ],
+        };
+
+        let samples = file.training_samples();
+        assert_eq!(samples.len(), 2);
+        assert!((samples[0].path_distance - 5.0).abs() < f32::EPSILON);
+        assert_eq!(samples[0].action_outcomes.executed, 1);
+        assert_eq!(samples[0].tool_call_error_count, 1);
+        assert!(matches!(
+            samples[0].encounter_transition,
+            Some(EncounterTransition::Joined {
+                encounter_id: 7,
+                kind: EncounterKind::WildCreature
+            })
+        ));
+        assert!(matches!(
+            samples[1].encounter_transition,
+            Some(EncounterTransition::CombatStateChanged {
+                encounter_id: 7,
+                in_combat: false
+            })
+        ));
     }
 }

--- a/crates/pod-core/src/telemetry.rs
+++ b/crates/pod-core/src/telemetry.rs
@@ -4,6 +4,7 @@ use glam::Vec2;
 use serde::{Deserialize, Serialize};
 
 use crate::action::Action;
+use crate::component::EncounterState;
 use crate::contract::AgentRuntimeProfile;
 use crate::id::{AgentId, EntityId};
 
@@ -220,6 +221,7 @@ pub struct AgentTelemetryFrame {
     pub message_count: usize,
     pub available_action_count: usize,
     pub objective_count: usize,
+    pub encounter: Option<EncounterState>,
     pub trajectory: Option<AgentTrajectoryFrame>,
     pub action_trace: Vec<AgentActionTrace>,
     pub tool_calls: Vec<AgentToolCallTrace>,
@@ -237,6 +239,7 @@ impl AgentTelemetryFrame {
         message_count: usize,
         available_action_count: usize,
         objective_count: usize,
+        encounter: Option<EncounterState>,
         trajectory_start: Option<TrajectorySample>,
     ) -> Self {
         Self {
@@ -249,6 +252,7 @@ impl AgentTelemetryFrame {
             message_count,
             available_action_count,
             objective_count,
+            encounter,
             trajectory: trajectory_start.map(|start| AgentTrajectoryFrame::new(start, start)),
             action_trace: Vec::new(),
             tool_calls: Vec::new(),
@@ -408,6 +412,7 @@ mod tests {
             0,
             4,
             1,
+            None,
             Some(start),
         );
         first.update_trajectory_end(mid);
@@ -427,6 +432,7 @@ mod tests {
             1,
             3,
             1,
+            None,
             Some(mid),
         );
         second.update_trajectory_end(end);

--- a/crates/pod-core/src/tick.rs
+++ b/crates/pod-core/src/tick.rs
@@ -82,6 +82,7 @@ pub fn execute_tick(
             obs.messages.len(),
             obs.available_actions.len(),
             obs.objectives.len(),
+            obs.self_state.encounter.clone(),
             trajectory_start,
         ));
         telemetry_indices.insert(slot.agent.id(), telemetry_index);

--- a/crates/pod-editor/src/lib.rs
+++ b/crates/pod-editor/src/lib.rs
@@ -2539,6 +2539,7 @@ mod tests {
             1,
             4,
             1,
+            None,
             Some(TrajectorySample::new(
                 tick,
                 tick as f32 / 60.0,


### PR DESCRIPTION
## Summary\n- embed encounter snapshots into authoritative agent telemetry and derive replay training samples from telemetry windows\n- let decision-log replay exports carry authoritative telemetry windows when available\n- add neural-agent helper APIs for replay-derived training samples\n\n## Testing\n- cargo test -p pod-core --lib\n- cargo test -p pod-agents --lib\n- cargo test -p pod-server --bin pod-server\n- cargo test -p pod-editor --lib