### PR TITLE
Use official TOON for agent prompts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3711,6 +3711,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "toon-format",
  "uuid",
 ]
 
@@ -4638,6 +4639,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -5305,6 +5307,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
+]
+
+[[package]]
+name = "toon-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d25e33e50b37f95f3b55b6e664218cac7e1a50f056a75bb4c7a6cccfbc8a8c4"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -551,5 +551,15 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cargo test -p pod-core --lib`
   - `cargo test -p pod-server --bin pod-server`
 
-**Last updated**: Iteration 62
-**Current focus**: Iteration 63 browser/editor acceptance consumption and flagship-world render/debug validation on top of the deterministic MMO acceptance harness
+### Iteration 63 — Official TOON Agent Prompt/Response Compliance
+
+- [x] Replaced the repo-local pseudo-TOON prompt shape in `pod-agents` with the official TOON format from `https://toonformat.dev/` using the `toon-format` Rust crate.
+- [x] Switched `ToonTemplate` to emit spec-compliant TOON documents that round-trip through the official decoder instead of the previous custom block syntax.
+- [x] Switched `ToonActionParser` to decode official TOON objects into gameplay actions, preserving the shared structured action payload path used by the JSON parser.
+- [x] Updated the LLM-agent integration tests and parser/template coverage to assert actual TOON decoding rather than string-matching the old fake syntax.
+- [x] Validated touched targets:
+  - `cargo test -p pod-agents --lib`
+  - `cargo test -p pod-agents --features agent_sdk_integration_tests`
+
+**Last updated**: Iteration 63
+**Current focus**: Iteration 64 browser/editor acceptance consumption and flagship-world render/debug validation on top of the deterministic MMO acceptance harness, with TOON used at structured agent I/O boundaries

--- a/crates/pod-agents/Cargo.toml
+++ b/crates/pod-agents/Cargo.toml
@@ -17,4 +17,5 @@ tokio.workspace = true
 uuid.workspace = true
 reqwest.workspace = true
 rand.workspace = true
+toon-format = { version = "0.4.4", default-features = false }
 ort = { workspace = true, optional = true }

--- a/crates/pod-agents/src/action_parser.rs
+++ b/crates/pod-agents/src/action_parser.rs
@@ -2,7 +2,7 @@
 //!
 //! Supports multiple response formats from LLMs:
 //! - JSON: `{"actions": [...], "reasoning": "..."}`
-//! - TOON: `actions[2]{...}`
+//! - TOON: `actions[2]: stop,attack`
 //! - Key-value: `ACTION: move up\nREASON: ...`
 //! - Natural language: regex extraction from free-form text
 //!
@@ -13,8 +13,7 @@ use log::{debug, warn};
 use pod_core::action::{Action, CompanionCommand, SpeakVolume};
 use pod_core::component::SkillKind;
 use pod_core::id::EntityId;
-use serde::Deserialize;
-use std::collections::HashMap;
+use toon_format::decode_default as decode_toon;
 
 // ============================================================
 // PARSE RESULT
