### PR TITLE
Add TOON exports for replay telemetry and editor snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3755,6 +3755,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "serde",
  "serde_json",
+ "toon-format",
  "uuid",
 ]
 

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -561,5 +561,20 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cargo test -p pod-agents --lib`
   - `cargo test -p pod-agents --features agent_sdk_integration_tests`
 
-**Last updated**: Iteration 63
-**Current focus**: Iteration 64 browser/editor acceptance consumption and flagship-world render/debug validation on top of the deterministic MMO acceptance harness, with TOON used at structured agent I/O boundaries
+### Iteration 64 — TOON Replay, Telemetry, World-Building Snapshots, and Ops Summaries
+
+- [x] Added shared TOON document helpers to `pod-core` plus reusable typed export methods for replay, telemetry, tool/runtime contracts, and shard incident summaries.
+- [x] Extended `ReplayFile`, `ReplayTrainingSample`, `DecisionTrace`, `TelemetryArchive`, `TickTelemetryFrame`, `AgentTelemetryFrame`, `AgentToolCallTrace`, `ToolInvocationRequest`, `ToolInvocationResult`, and `VersionedTickTelemetry` with TOON export surfaces for debugging and training workflows.
+- [x] Extended `pod-agents::DecisionLogger` and `DecisionEntry` with TOON exports, including a dedicated embedded-tool trace export for LLM/runtime side effects.
+- [x] Added `ShardIncidentSummary` in `pod-core` and wired `pod-server` stats to emit TOON-ready incident summaries for ops agents with damped severity thresholds.
+- [x] Added creator-facing authoring associations in `pod-editor` for models, objects, monsters, and scene entities, with convenience creation APIs and TOON world-snapshot export for world-building agents.
+- [x] Switched the editor’s project snapshot action to emit TOON instead of raw JSON so the authoring/debug surface uses the same structured interchange format as agents and ops tooling.
+- [x] Added deterministic coverage for TOON document round-tripping across replay/telemetry/contracts, decision-log tool traces, editor world snapshots/creator associations, and server incident summaries.
+- [x] Validated touched targets:
+  - `cargo test -p pod-core --lib`
+  - `cargo test -p pod-agents --lib`
+  - `cargo test -p pod-editor --lib`
+  - `cargo test -p pod-server --bin pod-server`
+
+**Last updated**: Iteration 64
+**Current focus**: Iteration 65 TOON-backed direct-connect and SpacetimeDB telemetry export parity, plus browser/editor consumption of replay and incident summaries for live debugging, training, and shard operations

--- a/apps/pod-server/src/main.rs
+++ b/apps/pod-server/src/main.rs
@@ -170,6 +170,7 @@ mod map {
 mod stats {
     use pod_core::action::Action;
     use pod_core::telemetry::ToolCallStatus;
+    use pod_core::{IncidentSeverity, ShardIncidentSummary};
     use std::time::Instant;
 
     /// Server statistics tracker
@@ -306,6 +307,71 @@ mod stats {
             self.tick_budget_overruns as f32 / self.ticks_completed as f32
         }
 
+        pub fn incident_summary(
+            &self,
+            shard_id: impl Into<String>,
+            latest_tick: u64,
+        ) -> ShardIncidentSummary {
+            let shard_id = shard_id.into();
+            let tick_budget_overrun_rate = self.tick_budget_overrun_rate();
+            let action_rejection_rate = self.action_rejection_rate();
+            let tool_call_error_rate = self.tool_call_error_rate();
+            let average_tool_latency_ms = self.average_tool_latency_ms();
+            let average_trajectory_distance = self.average_trajectory_distance();
+
+            let mut notes = Vec::new();
+            if tick_budget_overrun_rate >= 0.05 {
+                notes.push("tick budget overruns exceed 5%".to_string());
+            }
+            if action_rejection_rate >= 0.15 {
+                notes.push("action rejection rate exceeds 15%".to_string());
+            }
+            if tool_call_error_rate >= 0.10 {
+                notes.push("tool-call error rate exceeds 10%".to_string());
+            }
+            if average_tool_latency_ms >= 750.0 {
+                notes.push("tool-call latency exceeds 750ms".to_string());
+            }
+
+            let sustained_critical = self.ticks_completed >= 10
+                && (tick_budget_overrun_rate >= 0.10
+                    || action_rejection_rate >= 0.25
+                    || tool_call_error_rate >= 0.20);
+
+            let severity = if sustained_critical {
+                IncidentSeverity::Critical
+            } else if !notes.is_empty() {
+                IncidentSeverity::Warning
+            } else {
+                IncidentSeverity::Healthy
+            };
+
+            let summary = if notes.is_empty() {
+                format!("Shard {shard_id} is healthy at tick {latest_tick}")
+            } else {
+                format!("Shard {shard_id} requires attention: {}", notes.join("; "))
+            };
+
+            ShardIncidentSummary {
+                shard_id,
+                latest_tick,
+                severity,
+                summary,
+                tick_budget_overrun_rate,
+                action_rejection_rate,
+                tool_call_error_rate,
+                average_tool_latency_ms,
+                average_trajectory_distance,
+                peak_entity_count: self.peak_entity_count,
+                peak_agent_count: self.peak_agent_count,
+                capture_actions: self.capture_actions,
+                summon_actions: self.summon_actions,
+                gather_actions: self.gather_actions,
+                loot_actions: self.loot_actions,
+                notes,
+            }
+        }
+
         /// Print periodic stats (called once per second)
         pub fn print_periodic(&mut self, world: &pod_core::World) {
             use log::info;
@@ -391,6 +457,7 @@ mod stats {
             ActionLifecycleStage, ActionSource, AgentTelemetryFrame, AgentToolCallTrace,
             TickTelemetryFrame, ToolCallStatus, TrajectorySample,
         };
+        use pod_core::{decode_toon_value, IncidentSeverity};
 
         fn sample_tick() -> pod_core::tick::TickResult {
             let agent_id = AgentId::new();
@@ -497,6 +564,21 @@ mod stats {
             );
             assert_eq!(stats.ticks_completed, result.summary.ticks_completed);
             assert!(result.parity_passed());
+        }
+
+        #[test]
+        fn incident_summaries_export_to_toon_for_ops_agents() {
+            let mut stats = ServerStats::new(60);
+            let tick = sample_tick();
+            stats.record_tick(&tick, 5, true);
+            let summary = stats.incident_summary("overworld-a", tick.tick);
+            assert_eq!(summary.severity, IncidentSeverity::Warning);
+
+            let document = summary.to_toon_document();
+            let value = decode_toon_value(&document).expect("incident summary should decode");
+            assert_eq!(value["document_type"], "shard_incident_summary");
+            assert_eq!(value["payload"]["shard_id"], "overworld-a");
+            assert_eq!(value["payload"]["latest_tick"], 7);
         }
     }
 }

--- a/crates/pod-agents/src/decision_log.rs
+++ b/crates/pod-agents/src/decision_log.rs
@@ -49,7 +49,10 @@ use serde::{Deserialize, Serialize};
 
 use pod_core::observation::Relationship;
 use pod_core::replay::{DecisionTrace, ReplayFile, ReplayHeader};
-use pod_core::{Action, AgentId, AgentToolCallTrace, AgentType, Observation, TickTelemetryFrame};
+use pod_core::{
+    encode_toon_document, Action, AgentId, AgentToolCallTrace, AgentType, Observation,
+    TickTelemetryFrame,
+};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // ObservationSummary
@@ -226,6 +229,12 @@ pub struct DecisionEntry {
     pub tool_calls: Vec<AgentToolCallTrace>,
     /// Arbitrary key/value metadata (agent-specific diagnostics, test tags, …).
     pub metadata: HashMap<String, String>,
+}
+
+impl DecisionEntry {
+    pub fn to_toon_document(&self) -> String {
+        encode_toon_document("agent_decision_entry", self)
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -621,6 +630,64 @@ impl DecisionLogger {
         }
     }
 
+    pub fn to_toon_document(&self) -> String {
+        #[derive(Serialize)]
+        struct DecisionLogExport<'a> {
+            total_entries: usize,
+            entries: Vec<&'a DecisionEntry>,
+        }
+
+        encode_toon_document(
+            "agent_decision_log",
+            &DecisionLogExport {
+                total_entries: self.entries.len(),
+                entries: self.entries.iter().collect(),
+            },
+        )
+    }
+
+    pub fn tool_calls_to_toon_document(&self) -> String {
+        #[derive(Clone, Serialize)]
+        struct ToolCallEntry {
+            tick: u64,
+            agent_id: AgentId,
+            agent_type: AgentType,
+            decision_method: DecisionMethod,
+            tool_calls: Vec<AgentToolCallTrace>,
+            metadata: HashMap<String, String>,
+        }
+
+        #[derive(Serialize)]
+        struct ToolCallExport {
+            total_entries: usize,
+            entries_with_tool_calls: usize,
+            tool_call_entries: Vec<ToolCallEntry>,
+        }
+
+        let tool_call_entries = self
+            .entries
+            .iter()
+            .filter(|entry| !entry.tool_calls.is_empty())
+            .map(|entry| ToolCallEntry {
+                tick: entry.tick,
+                agent_id: entry.agent_id,
+                agent_type: entry.agent_type,
+                decision_method: entry.decision_method.clone(),
+                tool_calls: entry.tool_calls.clone(),
+                metadata: entry.metadata.clone(),
+            })
+            .collect::<Vec<_>>();
+
+        encode_toon_document(
+            "agent_tool_call_log",
+            &ToolCallExport {
+                total_entries: self.entries.len(),
+                entries_with_tool_calls: tool_call_entries.len(),
+                tool_call_entries,
+            },
+        )
+    }
+
     // ── Utility ───────────────────────────────────────────────────────────────
 
     /// Number of entries currently held in the buffer.
@@ -647,7 +714,8 @@ impl DecisionLogger {
 mod tests {
     use super::*;
     use pod_core::{
-        Action, AgentId, AgentToolCallTrace, AgentType, Observation, TickTelemetryFrame,
+        decode_toon_value, Action, AgentId, AgentToolCallTrace, AgentType, Observation,
+        TickTelemetryFrame,
     };
 
     // ── helpers ────────────────────────────────────────────────────────────
@@ -1041,5 +1109,29 @@ mod tests {
 
         assert_eq!(replay.telemetry_windows.len(), 1);
         assert_eq!(replay.telemetry_windows[0].tick, 0);
+    }
+
+    #[test]
+    fn decision_logs_export_tool_calls_to_toon() {
+        let mut logger = DecisionLogger::new();
+        let mut entry = make_llm_entry(3, AgentId::new());
+        entry.tool_calls.push(AgentToolCallTrace::success(
+            3,
+            "llm.complete",
+            "qwen",
+            21,
+            90,
+            24,
+        ));
+        logger.log(entry);
+
+        let document = logger.tool_calls_to_toon_document();
+        let value = decode_toon_value(&document).expect("TOON document should decode");
+        assert_eq!(value["document_type"], "agent_tool_call_log");
+        assert_eq!(value["payload"]["entries_with_tool_calls"], 1);
+        assert_eq!(
+            value["payload"]["tool_call_entries"][0]["tool_calls"][0]["provider"],
+            "qwen"
+        );
     }
 }

--- a/crates/pod-core/Cargo.toml
+++ b/crates/pod-core/Cargo.toml
@@ -16,6 +16,7 @@ rand.workspace = true
 rand_chacha.workspace = true
 log.workspace = true
 uuid.workspace = true
+toon-format = { version = "0.4.4", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom.workspace = true

--- a/crates/pod-core/src/contract.rs
+++ b/crates/pod-core/src/contract.rs
@@ -5,6 +5,7 @@ use crate::agent::AgentType;
 use crate::id::AgentId;
 use crate::observation::Observation;
 use crate::telemetry::{TickTelemetryFrame, ToolCallStatus};
+use crate::toon::encode_toon_document;
 
 pub const RUNTIME_CONTRACT_VERSION_V1: u16 = 1;
 
@@ -222,6 +223,10 @@ impl ToolCatalog {
             tools,
         }
     }
+
+    pub fn to_toon_document(&self) -> String {
+        encode_toon_document("tool_catalog", self)
+    }
 }
 
 /// Request emitted by an embedded tool runtime before a side effect occurs.
@@ -265,6 +270,10 @@ impl VersionedAgentAction {
             payload,
         }
     }
+
+    pub fn to_toon_document(&self) -> String {
+        encode_toon_document("versioned_agent_action", self)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -282,6 +291,10 @@ impl VersionedObservation {
             payload,
         }
     }
+
+    pub fn to_toon_document(&self) -> String {
+        encode_toon_document("versioned_observation", self)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -297,6 +310,40 @@ impl VersionedTickTelemetry {
             payload,
         }
     }
+
+    pub fn to_toon_document(&self) -> String {
+        encode_toon_document("versioned_tick_telemetry", self)
+    }
+}
+
+impl ToolDefinition {
+    pub fn to_toon_document(&self) -> String {
+        encode_toon_document("tool_definition", self)
+    }
+}
+
+impl ToolBudget {
+    pub fn to_toon_document(&self) -> String {
+        encode_toon_document("tool_budget", self)
+    }
+}
+
+impl ToolPolicy {
+    pub fn to_toon_document(&self) -> String {
+        encode_toon_document("tool_policy", self)
+    }
+}
+
+impl ToolInvocationRequest {
+    pub fn to_toon_document(&self) -> String {
+        encode_toon_document("tool_invocation_request", self)
+    }
+}
+
+impl ToolInvocationResult {
+    pub fn to_toon_document(&self) -> String {
+        encode_toon_document("tool_invocation_result", self)
+    }
 }
 
 #[cfg(test)]
@@ -306,6 +353,7 @@ mod tests {
     use crate::id::AgentId;
     use crate::observation::Observation;
     use crate::telemetry::{TickTelemetryFrame, ToolCallStatus};
+    use crate::toon::decode_toon_value;
 
     use super::{
         AgentCapabilities, AgentRole, AgentRuntimeProfile, RuntimeContractVersion, ToolBudget,
@@ -410,5 +458,29 @@ mod tests {
         assert_eq!(decoded.status, ToolCallStatus::RateLimited);
         assert_eq!(decoded.request_units, 320);
         assert!(decoded.output_json.is_none());
+    }
+
+    #[test]
+    fn tool_contracts_export_to_toon_documents() {
+        let request = ToolInvocationRequest {
+            tick: 12,
+            agent_id: AgentId::new(),
+            tool_name: "llm.complete".into(),
+            provider: "qwen".into(),
+            request_units: 320,
+            arguments_json: "{\"prompt\":\"hi\"}".into(),
+        };
+        let request_document = request.to_toon_document();
+        let request_value =
+            decode_toon_value(&request_document).expect("request document should decode");
+        assert_eq!(request_value["document_type"], "tool_invocation_request");
+        assert_eq!(request_value["payload"]["provider"], "qwen");
+
+        let telemetry = VersionedTickTelemetry::new(TickTelemetryFrame::empty(9));
+        let telemetry_document = telemetry.to_toon_document();
+        let telemetry_value =
+            decode_toon_value(&telemetry_document).expect("telemetry document should decode");
+        assert_eq!(telemetry_value["document_type"], "versioned_tick_telemetry");
+        assert_eq!(telemetry_value["payload"]["payload"]["tick"], 9);
     }
 }

--- a/crates/pod-core/src/lib.rs
+++ b/crates/pod-core/src/lib.rs
@@ -42,10 +42,12 @@ pub mod event;
 pub mod id;
 pub mod observation;
 pub mod observation_filter;
+pub mod ops;
 pub mod orchestrator;
 pub mod replay;
 pub mod telemetry;
 pub mod tick;
+pub mod toon;
 pub mod world;
 
 pub use acceptance::{
@@ -75,6 +77,7 @@ pub use observation::*;
 pub use observation_filter::{
     FilteredObservation, ObservationFilter, ObservationHistory, SalienceScore,
 };
+pub use ops::{IncidentSeverity, ShardIncidentSummary};
 pub use orchestrator::{AgentBatch, AgentOrchestrator, DecisionFreshness, PriorityScore};
 pub use replay::{
     ActionOutcomeSummary, DecisionTrace, EncounterTransition, ReplayFile, ReplayHeader,
@@ -85,6 +88,7 @@ pub use telemetry::{
     AgentTrajectoryFrame, TelemetryArchive, TelemetryConfig, TickTelemetryFrame, ToolCallStatus,
     TrajectorySample,
 };
+pub use toon::{decode_toon_value, encode_toon_document, encode_toon_string};
 pub use world::World;
 
 /// Fixed tick rate — all agents operate on the same clock

--- a/crates/pod-core/src/ops.rs
+++ b/crates/pod-core/src/ops.rs
@@ -1,0 +1,37 @@
+use serde::{Deserialize, Serialize};
+
+use crate::toon::encode_toon_document;
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum IncidentSeverity {
+    #[default]
+    Healthy,
+    Warning,
+    Critical,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ShardIncidentSummary {
+    pub shard_id: String,
+    pub latest_tick: u64,
+    pub severity: IncidentSeverity,
+    pub summary: String,
+    pub tick_budget_overrun_rate: f32,
+    pub action_rejection_rate: f32,
+    pub tool_call_error_rate: f32,
+    pub average_tool_latency_ms: f32,
+    pub average_trajectory_distance: f32,
+    pub peak_entity_count: usize,
+    pub peak_agent_count: usize,
+    pub capture_actions: usize,
+    pub summon_actions: usize,
+    pub gather_actions: usize,
+    pub loot_actions: usize,
+    pub notes: Vec<String>,
+}
+
+impl ShardIncidentSummary {
+    pub fn to_toon_document(&self) -> String {
+        encode_toon_document("shard_incident_summary", self)
+    }
+}

--- a/crates/pod-core/src/replay.rs
+++ b/crates/pod-core/src/replay.rs
@@ -19,6 +19,7 @@ use crate::observation::Observation;
 use crate::telemetry::{
     ActionLifecycleStage, AgentToolCallTrace, TickTelemetryFrame, ToolCallStatus,
 };
+use crate::toon::encode_toon_document;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -43,6 +44,12 @@ pub struct DecisionTrace {
     pub tool_calls: Vec<AgentToolCallTrace>,
     /// How long the API took to respond (ms)
     pub latency_ms: u32,
+}
+
+impl DecisionTrace {
+    pub fn to_toon_document(&self) -> String {
+        encode_toon_document("decision_trace", self)
+    }
 }
 
 /// A complete recording of one simulation run
@@ -98,6 +105,12 @@ pub struct ReplayTrainingSample {
     pub encounter_transition: Option<EncounterTransition>,
     pub tool_call_latency_ms: u32,
     pub tool_call_error_count: usize,
+}
+
+impl ReplayTrainingSample {
+    pub fn to_toon_document(&self) -> String {
+        encode_toon_document("replay_training_sample", self)
+    }
 }
 
 impl ReplayFile {
@@ -160,6 +173,30 @@ impl ReplayFile {
         }
 
         samples
+    }
+
+    pub fn to_toon_document(&self) -> String {
+        #[derive(Serialize)]
+        struct ReplayExport<'a> {
+            header: &'a ReplayHeader,
+            traces: &'a [Vec<DecisionTrace>],
+            telemetry_windows: &'a [TickTelemetryFrame],
+            training_samples: Vec<ReplayTrainingSample>,
+        }
+
+        encode_toon_document(
+            "replay_file",
+            &ReplayExport {
+                header: &self.header,
+                traces: &self.traces,
+                telemetry_windows: &self.telemetry_windows,
+                training_samples: self.training_samples(),
+            },
+        )
+    }
+
+    pub fn training_samples_to_toon_document(&self) -> String {
+        encode_toon_document("replay_training_samples", &self.training_samples())
     }
 }
 
@@ -400,6 +437,7 @@ mod tests {
     use crate::telemetry::{
         ActionLifecycleStage, ActionSource, AgentTelemetryFrame, TrajectorySample,
     };
+    use crate::toon::decode_toon_value;
     use glam::Vec2;
 
     #[test]
@@ -634,5 +672,50 @@ mod tests {
                 in_combat: false
             })
         ));
+    }
+
+    #[test]
+    fn replay_exports_roundtrip_through_toon_documents() {
+        let agent_id = AgentId::new();
+        let file = ReplayFile {
+            header: ReplayHeader {
+                name: "toon-replay".into(),
+                timestamp: 0,
+                world_seed: 7,
+                tick_count: 1,
+                agent_count: 1,
+                notes: String::new(),
+            },
+            traces: vec![vec![DecisionTrace {
+                tick: 0,
+                agent_id,
+                observation_hash: 42,
+                prompt_sent: "observe".into(),
+                raw_response: "act".into(),
+                actions_taken: vec![Action::Idle],
+                tool_calls: vec![AgentToolCallTrace::success(
+                    0,
+                    "llm.complete",
+                    "qwen",
+                    25,
+                    90,
+                    18,
+                )],
+                latency_ms: 25,
+            }]],
+            telemetry_windows: vec![TickTelemetryFrame::empty(0)],
+        };
+
+        let replay_document = file.to_toon_document();
+        let replay_value =
+            decode_toon_value(&replay_document).expect("replay document should decode");
+        assert_eq!(replay_value["document_type"], "replay_file");
+        assert_eq!(replay_value["payload"]["header"]["name"], "toon-replay");
+        assert_eq!(replay_value["payload"]["telemetry_windows"][0]["tick"], 0);
+
+        let training_document = file.training_samples_to_toon_document();
+        let training_value =
+            decode_toon_value(&training_document).expect("training document should decode");
+        assert_eq!(training_value["document_type"], "replay_training_samples");
     }
 }

--- a/crates/pod-core/src/telemetry.rs
+++ b/crates/pod-core/src/telemetry.rs
@@ -7,6 +7,7 @@ use crate::action::Action;
 use crate::component::EncounterState;
 use crate::contract::AgentRuntimeProfile;
 use crate::id::{AgentId, EntityId};
+use crate::toon::encode_toon_document;
 
 /// Shared retention defaults for telemetry consumers across runtime, browser,
 /// and editor tooling.
@@ -52,6 +53,10 @@ impl TrajectorySample {
             velocity,
             rotation,
         }
+    }
+
+    pub fn to_toon_document(&self) -> String {
+        encode_toon_document("trajectory_sample", self)
     }
 }
 
@@ -116,6 +121,10 @@ impl AgentActionTrace {
             action,
             rejection_reason,
         }
+    }
+
+    pub fn to_toon_document(&self) -> String {
+        encode_toon_document("agent_action_trace", self)
     }
 }
 
@@ -207,6 +216,10 @@ impl AgentToolCallTrace {
             Some(error_message.into()),
         )
     }
+
+    pub fn to_toon_document(&self) -> String {
+        encode_toon_document("agent_tool_call_trace", self)
+    }
 }
 
 /// Authoritative telemetry for one agent over one simulation tick.
@@ -285,6 +298,10 @@ impl AgentTelemetryFrame {
             self.trajectory = Some(AgentTrajectoryFrame::new(end, end));
         }
     }
+
+    pub fn to_toon_document(&self) -> String {
+        encode_toon_document("agent_telemetry_frame", self)
+    }
 }
 
 /// Telemetry for the full authoritative tick.
@@ -300,6 +317,10 @@ impl TickTelemetryFrame {
             tick,
             agents: Vec::new(),
         }
+    }
+
+    pub fn to_toon_document(&self) -> String {
+        encode_toon_document("tick_telemetry_frame", self)
     }
 }
 
@@ -357,6 +378,26 @@ impl TelemetryArchive {
         }
         samples
     }
+
+    pub fn to_toon_document(&self) -> String {
+        #[derive(Serialize)]
+        struct ArchiveExport<'a> {
+            max_frames: usize,
+            retained_frames: usize,
+            latest_tick: Option<u64>,
+            frames: &'a VecDeque<TickTelemetryFrame>,
+        }
+
+        encode_toon_document(
+            "telemetry_archive",
+            &ArchiveExport {
+                max_frames: self.max_frames,
+                retained_frames: self.frames.len(),
+                latest_tick: self.latest().map(|frame| frame.tick),
+                frames: &self.frames,
+            },
+        )
+    }
 }
 
 #[cfg(test)]
@@ -365,6 +406,8 @@ mod tests {
 
     use crate::agent::AgentType;
     use crate::contract::{AgentCapabilities, AgentRole};
+
+    use crate::toon::decode_toon_value;
 
     use super::{
         AgentTelemetryFrame, AgentToolCallTrace, TelemetryArchive, TelemetryConfig,
@@ -473,5 +516,23 @@ mod tests {
             .map(|frame| frame.tick)
             .collect::<Vec<_>>();
         assert_eq!(ticks, vec![2, 3]);
+    }
+
+    #[test]
+    fn telemetry_exports_roundtrip_through_toon_documents() {
+        let mut archive = TelemetryArchive::with_capacity(2);
+        archive.record_tick(TickTelemetryFrame::empty(7));
+
+        let frame_document = archive.latest().expect("frame recorded").to_toon_document();
+        let frame_value = decode_toon_value(&frame_document).expect("frame document should decode");
+        assert_eq!(frame_value["document_type"], "tick_telemetry_frame");
+        assert_eq!(frame_value["payload"]["tick"], 7);
+
+        let archive_document = archive.to_toon_document();
+        let archive_value =
+            decode_toon_value(&archive_document).expect("archive document should decode");
+        assert_eq!(archive_value["document_type"], "telemetry_archive");
+        assert_eq!(archive_value["payload"]["retained_frames"], 1);
+        assert_eq!(archive_value["payload"]["latest_tick"], 7);
     }
 }

--- a/crates/pod-core/src/toon.rs
+++ b/crates/pod-core/src/toon.rs
@@ -1,0 +1,61 @@
+use serde::Serialize;
+use serde_json::Value;
+use toon_format::{decode_default as decode_toon, encode_default as encode_toon};
+
+#[derive(Serialize)]
+struct ToonDocument<'a, T: Serialize> {
+    document_type: &'static str,
+    payload: &'a T,
+}
+
+/// Encode a serializable value using official TOON, with JSON fallback for
+/// callers that still need a debuggable payload on encoding failure.
+pub fn encode_toon_string<T: Serialize>(value: &T) -> String {
+    encode_toon(value).unwrap_or_else(|_| {
+        serde_json::to_string_pretty(value).unwrap_or_else(|_| "{}".to_string())
+    })
+}
+
+/// Wrap a serializable payload in a lightweight typed document envelope and
+/// encode it as official TOON.
+pub fn encode_toon_document<T: Serialize>(document_type: &'static str, payload: &T) -> String {
+    encode_toon_string(&ToonDocument {
+        document_type,
+        payload,
+    })
+}
+
+/// Decode a TOON document into JSON for tests and tooling that want to assert
+/// on structured content without depending on the TOON crate directly.
+pub fn decode_toon_value(document: &str) -> Result<Value, String> {
+    decode_toon(document).map_err(|error| error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::Serialize;
+
+    use super::{decode_toon_value, encode_toon_document};
+
+    #[derive(Serialize)]
+    struct SamplePayload<'a> {
+        label: &'a str,
+        count: usize,
+    }
+
+    #[test]
+    fn typed_documents_roundtrip_through_toon() {
+        let document = encode_toon_document(
+            "sample_payload",
+            &SamplePayload {
+                label: "monster",
+                count: 2,
+            },
+        );
+
+        let decoded = decode_toon_value(&document).expect("TOON document should decode");
+        assert_eq!(decoded["document_type"], "sample_payload");
+        assert_eq!(decoded["payload"]["label"], "monster");
+        assert_eq!(decoded["payload"]["count"], 2);
+    }
+}

--- a/crates/pod-editor/src/lib.rs
+++ b/crates/pod-editor/src/lib.rs
@@ -12,8 +12,8 @@
 use eframe::{App, Frame};
 use egui::{CentralPanel, Context, SidePanel, TopBottomPanel, Ui};
 use pod_core::{
-    ActionLifecycleStage, AgentTelemetryFrame, AgentType, TelemetryConfig, TickTelemetryFrame,
-    ToolCallStatus, TrajectorySample,
+    encode_toon_document, ActionLifecycleStage, AgentTelemetryFrame, AgentType, CreatureIdentity,
+    CreatureTemperament, TelemetryConfig, TickTelemetryFrame, ToolCallStatus, TrajectorySample,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
@@ -676,6 +676,10 @@ impl SpacetimeDashboardState {
             })
             .collect();
     }
+
+    pub fn to_toon_document(&self) -> String {
+        encode_toon_document("editor_spacetime_dashboard", self)
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -750,6 +754,10 @@ impl TelemetryPanelState {
                     .unwrap_or_default()
             })
             .sum()
+    }
+
+    pub fn to_toon_document(&self) -> String {
+        encode_toon_document("editor_telemetry_panel", self)
     }
 }
 
@@ -1000,6 +1008,286 @@ impl AssetBrowserState {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum CreatorNodeKind {
+    Model,
+    Object,
+    Monster,
+    Entity,
+    BehaviorTree,
+    StateMachine,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum CreatorAssociationKind {
+    VisualModel,
+    SceneEntity,
+    EncounterTrigger,
+    CompanionBond,
+    BehaviorSource,
+    StateSource,
+    DependsOn,
+}
+
+impl CreatorAssociationKind {
+    fn label(self) -> &'static str {
+        match self {
+            Self::VisualModel => "visual-model",
+            Self::SceneEntity => "scene-entity",
+            Self::EncounterTrigger => "encounter-trigger",
+            Self::CompanionBond => "companion-bond",
+            Self::BehaviorSource => "behavior-source",
+            Self::StateSource => "state-source",
+            Self::DependsOn => "depends-on",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CreatorEntityDefinition {
+    pub id: String,
+    pub name: String,
+    pub entity_id: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CreatorModelDefinition {
+    pub id: String,
+    pub name: String,
+    pub asset_id: String,
+    pub asset_path: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CreatorObjectDefinition {
+    pub id: String,
+    pub name: String,
+    pub entity_id: Option<u64>,
+    pub model_id: Option<String>,
+    pub tags: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CreatorMonsterDefinition {
+    pub id: String,
+    pub name: String,
+    pub entity_id: Option<u64>,
+    pub model_id: Option<String>,
+    pub creature: CreatureIdentity,
+    pub tags: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CreatorAssociation {
+    pub from_id: String,
+    pub from_kind: CreatorNodeKind,
+    pub to_id: String,
+    pub to_kind: CreatorNodeKind,
+    pub relation: CreatorAssociationKind,
+    pub label: String,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct CreatorCatalog {
+    pub entities: Vec<CreatorEntityDefinition>,
+    pub models: Vec<CreatorModelDefinition>,
+    pub objects: Vec<CreatorObjectDefinition>,
+    pub monsters: Vec<CreatorMonsterDefinition>,
+    pub associations: Vec<CreatorAssociation>,
+}
+
+fn creator_slug(value: &str) -> String {
+    let slug = value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() {
+                ch.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>();
+    let compact = slug
+        .split('-')
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("-");
+    if compact.is_empty() {
+        "entry".to_string()
+    } else {
+        compact
+    }
+}
+
+impl CreatorCatalog {
+    fn ensure_entity(&mut self, entity_id: u64, name: impl Into<String>) -> String {
+        let id = format!("entity:{entity_id}");
+        if !self.entities.iter().any(|entity| entity.id == id) {
+            self.entities.push(CreatorEntityDefinition {
+                id: id.clone(),
+                name: name.into(),
+                entity_id,
+            });
+        }
+        id
+    }
+
+    fn ensure_model_for_asset(&mut self, asset: &EditorAsset) -> String {
+        let id = format!("model:{}", asset.id);
+        if !self.models.iter().any(|model| model.id == id) {
+            self.models.push(CreatorModelDefinition {
+                id: id.clone(),
+                name: asset.label.clone(),
+                asset_id: asset.id.clone(),
+                asset_path: asset.path.clone(),
+            });
+        }
+        id
+    }
+
+    fn associate(
+        &mut self,
+        from_id: impl Into<String>,
+        from_kind: CreatorNodeKind,
+        to_id: impl Into<String>,
+        to_kind: CreatorNodeKind,
+        relation: CreatorAssociationKind,
+        label: impl Into<String>,
+    ) {
+        let association = CreatorAssociation {
+            from_id: from_id.into(),
+            from_kind,
+            to_id: to_id.into(),
+            to_kind,
+            relation,
+            label: label.into(),
+        };
+
+        if self.associations.iter().any(|existing| {
+            existing.from_id == association.from_id
+                && existing.from_kind == association.from_kind
+                && existing.to_id == association.to_id
+                && existing.to_kind == association.to_kind
+                && existing.relation == association.relation
+        }) {
+            return;
+        }
+
+        self.associations.push(association);
+    }
+
+    fn create_object(
+        &mut self,
+        name: impl Into<String>,
+        entity_id: Option<u64>,
+        entity_label: Option<&str>,
+        asset: Option<&EditorAsset>,
+    ) -> String {
+        let name = name.into();
+        let id = format!("object:{}", creator_slug(&name));
+        let model_id = asset.map(|asset| self.ensure_model_for_asset(asset));
+
+        if let Some(existing) = self.objects.iter_mut().find(|object| object.id == id) {
+            existing.entity_id = entity_id.or(existing.entity_id);
+            if model_id.is_some() {
+                existing.model_id = model_id.clone();
+            }
+        } else {
+            self.objects.push(CreatorObjectDefinition {
+                id: id.clone(),
+                name: name.clone(),
+                entity_id,
+                model_id: model_id.clone(),
+                tags: vec!["object".to_string()],
+            });
+        }
+
+        if let Some(asset) = asset {
+            let model_id = model_id.expect("model id should exist when asset is present");
+            self.associate(
+                id.clone(),
+                CreatorNodeKind::Object,
+                model_id,
+                CreatorNodeKind::Model,
+                CreatorAssociationKind::VisualModel,
+                format!("{name} uses {}", asset.label),
+            );
+        }
+
+        if let Some(entity_id) = entity_id {
+            let entity_name = entity_label.unwrap_or("Entity");
+            let entity_ref = self.ensure_entity(entity_id, entity_name.to_string());
+            self.associate(
+                id.clone(),
+                CreatorNodeKind::Object,
+                entity_ref,
+                CreatorNodeKind::Entity,
+                CreatorAssociationKind::SceneEntity,
+                format!("{name} is placed on entity #{entity_id}"),
+            );
+        }
+
+        id
+    }
+
+    fn create_monster(
+        &mut self,
+        name: impl Into<String>,
+        entity_id: Option<u64>,
+        entity_label: Option<&str>,
+        asset: Option<&EditorAsset>,
+        creature: CreatureIdentity,
+    ) -> String {
+        let name = name.into();
+        let id = format!("monster:{}", creator_slug(&name));
+        let model_id = asset.map(|asset| self.ensure_model_for_asset(asset));
+
+        if let Some(existing) = self.monsters.iter_mut().find(|monster| monster.id == id) {
+            existing.entity_id = entity_id.or(existing.entity_id);
+            if model_id.is_some() {
+                existing.model_id = model_id.clone();
+            }
+            existing.creature = creature.clone();
+        } else {
+            self.monsters.push(CreatorMonsterDefinition {
+                id: id.clone(),
+                name: name.clone(),
+                entity_id,
+                model_id: model_id.clone(),
+                creature,
+                tags: vec!["monster".to_string(), "creature".to_string()],
+            });
+        }
+
+        if let Some(asset) = asset {
+            let model_id = model_id.expect("model id should exist when asset is present");
+            self.associate(
+                id.clone(),
+                CreatorNodeKind::Monster,
+                model_id,
+                CreatorNodeKind::Model,
+                CreatorAssociationKind::VisualModel,
+                format!("{name} uses {}", asset.label),
+            );
+        }
+
+        if let Some(entity_id) = entity_id {
+            let entity_name = entity_label.unwrap_or("Entity");
+            let entity_ref = self.ensure_entity(entity_id, entity_name.to_string());
+            self.associate(
+                id.clone(),
+                CreatorNodeKind::Monster,
+                entity_ref,
+                CreatorNodeKind::Entity,
+                CreatorAssociationKind::SceneEntity,
+                format!("{name} is bound to entity #{entity_id}"),
+            );
+        }
+
+        id
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum PlayState {
     Stopped,
     Playing,
@@ -1096,6 +1384,26 @@ impl SceneHierarchy {
         self.roots
             .iter()
             .any(|node| node.contains_entity(entity_id))
+    }
+
+    pub fn entity_label(&self, entity_id: u64) -> Option<&str> {
+        fn find_label(node: &HierarchyNode, entity_id: u64) -> Option<&str> {
+            if node.entity_id == entity_id {
+                return Some(node.label.as_str());
+            }
+
+            for child in &node.children {
+                if let Some(label) = find_label(child, entity_id) {
+                    return Some(label);
+                }
+            }
+
+            None
+        }
+
+        self.roots
+            .iter()
+            .find_map(|node| find_label(node, entity_id))
     }
 
     pub fn render(&mut self, ui: &mut Ui, selected_entity: &mut Option<u64>) {
@@ -1226,6 +1534,7 @@ pub struct EditorState {
     pub llm_agent_config: LlmAgentConfig,
     pub telemetry: TelemetryPanelState,
     pub spacetime_dashboard: SpacetimeDashboardState,
+    pub creator_catalog: CreatorCatalog,
 }
 
 impl Default for EditorState {
@@ -1237,6 +1546,22 @@ impl Default for EditorState {
             transforms_2d.insert(entity_id, Transform2D::with_defaults(entity_id));
         }
 
+        let hierarchy = SceneHierarchy::default();
+        let asset_browser = AssetBrowserState::default();
+        let mut creator_catalog = CreatorCatalog::default();
+        if let Some(asset) = asset_browser
+            .assets
+            .iter()
+            .find(|asset| asset.id == "hero_character")
+        {
+            creator_catalog.create_object(
+                "player-avatar",
+                Some(1001),
+                hierarchy.entity_label(1001),
+                Some(asset),
+            );
+        }
+
         Self {
             project_name: "Unnamed Project".to_string(),
             active_panel: EditorPanel::Viewport,
@@ -1245,20 +1570,77 @@ impl Default for EditorState {
             run_state: PlayState::Stopped,
             viewport_mode: ViewportMode::TwoD,
             viewport_3d: Viewport3DState::default(),
-            hierarchy: SceneHierarchy::default(),
+            hierarchy,
             inspector_data,
             transforms_2d,
             console_output: vec![
                 "prompt-or-die editor launched".to_string(),
                 "dock: hierarchy(left), inspector(right), console(bottom)".to_string(),
             ],
-            asset_browser: AssetBrowserState::default(),
+            asset_browser,
             behavior_tree: BehaviorTree::default(),
             fsm: FiniteStateMachine::default(),
             llm_agent_config: LlmAgentConfig::default(),
             telemetry: TelemetryPanelState::default(),
             spacetime_dashboard: SpacetimeDashboardState::default(),
+            creator_catalog,
         }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct EditorSnapshotExport {
+    pub project_name: String,
+    pub active_panel: EditorPanel,
+    pub selected_entity: Option<u64>,
+    pub selected_asset: Option<String>,
+    pub hierarchy: SceneHierarchy,
+    pub selected_entity_properties: Option<HashMap<String, String>>,
+    pub selected_entity_transform: Option<Transform2D>,
+    pub selected_entity_trajectory: Vec<TrajectorySample>,
+    pub assets: Vec<EditorAsset>,
+    pub creator_catalog: CreatorCatalog,
+    pub behavior_tree: BehaviorTree,
+    pub fsm: FiniteStateMachine,
+    pub latest_tick_telemetry: Option<TickTelemetryFrame>,
+    pub spacetime_dashboard: SpacetimeDashboardState,
+}
+
+impl EditorSnapshotExport {
+    fn from_state(state: &EditorState) -> Self {
+        let selected_entity_properties = state
+            .selected_entity
+            .and_then(|entity_id| state.inspector_data.get(&entity_id))
+            .map(|properties| properties.entries.clone());
+        let selected_entity_transform = state
+            .selected_entity
+            .and_then(|entity_id| state.transforms_2d.get(&entity_id))
+            .cloned();
+        let selected_entity_trajectory = state
+            .selected_entity
+            .map(|entity_id| state.telemetry.trajectory_for_entity(entity_id))
+            .unwrap_or_default();
+
+        Self {
+            project_name: state.project_name.clone(),
+            active_panel: state.active_panel,
+            selected_entity: state.selected_entity,
+            selected_asset: state.asset_browser.selected.clone(),
+            hierarchy: state.hierarchy.clone(),
+            selected_entity_properties,
+            selected_entity_transform,
+            selected_entity_trajectory,
+            assets: state.asset_browser.assets.clone(),
+            creator_catalog: state.creator_catalog.clone(),
+            behavior_tree: state.behavior_tree.clone(),
+            fsm: state.fsm.clone(),
+            latest_tick_telemetry: state.telemetry.latest().cloned(),
+            spacetime_dashboard: state.spacetime_dashboard.clone(),
+        }
+    }
+
+    pub fn to_toon_document(&self) -> String {
+        encode_toon_document("editor_world_snapshot", self)
     }
 }
 
@@ -1405,6 +1787,143 @@ impl PodEditorApp {
 
     pub fn selected_asset_label(&self) -> Option<&str> {
         self.state.asset_browser.selected.as_deref()
+    }
+
+    fn selected_asset(&self) -> Option<&EditorAsset> {
+        let selected = self.state.asset_browser.selected.as_deref()?;
+        self.state
+            .asset_browser
+            .assets
+            .iter()
+            .find(|asset| asset.id == selected)
+    }
+
+    pub fn set_selected_asset(&mut self, asset_id: impl Into<String>) -> bool {
+        let asset_id = asset_id.into();
+        if !self
+            .state
+            .asset_browser
+            .assets
+            .iter()
+            .any(|asset| asset.id == asset_id)
+        {
+            return false;
+        }
+
+        self.history.remember(self.state.clone());
+        self.state.asset_browser.select(asset_id.clone());
+        self.push_console(format!("Selected asset {asset_id}"));
+        true
+    }
+
+    pub fn create_model_from_asset_id(&mut self, asset_id: &str) -> Option<String> {
+        let asset = self
+            .state
+            .asset_browser
+            .assets
+            .iter()
+            .find(|asset| asset.id == asset_id)
+            .cloned()?;
+
+        self.history.remember(self.state.clone());
+        let model_id = self.state.creator_catalog.ensure_model_for_asset(&asset);
+        self.push_console(format!("Created model {model_id} from {}", asset.label));
+        Some(model_id)
+    }
+
+    pub fn create_object_from_selection(&mut self, name: impl Into<String>) -> Option<String> {
+        let name = name.into();
+        if name.trim().is_empty() {
+            return None;
+        }
+
+        let selected_entity = self.state.selected_entity;
+        let entity_label = selected_entity.and_then(|entity_id| {
+            self.state
+                .hierarchy
+                .entity_label(entity_id)
+                .map(str::to_string)
+        });
+        let selected_asset = self.selected_asset().cloned();
+
+        self.history.remember(self.state.clone());
+        let object_id = self.state.creator_catalog.create_object(
+            name.clone(),
+            selected_entity,
+            entity_label.as_deref(),
+            selected_asset.as_ref(),
+        );
+        self.push_console(format!("Created object {name} ({object_id})"));
+        Some(object_id)
+    }
+
+    pub fn create_monster_from_selection(
+        &mut self,
+        name: impl Into<String>,
+        temperament: CreatureTemperament,
+    ) -> Option<String> {
+        let name = name.into();
+        if name.trim().is_empty() {
+            return None;
+        }
+
+        let selected_entity = self.state.selected_entity;
+        let entity_label = selected_entity.and_then(|entity_id| {
+            self.state
+                .hierarchy
+                .entity_label(entity_id)
+                .map(str::to_string)
+        });
+        let selected_asset = self.selected_asset().cloned();
+        let creature = CreatureIdentity {
+            species_id: creator_slug(&name),
+            species_name: name.clone(),
+            temperament,
+            ..CreatureIdentity::default()
+        };
+
+        self.history.remember(self.state.clone());
+        let monster_id = self.state.creator_catalog.create_monster(
+            name.clone(),
+            selected_entity,
+            entity_label.as_deref(),
+            selected_asset.as_ref(),
+            creature,
+        );
+        self.push_console(format!("Created monster {name} ({monster_id})"));
+        Some(monster_id)
+    }
+
+    pub fn associate_creator_content(
+        &mut self,
+        from_id: impl Into<String>,
+        from_kind: CreatorNodeKind,
+        to_id: impl Into<String>,
+        to_kind: CreatorNodeKind,
+        relation: CreatorAssociationKind,
+        label: impl Into<String>,
+    ) {
+        let from_id = from_id.into();
+        let to_id = to_id.into();
+        let label = label.into();
+
+        self.history.remember(self.state.clone());
+        self.state.creator_catalog.associate(
+            from_id.clone(),
+            from_kind,
+            to_id.clone(),
+            to_kind,
+            relation,
+            label.clone(),
+        );
+        self.push_console(format!(
+            "Associated {from_id} -> {to_id} ({})",
+            relation.label()
+        ));
+    }
+
+    pub fn export_snapshot_toon_document(&self) -> String {
+        EditorSnapshotExport::from_state(&self.state).to_toon_document()
     }
 
     pub fn can_undo(&self) -> bool {
@@ -1573,9 +2092,8 @@ impl PodEditorApp {
 
     fn build_dock_toolbar(&mut self, ui: &mut Ui) {
         if ui.button("Project").clicked() {
-            let snapshot = serde_json::to_string_pretty(&self.state)
-                .unwrap_or_else(|_| "serialization failed".to_string());
-            self.push_console(format!("Project snapshot {snapshot}"));
+            let snapshot = self.export_snapshot_toon_document();
+            self.push_console(format!("Project TOON snapshot {snapshot}"));
         }
         ui.separator();
         if ui
@@ -2518,9 +3036,9 @@ pub fn launch_headless_editor() -> Result<(), eframe::Error> {
 mod tests {
     use super::*;
     use pod_core::{
-        Action, ActionLifecycleStage, ActionSource, AgentCapabilities, AgentId, AgentRole,
-        AgentRuntimeProfile, AgentTelemetryFrame, AgentToolCallTrace, EntityId, TickTelemetryFrame,
-        ToolCallStatus,
+        decode_toon_value, Action, ActionLifecycleStage, ActionSource, AgentCapabilities, AgentId,
+        AgentRole, AgentRuntimeProfile, AgentTelemetryFrame, AgentToolCallTrace,
+        CreatureTemperament, EntityId, TickTelemetryFrame, ToolCallStatus,
     };
 
     fn sample_tick_telemetry(tick: u64, entity_id: u64) -> TickTelemetryFrame {
@@ -2855,6 +3373,103 @@ mod tests {
             app.state.spacetime_dashboard.agent_summaries[0].entity_id,
             Some(1001)
         );
+    }
+
+    #[test]
+    fn creator_catalog_links_models_objects_and_monsters() {
+        let mut app = PodEditorApp::default();
+        assert!(app
+            .state
+            .creator_catalog
+            .objects
+            .iter()
+            .any(|object| object.id == "object:player-avatar"));
+
+        assert!(app.set_selected_asset("hero_character"));
+        let object_id = app
+            .create_object_from_selection("oak-crate")
+            .expect("object should be created");
+        let monster_id = app
+            .create_monster_from_selection("ember-fox", CreatureTemperament::Aggressive)
+            .expect("monster should be created");
+        app.associate_creator_content(
+            monster_id.clone(),
+            CreatorNodeKind::Monster,
+            object_id.clone(),
+            CreatorNodeKind::Object,
+            CreatorAssociationKind::EncounterTrigger,
+            "ember-fox guards the oak-crate",
+        );
+
+        assert!(app
+            .state
+            .creator_catalog
+            .associations
+            .iter()
+            .any(|association| {
+                association.from_id == object_id
+                    && association.relation == CreatorAssociationKind::VisualModel
+            }));
+        assert!(app
+            .state
+            .creator_catalog
+            .associations
+            .iter()
+            .any(|association| {
+                association.from_id == monster_id
+                    && association.relation == CreatorAssociationKind::VisualModel
+            }));
+        assert!(app
+            .state
+            .creator_catalog
+            .associations
+            .iter()
+            .any(|association| {
+                association.from_id == monster_id
+                    && association.to_id == object_id
+                    && association.relation == CreatorAssociationKind::EncounterTrigger
+            }));
+    }
+
+    #[test]
+    fn editor_snapshot_exports_to_toon_for_world_building_agents() {
+        let mut app = PodEditorApp::default();
+        assert!(app.set_selected_asset("hero_character"));
+        let monster_id = app
+            .create_monster_from_selection("storm-lark", CreatureTemperament::Loyal)
+            .expect("monster should be created");
+        app.record_tick_telemetry(sample_tick_telemetry(13, 1001));
+
+        let snapshot = app.export_snapshot_toon_document();
+        let value = decode_toon_value(&snapshot).expect("snapshot should decode");
+        assert_eq!(value["document_type"], "editor_world_snapshot");
+        assert_eq!(value["payload"]["selected_entity"], 1001);
+        assert_eq!(
+            value["payload"]["creator_catalog"]["monsters"][0]["id"],
+            monster_id
+        );
+        assert_eq!(value["payload"]["latest_tick_telemetry"]["tick"], 13);
+    }
+
+    #[test]
+    fn editor_telemetry_surfaces_export_to_toon_documents() {
+        let mut app = PodEditorApp::default();
+        app.record_tick_telemetry(sample_tick_telemetry(14, 1001));
+
+        let telemetry_document = app.state.telemetry.to_toon_document();
+        let telemetry_value =
+            decode_toon_value(&telemetry_document).expect("telemetry document should decode");
+        assert_eq!(telemetry_value["document_type"], "editor_telemetry_panel");
+        assert_eq!(telemetry_value["payload"]["timeline"][0]["tick"], 14);
+
+        let dashboard_document = app.state.spacetime_dashboard.to_toon_document();
+        let dashboard_value =
+            decode_toon_value(&dashboard_document).expect("dashboard document should decode");
+        assert_eq!(
+            dashboard_value["document_type"],
+            "editor_spacetime_dashboard"
+        );
+        assert_eq!(dashboard_value["payload"]["latest_tick"], 14);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add shared official TOON document helpers in pod-core and expose TOON exports for replay, telemetry, tool/runtime contracts, and shard incident summaries
- export embedded LLM tool traces, editor world-building snapshots, and creator-facing object/model/monster associations in TOON
- wire pod-server ops summaries and pod-editor project snapshots to the shared TOON surface with deterministic coverage

## Validation
- cargo test -p pod-core --lib
- cargo test -p pod-agents --lib
- cargo test -p pod-editor --lib
- cargo test -p pod-server --bin pod-server

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added incident summary API to monitor shard health with severity levels and threshold-based warnings.
  * Enabled serialization of telemetry, decision logs, and replay data to standardized formats for enhanced interoperability.
  * Introduced creator catalog system to the editor for managing content relationships and entities.
  * Added world-snapshot export functionality for editor state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->