@@ -77,15 +76,6 @@ pub trait ActionParser: Send + Sync {
 /// This is the default and recommended parser.
 pub struct JsonActionParser;
 
-/// Intermediate JSON structure from LLM
-#[derive(Deserialize)]
-struct LlmJsonResponse {
-    actions: Option<Vec<serde_json::Value>>,
-    reasoning: Option<String>,
-    #[serde(alias = "reason")]
-    reason_alt: Option<String>,
-}
-
 impl ActionParser for JsonActionParser {
     fn parse(&self, response: &str) -> Result<ActionParseResult, ActionParseError> {
         let response = response.trim();
@@ -96,46 +86,9 @@ impl ActionParser for JsonActionParser {
         // Try to extract JSON from response (LLMs sometimes wrap in markdown)
         let json_str = extract_json(response).unwrap_or(response);
 
-        let parsed: LlmJsonResponse = serde_json::from_str(json_str)
+        let parsed: serde_json::Value = serde_json::from_str(json_str)
             .map_err(|e| ActionParseError::InvalidFormat(format!("JSON parse failed: {}", e)))?;
-
-        let reasoning = parsed
-            .reasoning
-            .or(parsed.reason_alt)
-            .unwrap_or_else(|| "No reasoning provided".to_string());
-
-        let mut actions = Vec::new();
-        let mut warnings = Vec::new();
-
-        if let Some(action_values) = parsed.actions {
-            for val in &action_values {
-                match val {
-                    serde_json::Value::String(s) => match parse_action_string(s) {
-                        Ok(action) => actions.push(action),
-                        Err(e) => warnings.push(format!("Unknown action '{}': {}", s, e)),
-                    },
-                    serde_json::Value::Object(obj) => match parse_action_object(obj) {
-                        Ok(action) => actions.push(action),
-                        Err(e) => warnings.push(format!("Invalid action object: {}", e)),
-                    },
-                    _ => warnings.push(format!("Unexpected action value: {}", val)),
-                }
-            }
-        }
-
-        if actions.is_empty() {
-            actions.push(Action::Idle);
-        }
-
-        let confidence = if warnings.is_empty() { 1.0 } else { 0.7 };
-
-        Ok(ActionParseResult {
-            actions,
-            reasoning,
-            confidence,
-            raw_response: response.to_string(),
-            warnings,
-        })
+        parse_structured_action_payload(&parsed, response)
     }
 
     fn name(&self) -> &str {
@@ -147,17 +100,12 @@ impl ActionParser for JsonActionParser {
 // TOON PARSER
 // ============================================================
 
-/// Parses TOON-formatted outputs with explicit row counts and 2-space indentation.
+/// Parses official TOON outputs like `actions[2]: stop,attack`.
 ///
 /// Example:
 /// ```text
-/// actions[2]{
-///   move up
-///   attack
-/// }
-/// reasoning[1]{
-///   Hold position until cleared.
-/// }
+/// actions[2]: stop,attack
+/// reasoning: Hold position until cleared.
 /// ```
 pub struct ToonActionParser;
 
@@ -168,47 +116,79 @@ impl ActionParser for ToonActionParser {
             return Err(ActionParseError::EmptyResponse);
         }
 
-        let sections = parse_toon_sections(response)?;
-
-        let action_rows = sections.get("actions").cloned().unwrap_or_else(Vec::new);
-        let reasoning_rows = sections.get("reasoning").cloned().unwrap_or_else(Vec::new);
-
-        let mut actions = Vec::new();
-        let mut warnings = Vec::new();
-
-        if action_rows.is_empty() {
-            actions.push(Action::Idle);
-        } else {
-            for row in &action_rows {
-                match parse_action_string(row) {
-                    Ok(action) => actions.push(action),
-                    Err(e) => warnings.push(format!("Unknown action '{}': {}", row, e)),
-                }
-            }
-            if actions.is_empty() {
-                actions.push(Action::Idle);
-            }
-        }
-
-        let reasoning = if reasoning_rows.is_empty() {
-            "No reasoning provided".to_string()
-        } else {
-            reasoning_rows.join("\n")
-        };
-
-        let confidence = if warnings.is_empty() { 1.0 } else { 0.8 };
-
-        Ok(ActionParseResult {
-            actions,
-            reasoning,
-            confidence,
-            raw_response: response.to_string(),
-            warnings,
-        })
+        let parsed: serde_json::Value = decode_toon(response)
+            .map_err(|e| ActionParseError::InvalidFormat(format!("TOON parse failed: {}", e)))?;
+        parse_structured_action_payload(&parsed, response)
     }
 
     fn name(&self) -> &str {
         "toon"
+    }
+}
+
+fn parse_structured_action_payload(
+    value: &serde_json::Value,
+    raw_response: &str,
+) -> Result<ActionParseResult, ActionParseError> {
+    let obj = value.as_object().ok_or_else(|| {
+        ActionParseError::InvalidFormat("Structured response must decode to an object".to_string())
+    })?;
+
+    let mut actions = Vec::new();
+    let mut warnings = Vec::new();
+
+    if let Some(action_value) = obj.get("actions") {
+        parse_action_value(action_value, &mut actions, &mut warnings);
+    }
+
+    if actions.is_empty() {
+        actions.push(Action::Idle);
+    }
+
+    let reasoning = obj
+        .get("reasoning")
+        .or_else(|| obj.get("reason"))
+        .map(stringify_reasoning)
+        .unwrap_or_else(|| "No reasoning provided".to_string());
+
+    let confidence = if warnings.is_empty() { 1.0 } else { 0.7 };
+
+    Ok(ActionParseResult {
+        actions,
+        reasoning,
+        confidence,
+        raw_response: raw_response.to_string(),
+        warnings,
+    })
+}
+
+fn parse_action_value(
+    value: &serde_json::Value,
+    actions: &mut Vec<Action>,
+    warnings: &mut Vec<String>,
+) {
+    match value {
+        serde_json::Value::Array(items) => {
+            for item in items {
+                parse_action_value(item, actions, warnings);
+            }
+        }
+        serde_json::Value::String(s) => match parse_action_string(s) {
+            Ok(action) => actions.push(action),
+            Err(e) => warnings.push(format!("Unknown action '{}': {}", s, e)),
+        },
+        serde_json::Value::Object(obj) => match parse_action_object(obj) {
+            Ok(action) => actions.push(action),
+            Err(e) => warnings.push(format!("Invalid action object: {}", e)),
+        },
+        other => warnings.push(format!("Unexpected action value: {}", other)),
+    }
+}
+
+fn stringify_reasoning(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(text) => text.clone(),
+        other => serde_json::to_string(other).unwrap_or_else(|_| "No reasoning provided".into()),
     }
 }
 
@@ -805,126 +785,6 @@ fn extract_json(s: &str) -> Option<&str> {
     None
 }
 
-fn parse_toon_sections(raw: &str) -> Result<HashMap<String, Vec<String>>, ActionParseError> {
-    let mut sections: HashMap<String, Vec<String>> = HashMap::new();
-    let mut current: Option<(String, usize, Vec<String>)> = None;
-    let mut saw_section = false;
-
-    for line in raw.lines() {
-        let trimmed = line.trim_end_matches(&['\r', '\n'][..]).trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-
-        if trimmed == "```" || trimmed.starts_with("```toon") {
-            continue;
-        }
-
-        if trimmed == "}" {
-            let (name, expected_rows, rows) = current.take().ok_or_else(|| {
-                ActionParseError::InvalidFormat("Unexpected TOON section close".to_string())
-            })?;
-            if rows.len() != expected_rows {
-                return Err(ActionParseError::InvalidFormat(format!(
-                    "Section '{}' expected {} rows but got {}",
-                    name,
-                    expected_rows,
-                    rows.len()
-                )));
-            }
-            if sections.contains_key(&name) {
-                return Err(ActionParseError::InvalidFormat(format!(
-                    "Duplicate TOON section '{}'",
-                    name
-                )));
-            }
-            sections.insert(name, rows);
-            continue;
-        }
-
-        if let Some((name, expected_rows)) = parse_toon_header(trimmed) {
-            if current.is_some() {
-                return Err(ActionParseError::InvalidFormat(
-                    "Nested TOON sections are not allowed".to_string(),
-                ));
-            }
-            current = Some((name, expected_rows, Vec::new()));
-            saw_section = true;
-            continue;
-        }
-
-        if let Some((name, expected_rows, rows)) = current.as_mut() {
-            if !line.starts_with("  ") {
-                return Err(ActionParseError::InvalidFormat(format!(
-                    "Section '{}' rows must start with two spaces",
-                    name
-                )));
-            }
-            if rows.len() >= *expected_rows {
-                return Err(ActionParseError::InvalidFormat(format!(
-                    "Section '{}' has more rows than declared ({})",
-                    name, expected_rows
-                )));
-            }
-            let row = line[2..].trim();
-            if row.is_empty() {
-                return Err(ActionParseError::InvalidFormat(format!(
-                    "Section '{}' has an empty row",
-                    name
-                )));
-            }
-            rows.push(row.to_string());
-            continue;
-        }
-
-        if saw_section {
-            return Err(ActionParseError::InvalidFormat(
-                "TOON content found outside section body".to_string(),
-            ));
-        }
-
-        return Err(ActionParseError::InvalidFormat(
-            "No TOON section headers found".to_string(),
-        ));
-    }
-
-    if let Some((name, expected_rows, rows)) = current {
-        return Err(ActionParseError::InvalidFormat(format!(
-            "TOON section '{}' missing closing brace (expected {} rows, got {})",
-            name,
-            expected_rows,
-            rows.len()
-        )));
-    }
-    if !saw_section {
-        return Err(ActionParseError::InvalidFormat(
-            "No TOON section headers found".to_string(),
-        ));
-    }
-
-    Ok(sections)
-}
-
-fn parse_toon_header(line: &str) -> Option<(String, usize)> {
-    let line = line.trim();
-    if !line.ends_with('{') {
-        return None;
-    }
-
-    let header = &line[..line.len().saturating_sub(1)].trim();
-    let open = header.rfind('[')?;
-    let close = header.rfind(']')?;
-    if open >= close {
-        return None;
-    }
-
-    let name = header[..open].trim().to_ascii_lowercase();
-    let count = header[open + 1..close].trim();
-    let expected_rows = count.parse::<usize>().ok()?;
-
-    Some((name, expected_rows))
-}
-
 // ============================================================
 // TESTS
 // ============================================================
@@ -1090,42 +950,28 @@ mod tests {
     #[test]
     fn test_toon_parser_basic() {
         let parser = ToonActionParser;
-        let response = r#"actions[2]{
-  move up
-  attack
-}
-reasoning[1]{
-  Keep distance while advancing.
-}"#;
+        let response = r#"actions[2]: stop,attack
+reasoning: Keep distance while advancing."#;
         let result = parser.parse(response).unwrap();
         assert_eq!(result.actions.len(), 2);
         assert_eq!(result.reasoning, "Keep distance while advancing.");
-        assert!(matches!(result.actions[0], Action::Move { .. }));
+        assert!(matches!(result.actions[0], Action::Stop));
         assert!(matches!(result.actions[1], Action::Attack));
     }
 
     #[test]
     fn test_toon_parser_mismatched_count() {
         let parser = ToonActionParser;
-        let response = r#"actions[2]{
-  move up
-}
-reasoning[1]{
-  Bad count declaration.
-}"#;
+        let response = r#"actions[2]: stop
+reasoning: Bad count declaration."#;
         assert!(parser.parse(response).is_err());
     }
 
     #[test]
     fn test_toon_parser_unknown_rows() {
         let parser = ToonActionParser;
-        let response = r#"actions[2]{
-  move up
-  nonsense
-}
-reasoning[1]{
-  fallback behavior
-}"#;
+        let response = r#"actions[2]: move up,nonsense
+reasoning: fallback behavior"#;
         let result = parser.parse(response).unwrap();
         assert_eq!(result.actions.len(), 2);
         assert!(matches!(result.actions[0], Action::Move { .. }));
@@ -1136,13 +982,7 @@ reasoning[1]{
     #[test]
     fn test_fallback_parser_includes_toon() {
         let parser = FallbackParser::default_chain();
-        let result = parser
-            .parse(
-                r#"actions[1]{
-  stop
-}"#,
-            )
-            .unwrap();
+        let result = parser.parse(r#"actions[1]: stop"#).unwrap();
         assert!(matches!(result.actions[0], Action::Stop));
     }
 }

--- a/crates/pod-agents/src/llm_agent.rs
+++ b/crates/pod-agents/src/llm_agent.rs
@@ -707,13 +707,9 @@ mod tests {
     #[test]
     fn test_new_agent_uses_toon_template_and_parser_by_default() {
         let captured = Arc::new(Mutex::new(None));
-        let response = r#"actions[1]{
-  stop
-}
-reasoning[1]{
-  Default smoke test
-}"#
-        .to_string();
+        let response = r#"actions[1]: stop
+reasoning: Default smoke test"#
+            .to_string();
         let provider = Arc::new(CapturingProvider::new(response, Arc::clone(&captured)));
 
         let mut agent = LlmAgent::new(LlmAgentConfig {
@@ -732,14 +728,21 @@ reasoning[1]{
             .clone()
             .expect("provider should have captured completion request");
 
-        assert!(request.user_prompt.contains("self["));
-        assert!(request.user_prompt.contains("visible_entities["));
-        assert!(request.user_prompt.contains("available_actions["));
-        assert!(request
-            .system_prompt
-            .contains("TOON-formatted observations"));
+        let prompt_section = request
+            .user_prompt
+            .split("Current observation:\n")
+            .nth(1)
+            .and_then(|rest| rest.split("\n\nRespond with a valid TOON object").next())
+            .expect("request should include the TOON observation section");
+        let decoded_prompt: serde_json::Value =
+            toon_format::decode_default(prompt_section).expect("prompt should decode as TOON");
+        assert_eq!(decoded_prompt["tick"], 1);
+        assert!(decoded_prompt["self_state"].is_object());
+        assert!(decoded_prompt["available_actions"].is_array());
+        assert!(request.system_prompt.contains("official TOON"));
+        assert!(request.system_prompt.contains("toonformat.dev"));
         assert!(request.system_prompt.contains("actions["));
-        assert!(request.system_prompt.contains("reasoning["));
+        assert!(request.system_prompt.contains("reasoning:"));
 
         let actions = agent.decide();
         assert_eq!(actions.len(), 1);

--- a/crates/pod-agents/src/prompt_template.rs
+++ b/crates/pod-agents/src/prompt_template.rs
@@ -8,8 +8,9 @@
 //! - JsonTemplate: Machine-readable JSON for structured output models
 
 use pod_core::observation::{Observation, Relationship, VisibleEntity};
+use serde::Serialize;
 use std::collections::HashMap;
-use std::fmt::Write;
+use toon_format::encode_default as encode_toon;
 
 const JSON_ACTION_INSTRUCTION: &str = r#"
 Respond with a JSON object like this:
@@ -34,18 +35,15 @@ List multiple actions if needed. Actions are processed in order each tick.
 "#;
 
 const TOON_ACTION_INSTRUCTION: &str = r#"
-Respond with TOON blocks exactly like this (with 2-space-indented rows and explicit counts):
-actions[N]{
-  move up
-  attack
-}
-reasoning[M]{
-  Brief explanation for this tick.
-}
+Respond with a valid TOON object that decodes to this shape:
+actions[2]: stop,attack
+reasoning: Brief explanation for this tick
 
 Important:
-- Actions must be 2-space indented rows inside each block.
-- [N] and [M] must exactly match the number of rows in each block.
+- Use the official TOON format from https://toonformat.dev/.
+- Return a single TOON object, not markdown fences.
+- `actions` must be an array of action strings or action objects.
+- `reasoning` must be a single string.
 - Unknown actions are ignored and will default to Idle.
 "#;
 
@@ -369,136 +367,23 @@ impl PromptTemplate for JsonTemplate {
 // TOON TEMPLATE
 // ============================================================
 
-/// TOON-formatted template for strict block/row prompts and responses.
-pub struct ToonTemplate;
-
-impl ToonTemplate {
-    fn push_section(output: &mut String, name: &str, rows: &[String]) {
-        let _ = writeln!(output, "{}[{}]{{", name, rows.len());
-        for row in rows {
-            let _ = writeln!(output, "  {}", row);
-        }
-        output.push_str("}\n");
-    }
+fn encode_to_toon<T: Serialize>(value: &T) -> String {
+    encode_toon(value).unwrap_or_else(|_| {
+        serde_json::to_string_pretty(value).unwrap_or_else(|_| "{}".to_string())
+    })
 }
+
+/// Official TOON v3 template for structured observation prompts.
+pub struct ToonTemplate;
 
 impl PromptTemplate for ToonTemplate {
     fn format_observation(&self, obs: &Observation) -> String {
-        let mut out = String::new();
-
-        let mut self_rows = Vec::new();
-        let hp = obs
-            .self_state
-            .health
-            .map_or("unknown".to_string(), |h| format!("{:.0}", h));
-        let max_hp = obs
-            .self_state
-            .max_health
-            .map_or("unknown".to_string(), |h| format!("{:.0}", h));
-        let rotation = obs.self_state.rotation.to_degrees();
-        self_rows.push(format!(
-            "tick={} elapsed={:.2} position={:.0},{:.0} rotation={:.0} health={}/{} velocity={:.1},{:.1} team={:?} entity_id={:?} agent_id={:?}",
-            obs.tick,
-            obs.elapsed_secs,
-            obs.self_state.position.x,
-            obs.self_state.position.y,
-            rotation,
-            hp,
-            max_hp,
-            obs.self_state.velocity.x,
-            obs.self_state.velocity.y,
-            obs.self_state.team,
-            obs.self_state.entity_id.0,
-            obs.self_state.agent_id
-        ));
-        self_rows.push(format!("cooldowns={}", obs.self_state.cooldowns.len()));
-        let cooldown_rows: Vec<String> = obs
-            .self_state
-            .cooldowns
-            .iter()
-            .map(|cd| format!("{} rem={}/{}", cd.name, cd.remaining_ticks, cd.total_ticks))
-            .collect();
-
-        let visible_rows: Vec<String> = obs
-            .visible_entities
-            .iter()
-            .map(|e| {
-                let hp = e
-                    .health_fraction
-                    .map(|v| format!("{:.0}%", v * 100.0))
-                    .unwrap_or_else(|| "unknown".to_string());
-                format!(
-                    "{} id={} pos={:.0},{:.0} vel={:.1},{:.1} rot={:.0} relation={:?} distance={:.0} hp={}",
-                    e.entity_type,
-                    e.entity_id.0,
-                    e.position.x,
-                    e.position.y,
-                    e.velocity.x,
-                    e.velocity.y,
-                    e.rotation,
-                    e.relationship,
-                    e.distance,
-                    hp
-                )
-            })
-            .collect();
-
-        let available_action_rows: Vec<String> = obs
-            .available_actions
-            .iter()
-            .enumerate()
-            .map(|(idx, action)| format!("{}: {}", idx, action))
-            .collect();
-
-        let message_rows: Vec<String> = obs
-            .messages
-            .iter()
-            .map(|message| {
-                format!(
-                    "from={:?} channel={:?} content={}",
-                    message.from, message.channel, message.content
-                )
-            })
-            .collect();
-
-        let objective_rows: Vec<String> = obs
-            .objectives
-            .iter()
-            .map(|obj| {
-                format!(
-                    "{} progress={:.0}% completed={} desc={}",
-                    obj.id,
-                    obj.progress * 100.0,
-                    obj.completed,
-                    obj.description
-                )
-            })
-            .collect();
-
-        let audio_rows: Vec<String> = obs
-            .audible_events
-            .iter()
-            .map(|event| {
-                format!(
-                    "{} at {:.0} ({:.0})",
-                    event.event_type, event.distance, event.intensity
-                )
-            })
-            .collect();
-
-        Self::push_section(&mut out, "self", &self_rows);
-        Self::push_section(&mut out, "cooldowns", &cooldown_rows);
-        Self::push_section(&mut out, "visible_entities", &visible_rows);
-        Self::push_section(&mut out, "available_actions", &available_action_rows);
-        Self::push_section(&mut out, "messages", &message_rows);
-        Self::push_section(&mut out, "objectives", &objective_rows);
-        Self::push_section(&mut out, "audio", &audio_rows);
-        out
+        encode_to_toon(obs)
     }
 
     fn format_system_prompt(&self, base_prompt: &str, action_instructions: &str) -> String {
         format!(
-            "{}\n\nTOON-formatted observations are required for this model. Preserve strict section counts.\n{}",
+            "{}\n\nUse the official TOON format from https://toonformat.dev/ for both observations and structured responses.\n{}",
             base_prompt, action_instructions
         )
     }
@@ -688,9 +573,11 @@ mod tests {
         let template = ToonTemplate;
         let obs = test_observation();
         let result = template.format_observation(&obs);
-        assert!(result.contains("self["));
-        assert!(result.contains("visible_entities"));
-        assert!(result.contains("objectives"));
+        let decoded: serde_json::Value = toon_format::decode_default(&result).unwrap();
+        assert_eq!(decoded["tick"], 100);
+        assert!(decoded["self_state"].is_object());
+        assert!(decoded["visible_entities"].is_array());
+        assert!(decoded["objectives"].is_array());
     }
 
     #[test]

--- a/crates/pod-agents/tests/agent_sdk_tests.rs
+++ b/crates/pod-agents/tests/agent_sdk_tests.rs
@@ -1,54 +1,23 @@
-//! Comprehensive integration tests for the pod-agents SDK.
+//! Public-surface integration tests for `pod-agents`.
 //!
-//! Tests cover all public APIs through the crate's public interface only.
-//! Internal unit tests within each module are separate and not duplicated here.
+//! These tests intentionally use only the crate's exported API so the
+//! integration suite stays aligned with downstream usage.
 #![cfg(feature = "agent_sdk_integration_tests")]
 
-use pod_agents::{
-    // LLM agent
-    LlmAgent, LlmAgentConfig,
-    // Scripted agent
-    ScriptedAgent, BehaviorTree, BehaviorNode, BehaviorStatus, Blackboard,
-    FiniteStateMachine, FsmState, FsmTransition,
-    patrol, chase_target, chase_nearest_hostile, attack_nearest, flee_from, guard, wander,
-    patrol_and_chase_on_threat, guard_with_defense,
-    // Neural agent
-    NeuralAgent, ActionSelector, PolicyNetwork, Experience,
-    RandomActionSelector, GreedyActionSelector, UniformPolicyNetwork,
-    // Hybrid agent
-    HybridAgent, HybridAgentConfig, StrategyDirective, StrategyTrigger,
-    aggressive_hybrid, defensive_hybrid,
-    // LLM provider
-    LlmProvider, LlmError, CompletionRequest, CompletionResponse, TokenUsage,
-    TokenBudget, MockProvider,
-    // Prompt templates
-    PromptTemplate, CompactTemplate, DetailedTemplate, TacticalTemplate,
-    JsonTemplate, TemplateRegistry,
-    // Action parser
-    ActionParser, ActionParseResult, ActionParseError,
-    JsonActionParser, KeyValueParser, FallbackParser,
-    // Conversation memory
-    ConversationMemory, MemoryEntry, MemoryConfig,
-};
-use pod_agents::decision_log::{DecisionLogger, LogFilter, ObservationSummary};
-use pod_agents::utility_ai::{UtilityAgent, ActionScorer, UtilityProfile};
-
-use pod_core::action::{Action, AgentConstraints};
-use pod_core::agent::{Agent, AgentType};
-use pod_core::id::{AgentId, EntityId};
-use pod_core::observation::{
-    Observation, SelfState, VisibleEntity, AudibleEvent, AgentMessage,
-    MessageChannel, Relationship, Objective,
-};
-use pod_core::component::Team;
-
 use glam::Vec2;
+use pod_agents::{
+    ActionParser, CompactTemplate, CompletionRequest, CompletionResponse, ConversationMemory,
+    DetailedTemplate, FallbackParser, JsonActionParser, JsonTemplate, KeyValueParser, LlmAgent,
+    LlmAgentConfig, LlmError, LlmProvider, MemoryConfig, MockProvider, PromptTemplate,
+    TacticalTemplate, TemplateRegistry, TokenBudget, TokenUsage, ToonActionParser, ToonTemplate,
+};
+use pod_core::action::Action;
+use pod_core::agent::Agent;
+use pod_core::component::Team;
+use pod_core::id::{AgentId, EntityId};
+use pod_core::observation::{Observation, Relationship, SelfState, VisibleEntity};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-
-// ============================================================
-// TEST HELPERS
-// ============================================================
 
 fn make_observation() -> Observation {
     Observation {
@@ -64,6 +33,7 @@ fn make_observation() -> Observation {
             max_health: Some(100.0),
             team: Team::default(),
             cooldowns: vec![],
+            ..Default::default()
         },
         visible_entities: vec![],
         audible_events: vec![],
@@ -76,7 +46,7 @@ fn make_observation() -> Observation {
 fn make_observation_with_hostile() -> Observation {
     let mut obs = make_observation();
     obs.visible_entities.push(VisibleEntity {
-        entity_id: EntityId::default(),
+        entity_id: EntityId(77),
         entity_type: "player".to_string(),
         position: Vec2::new(120.0, 200.0),
         velocity: Vec2::ZERO,
@@ -84,33 +54,37 @@ fn make_observation_with_hostile() -> Observation {
         distance: 20.0,
         relationship: Relationship::Hostile,
         health_fraction: Some(1.0),
+        ..Default::default()
     });
     obs
 }
 
-fn make_observation_low_health() -> Observation {
-    let mut obs = make_observation();
-    obs.self_state.health = Some(15.0);
-    obs.self_state.max_health = Some(100.0);
-    obs
+fn extract_toon_observation(user_prompt: &str) -> serde_json::Value {
+    let toon = user_prompt
+        .split("Current observation:\n")
+        .nth(1)
+        .and_then(|rest| rest.split("\n\nRespond with a valid TOON object").next())
+        .expect("prompt should include a TOON observation section");
+    toon_format::decode_default(toon).expect("observation should decode as official TOON")
 }
 
-// Provider that captures the exact completion request and returns a fixed response.
 struct CapturingProvider {
     response: String,
     captured: Arc<Mutex<Option<CompletionRequest>>>,
 }
 
 impl CapturingProvider {
-    fn new(response: String, captured: Arc<Mutex<Option<CompletionRequest>>>) -> Self {
-        Self { response, captured }
+    fn new(response: impl Into<String>, captured: Arc<Mutex<Option<CompletionRequest>>>) -> Self {
+        Self {
+            response: response.into(),
+            captured,
+        }
     }
 }
 
 impl LlmProvider for CapturingProvider {
     fn complete(&self, request: &CompletionRequest) -> Result<CompletionResponse, LlmError> {
-        let mut captured = self.captured.lock().unwrap();
-        *captured = Some(request.clone());
+        *self.captured.lock().unwrap() = Some(request.clone());
         Ok(CompletionResponse {
             content: self.response.clone(),
             usage: TokenUsage {
@@ -127,12 +101,8 @@ impl LlmProvider for CapturingProvider {
     }
 }
 
-// ============================================================
-// LLM PROVIDER TESTS
-// ============================================================
-
 #[test]
-fn test_mock_provider_idle_creation() {
+fn mock_provider_idle_creation() {
     let provider = MockProvider::idle();
     let req = CompletionRequest {
         model: "test".to_string(),
@@ -141,16 +111,13 @@ fn test_mock_provider_idle_creation() {
         temperature: 0.7,
         max_tokens: 100,
     };
-    let result = provider.complete(&req);
-    assert!(result.is_ok());
-    let resp = result.unwrap();
+    let resp = provider.complete(&req).unwrap();
     assert!(resp.content.contains("Idle"));
 }
 
 #[test]
-fn test_mock_provider_responding() {
-    let response_text = r#"{"actions":["Move"]}"#;
-    let provider = MockProvider::responding(response_text.to_string());
+fn mock_provider_custom_creation() {
+    let provider = MockProvider::new(r#"{"actions":["stop"]}"#.to_string());
     let req = CompletionRequest {
         model: "test".to_string(),
         system_prompt: "sys".to_string(),
@@ -158,14 +125,12 @@ fn test_mock_provider_responding() {
         temperature: 0.7,
         max_tokens: 100,
     };
-    let result = provider.complete(&req);
-    assert!(result.is_ok());
-    let resp = result.unwrap();
-    assert_eq!(resp.content, response_text);
+    let resp = provider.complete(&req).unwrap();
+    assert_eq!(resp.content, r#"{"actions":["stop"]}"#);
 }
 
 #[test]
-fn test_llm_agent_new_uses_toon_formatted_prompt_by_default() {
+fn llm_agent_defaults_to_official_toon_prompting() {
     let mut agent = LlmAgent::new(LlmAgentConfig {
         reaction_time_ms: 0,
         ..Default::default()
@@ -178,30 +143,18 @@ fn test_llm_agent_new_uses_toon_formatted_prompt_by_default() {
     assert_eq!(actions.len(), 1);
     assert!(matches!(actions[0], Action::Idle));
 
-    let trace = agent
-        .decision_traces()
-        .back()
-        .expect("a decision trace should be recorded");
-    assert!(trace.llm_prompt.contains("self["));
-    assert!(trace.llm_prompt.contains("visible_entities["));
-    assert!(trace.llm_prompt.contains("available_actions["));
-    assert!(trace.llm_prompt.contains("TOON-formatted observations"));
+    let trace = agent.decision_traces().back().unwrap();
+    assert!(trace.llm_prompt.contains("official TOON"));
+    assert!(trace.llm_prompt.contains("toonformat.dev"));
     assert!(trace.llm_prompt.contains("actions["));
-    assert!(trace.llm_prompt.contains("reasoning["));
-    assert!(matches!(trace.parsed_actions.first(), Some(Action::Idle)));
+    assert!(trace.llm_prompt.contains("reasoning:"));
 }
 
 #[test]
-fn test_new_llm_agent_emits_toon_prompts_and_toon_parser_roundtrip() {
+fn llm_agent_roundtrips_official_toon_prompt_and_response() {
     let captured = Arc::new(Mutex::new(None));
     let provider = Arc::new(CapturingProvider::new(
-        r#"actions[1]{
-  stop
-}
-reasoning[1]{
-  SDK smoke test default alignment
-}"#
-        .to_string(),
+        "actions[1]: stop\nreasoning: SDK smoke test default alignment",
         Arc::clone(&captured),
     ));
 
@@ -220,263 +173,112 @@ reasoning[1]{
     agent.observe(make_observation());
     std::thread::sleep(Duration::from_millis(50));
 
-    let request = captured
-        .lock()
-        .unwrap()
-        .clone()
-        .expect("capturing provider should have seen a completion request");
-
-    assert!(request.user_prompt.contains("self["));
-    assert!(request.user_prompt.contains("cooldowns["));
-    assert!(request.user_prompt.contains("visible_entities["));
-    assert!(request.user_prompt.contains("available_actions["));
-    assert!(request.system_prompt.contains("TOON-formatted observations"));
-    assert!(request.system_prompt.contains("actions["));
-    assert!(request.system_prompt.contains("reasoning["));
+    let request = captured.lock().unwrap().clone().unwrap();
+    let decoded_prompt = extract_toon_observation(&request.user_prompt);
+    assert_eq!(decoded_prompt["tick"], 10);
+    assert!(decoded_prompt["self_state"].is_object());
+    assert!(decoded_prompt["available_actions"].is_array());
+    assert!(request.system_prompt.contains("official TOON"));
 
     let actions = agent.decide();
     assert_eq!(actions.len(), 1);
     assert!(matches!(actions[0], Action::Stop));
 
-    let trace = agent
-        .decision_traces()
-        .back()
-        .expect("a decision trace should be recorded");
+    let trace = agent.decision_traces().back().unwrap();
     assert_eq!(trace.reasoning, "SDK smoke test default alignment");
 }
 
 #[test]
-fn test_token_budget_unlimited() {
-    let budget = TokenBudget::unlimited();
-    assert!(budget.has_budget(1_000_000));
+fn token_budget_smoke() {
+    let mut budget = TokenBudget::new(100, 1000);
+    assert!(budget.can_request(50));
+    budget.record_usage(&TokenUsage {
+        prompt_tokens: 20,
+        completion_tokens: 30,
+        total_tokens: 50,
+    });
+    assert!(!budget.can_request(60));
+    assert!(budget.can_request(50));
+    budget.reset_tick();
+    assert!(budget.can_request(100));
 }
 
 #[test]
-fn test_token_budget_limited() {
-    let mut budget = TokenBudget::with_limit(100);
-    assert!(budget.has_budget(50));
-    budget.consume(80);
-    assert!(!budget.has_budget(50));
-    assert!(budget.has_budget(20));
-}
-
-#[test]
-fn test_token_budget_reset() {
-    let mut budget = TokenBudget::with_limit(100);
-    budget.consume(90);
-    budget.reset();
-    assert!(budget.has_budget(100));
-}
-
-// ============================================================
-// PROMPT TEMPLATE TESTS
-// ============================================================
-
-#[test]
-fn test_compact_template_renders() {
-    let template = CompactTemplate;
-    let obs = make_observation();
-    let prompt = template.render(&obs);
-    assert!(!prompt.is_empty());
-    // Should contain position or tick info
-    assert!(prompt.contains("100") || prompt.contains("10") || prompt.len() > 5);
-}
-
-#[test]
-fn test_detailed_template_renders() {
-    let template = DetailedTemplate;
-    let obs = make_observation();
-    let prompt = template.render(&obs);
-    assert!(!prompt.is_empty());
-}
-
-#[test]
-fn test_tactical_template_renders() {
-    let template = TacticalTemplate;
+fn template_suite_renders_current_formats() {
     let obs = make_observation_with_hostile();
-    let prompt = template.render(&obs);
-    assert!(!prompt.is_empty());
+
+    let compact = CompactTemplate::default().render(&obs);
+    assert!(!compact.is_empty());
+
+    let detailed = DetailedTemplate.render(&obs);
+    assert!(!detailed.is_empty());
+
+    let tactical = TacticalTemplate::default().render(&obs);
+    assert!(!tactical.is_empty());
+
+    let json_prompt = JsonTemplate.render(&obs);
+    let json_value: serde_json::Value = serde_json::from_str(&json_prompt).unwrap();
+    assert_eq!(json_value["tick"], 10);
+
+    let toon_prompt = ToonTemplate.render(&obs);
+    let toon_value: serde_json::Value = toon_format::decode_default(&toon_prompt).unwrap();
+    assert_eq!(toon_value["tick"], 10);
+    assert!(toon_value["visible_entities"].is_array());
 }
 
 #[test]
-fn test_json_template_renders_valid_json() {
-    let template = JsonTemplate;
-    let obs = make_observation();
-    let prompt = template.render(&obs);
-    // JSON template should produce parseable JSON
-    assert!(!prompt.is_empty());
-    // Should at minimum be valid enough to not be empty
-    assert!(prompt.len() > 2);
-}
-
-#[test]
-fn test_template_registry_default_contains_templates() {
+fn template_registry_exposes_toon() {
     let registry = TemplateRegistry::default();
-    let names = registry.available_templates();
-    assert!(!names.is_empty());
+    assert!(registry.get("toon").is_some());
+    assert!(registry.available_templates().contains(&"toon"));
 }
 
 #[test]
-fn test_template_registry_get_by_name() {
-    let registry = TemplateRegistry::default();
-    // Should be able to get "compact" template
-    let names = registry.available_templates();
-    if let Some(name) = names.first() {
-        let template = registry.get(name);
-        assert!(template.is_some());
-    }
-}
+fn parser_suite_handles_json_toon_and_key_value() {
+    let json_result = JsonActionParser
+        .parse(r#"{"actions":["stop"],"reasoning":"json"}"#)
+        .unwrap();
+    assert!(matches!(json_result.actions[0], Action::Stop));
+    assert_eq!(json_result.reasoning, "json");
 
-// ============================================================
-// ACTION PARSER TESTS
-// ============================================================
+    let toon_result = ToonActionParser
+        .parse("actions[2]: stop,attack\nreasoning: toon")
+        .unwrap();
+    assert!(matches!(toon_result.actions[0], Action::Stop));
+    assert!(matches!(toon_result.actions[1], Action::Attack));
+    assert_eq!(toon_result.reasoning, "toon");
 
-#[test]
-fn test_json_action_parser_idle() {
-    let parser = JsonActionParser;
-    let result = parser.parse(r#"{"actions":["Idle"]}"#);
-    assert!(result.is_ok());
-    let parsed = result.unwrap();
-    assert!(!parsed.actions.is_empty());
-    assert!(parsed.confidence > 0.5);
-}
+    let kv_result = KeyValueParser
+        .parse("ACTION: stop\nREASON: key value")
+        .unwrap();
+    assert!(matches!(kv_result.actions[0], Action::Stop));
 
-#[test]
-fn test_json_action_parser_move() {
-    let parser = JsonActionParser;
-    let result = parser.parse(r#"{"actions":["Move"]}"#);
-    assert!(result.is_ok());
-    let parsed = result.unwrap();
-    assert!(!parsed.actions.is_empty());
+    let fallback_result = FallbackParser::default_chain()
+        .parse("actions[1]: stop")
+        .unwrap();
+    assert!(matches!(fallback_result.actions[0], Action::Stop));
 }
 
 #[test]
-fn test_json_action_parser_invalid_json() {
-    let parser = JsonActionParser;
-    let result = parser.parse("not json at all !!!");
-    // Should fail gracefully
-    assert!(result.is_err());
-}
+fn conversation_memory_records_current_decision_shape() {
+    let mut memory = ConversationMemory::new(MemoryConfig {
+        max_entries: 3,
+        max_tokens: 200,
+        importance_threshold: 0.0,
+        record_interval: 1,
+        include_in_prompts: true,
+    });
 
-#[test]
-fn test_key_value_parser_basic() {
-    let parser = KeyValueParser;
-    let result = parser.parse("action=Idle");
-    assert!(result.is_ok());
-    let parsed = result.unwrap();
-    assert!(!parsed.actions.is_empty());
-}
+    let obs = make_observation_with_hostile();
+    assert!(memory.record(&obs, &[Action::Attack], "Pressure the hostile target"));
+    assert_eq!(memory.entries().len(), 1);
 
-#[test]
-fn test_fallback_parser_chain_uses_first_succeeding() {
-    let parser = FallbackParser::default_chain();
-    // Valid JSON should succeed
-    let result = parser.parse(r#"{"actions":["Idle"]}"#);
-    assert!(result.is_ok());
-    let parsed = result.unwrap();
-    assert!(!parsed.actions.is_empty());
-}
+    let entry = memory.last_entry().unwrap();
+    assert_eq!(entry.tick, obs.tick);
+    assert_eq!(entry.reasoning, "Pressure the hostile target");
+    assert!(!entry.actions_taken.is_empty());
 
-#[test]
-fn test_fallback_parser_chain_falls_back() {
-    let parser = FallbackParser::default_chain();
-    // Plain text with no JSON — should fall back through chain
-    let result = parser.parse("Idle");
-    // FallbackParser returns last result even on low confidence
-    assert!(result.is_ok());
-}
-
-#[test]
-fn test_action_parse_result_confidence_range() {
-    let parser = JsonActionParser;
-    let result = parser.parse(r#"{"actions":["Idle"]}"#).unwrap();
-    assert!(result.confidence >= 0.0 && result.confidence <= 1.0);
-}
-
-// ============================================================
-// CONVERSATION MEMORY TESTS
-// ============================================================
-
-#[test]
-fn test_conversation_memory_new_is_empty() {
-    let mem = ConversationMemory::new(MemoryConfig::default());
-    assert_eq!(mem.entries().len(), 0);
-}
-
-#[test]
-fn test_conversation_memory_record_first_entry() {
-    let mut mem = ConversationMemory::new(MemoryConfig::default());
-    let obs = make_observation();
-    // First call always records
-    mem.record(obs.tick, "prompt".to_string(), "response".to_string(), 0.3);
-    assert_eq!(mem.entries().len(), 1);
-}
-
-#[test]
-fn test_conversation_memory_record_high_importance_bypasses_interval() {
-    let config = MemoryConfig {
-        window_size: 20,
-        record_interval_ticks: 30,
-    };
-    let mut mem = ConversationMemory::new(config);
-    // First entry
-    mem.record(1, "p1".to_string(), "r1".to_string(), 0.3);
-    // Tick 5 — within interval (< 30) but high importance >= 0.5 → records
-    mem.record(5, "p2".to_string(), "r2".to_string(), 0.8);
-    assert_eq!(mem.entries().len(), 2);
-}
-
-#[test]
-fn test_conversation_memory_record_low_importance_respects_interval() {
-    let config = MemoryConfig {
-        window_size: 20,
-        record_interval_ticks: 30,
-    };
-    let mut mem = ConversationMemory::new(config);
-    // First entry at tick 1
-    mem.record(1, "p1".to_string(), "r1".to_string(), 0.3);
-    // Tick 5 — within interval and low importance → skipped
-    mem.record(5, "p2".to_string(), "r2".to_string(), 0.3);
-    assert_eq!(mem.entries().len(), 1);
-}
-
-#[test]
-fn test_conversation_memory_window_limits_entries() {
-    let config = MemoryConfig {
-        window_size: 3,
-        record_interval_ticks: 1,
-    };
-    let mut mem = ConversationMemory::new(config);
-    for i in 0..10u64 {
-        mem.record(i, format!("p{}", i), format!("r{}", i), 0.8);
-    }
-    // Should be capped at window_size
-    assert!(mem.entries().len() <= 3);
-}
-
-#[test]
-fn test_conversation_memory_entry_fields() {
-    let mut mem = ConversationMemory::new(MemoryConfig::default());
-    mem.record(42, "my prompt".to_string(), "my response".to_string(), 0.7);
-    let entry = &mem.entries()[0];
-    assert_eq!(entry.tick, 42);
-    assert_eq!(entry.prompt, "my prompt");
-    assert_eq!(entry.response, "my response");
-}
-
-#[test]
-fn test_conversation_memory_to_messages() {
-    let mut mem = ConversationMemory::new(MemoryConfig::default());
-    mem.record(1, "prompt1".to_string(), "response1".to_string(), 0.9);
-    mem.record(100, "prompt2".to_string(), "response2".to_string(), 0.9);
-    let messages = mem.to_messages();
-    // Should produce user/assistant message pairs
-    assert!(!messages.is_empty());
-}
-
-#[test]
-fn test_memory_config_default() {
-    let config = MemoryConfig::default();
-    assert!(config.window_size > 0);
-    assert!(config.record_interval_ticks > 0);
+    let prompt_section = memory.to_prompt_section();
+    assert!(prompt_section.contains("MEMORY"));
+    assert!(prompt_section.contains("Pressure the hostile target"));
 }


### PR DESCRIPTION
## Summary
- replace the repo-local pseudo-TOON prompt and response format with the official TOON format from toonformat.dev using the official Rust crate
- make  emit spec-compliant TOON and make  decode TOON back into the shared structured action payload path
- refresh the public  integration suite so it matches the current  API and validates the TOON round-trip

## Testing
- cargo test -p pod-agents --features agent_sdk_integration_tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Adopted official TOON format for agent input/output communications.

* **Refactor**
  * Migrated to specification-compliant TOON format handling for structured payloads.
  * Improved response validation and payload parsing flow.

* **Documentation**
  * Updated implementation roadmap to reflect TOON compliance phase completion.

* **Tests**
  * Updated test suite to validate official TOON format encoding and decoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->