### PR TITLE
Add TOON telemetry transport and debug consumers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3902,6 +3902,7 @@ version = "0.1.0"
 dependencies = [
  "glam",
  "log",
+ "pod-core",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "serde",

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -576,5 +576,25 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cargo test -p pod-editor --lib`
   - `cargo test -p pod-server --bin pod-server`
 
-**Last updated**: Iteration 64
-**Current focus**: Iteration 65 TOON-backed direct-connect and SpacetimeDB telemetry export parity, plus browser/editor consumption of replay and incident summaries for live debugging, training, and shard operations
+### Iteration 65 — TOON Telemetry Transport Parity and Debug Consumer Ingestion
+
+- [x] Added typed TOON decode helpers in `pod-core` so downstream consumers can validate document kinds and extract payloads without reimplementing TOON envelope parsing.
+- [x] Switched direct-connect debug telemetry transport in `pod-net` from the legacy JSON wrapper to the versioned TOON telemetry contract while keeping gameplay-state traffic unchanged.
+- [x] Updated `pod-net` and `pod-stdb` debug telemetry tests/fixtures to use official TOON documents, and added neutral `last_debug_telemetry_document()` accessors without breaking existing string-based callers.
+- [x] Added official TOON parsing to `apps/pod-web` using the TypeScript TOON package, extending the existing browser contract layer to consume TOON tick telemetry, replay files, and shard incident summaries alongside JSON fallback.
+- [x] Added browser-side replay and incident summary consumption APIs plus HUD surfacing so the flagship WebGPU client can ingest TOON replay/debug artifacts directly.
+- [x] Extended `pod-editor` to import replay and shard incident TOON documents, wiring replay telemetry windows into the existing telemetry panel/dashboard and incident summaries into the operational dashboard state.
+- [x] Expanded the editor dashboard with average tool latency, average trajectory distance, MMO-loop action counts, and retained incident summaries so creator tooling stays connected to runtime/ops artifacts.
+- [x] Added deterministic coverage for TOON telemetry round-tripping in `pod-net`, SpacetimeDB client/debug events using TOON documents, browser TOON parsing/summaries, and editor replay/incident ingestion.
+- [x] Validated touched targets:
+  - `cargo test -p pod-core --lib`
+  - `cargo test -p pod-net --lib`
+  - `cargo test -p pod-net --features spacetimedb --lib`
+  - `cargo test -p pod-stdb --no-default-features --features client`
+  - `cargo test -p pod-editor --lib`
+  - `bun test`
+  - `bun run typecheck`
+  - `bun run build`
+
+**Last updated**: Iteration 65
+**Current focus**: Iteration 66 TOON-backed tool-call event and telemetry rollup parity across SpacetimeDB/browser/editor consumers, plus live replay/incident streaming hooks for shard debug operations

--- a/apps/pod-web/bun.lock
+++ b/apps/pod-web/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "@prompt-or-die/pod-web",
       "dependencies": {
+        "@toon-format/toon": "^2.1.0",
         "three": "^0.182.0",
       },
       "devDependencies": {
@@ -119,6 +120,8 @@
     "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA=="],
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA=="],
+
+    "@toon-format/toon": ["@toon-format/toon@2.1.0", "", {}, "sha512-JwWptdF5eOA0HaQxbKAzkpQtR4wSWTEfDlEy/y3/4okmOAX1qwnpLZMmtEWr+ncAhTTY1raCKH0kteHhSXnQqg=="],
 
     "@tweenjs/tween.js": ["@tweenjs/tween.js@23.1.3", "", {}, "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA=="],
 

--- a/apps/pod-web/index.html
+++ b/apps/pod-web/index.html
@@ -176,6 +176,10 @@
           <dd id="telemetry-tools">No tool calls</dd>
           <dt>Recovery</dt>
           <dd id="telemetry-recovery">No recovery telemetry</dd>
+          <dt>Replay</dt>
+          <dd id="replay-summary">No replay summary loaded</dd>
+          <dt>Incident</dt>
+          <dd id="incident-summary">No shard incident summary loaded</dd>
         </dl>
       </section>
     </div>

--- a/apps/pod-web/package.json
+++ b/apps/pod-web/package.json
@@ -11,6 +11,7 @@
     "test": "bun test"
   },
   "dependencies": {
+    "@toon-format/toon": "^2.1.0",
     "three": "^0.182.0"
   },
   "devDependencies": {

--- a/apps/pod-web/src/contracts.test.ts
+++ b/apps/pod-web/src/contracts.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test";
+import { encode } from "@toon-format/toon";
+
+import {
+  parseReplayFile,
+  parseShardIncidentSummary,
+  parseTickTelemetryEnvelope,
+  summarizeReplayFile
+} from "./contracts";
+
+describe("TOON contract parsing", () => {
+  test("accepts versioned tick telemetry TOON documents", () => {
+    const document = encode({
+      document_type: "versioned_tick_telemetry",
+      payload: {
+        version: "V1",
+        payload: {
+          tick: 9,
+          agents: []
+        }
+      }
+    });
+
+    const envelope = parseTickTelemetryEnvelope(document);
+    expect(envelope.tickTelemetry.tick).toBe(9);
+    expect(envelope.tickTelemetry.agents).toEqual([]);
+  });
+
+  test("accepts replay TOON documents and builds summaries", () => {
+    const document = encode({
+      document_type: "replay_file",
+      payload: {
+        header: {
+          name: "flagship-mmo-loop",
+          timestamp: 1_741_315_200,
+          world_seed: 42,
+          tick_count: 120,
+          agent_count: 2,
+          notes: "acceptance"
+        },
+        traces: [
+          [
+            {
+              tick: 12,
+              agent_id: "agent-a",
+              observation_hash: 44,
+              prompt_sent: "observe",
+              raw_response: "idle",
+              actions_taken: [{ Idle: null }],
+              tool_calls: [
+                {
+                  tick: 12,
+                  tool_name: "llm.complete",
+                  provider: "qwen",
+                  status: "Succeeded",
+                  latency_ms: 48,
+                  request_units: 120,
+                  response_units: 40,
+                  error_message: null
+                }
+              ],
+              latency_ms: 48
+            }
+          ]
+        ],
+        telemetry_windows: [
+          {
+            tick: 12,
+            agents: []
+          }
+        ],
+        training_samples: [
+          {
+            tick: 12,
+            agent_id: "agent-a",
+            path_distance: 16.75,
+            action_outcomes: {
+              submitted: 1,
+              executed: 1,
+              rejected: 0,
+              queued: 0
+            },
+            encounter_transition: null,
+            tool_call_latency_ms: 48,
+            tool_call_error_count: 0
+          }
+        ]
+      }
+    });
+
+    const replay = parseReplayFile(document);
+    const summary = summarizeReplayFile(replay);
+
+    expect(replay.header.name).toBe("flagship-mmo-loop");
+    expect(summary.traceCount).toBe(1);
+    expect(summary.trainingSampleCount).toBe(1);
+    expect(summary.totalPathDistance).toBe(16.75);
+    expect(summary.latestTelemetryTick).toBe(12);
+  });
+
+  test("accepts shard incident summary TOON documents", () => {
+    const document = encode({
+      document_type: "shard_incident_summary",
+      payload: {
+        shard_id: "alpha-1",
+        latest_tick: 360,
+        severity: "Warning",
+        summary: "Shard alpha-1 requires attention",
+        tick_budget_overrun_rate: 0.08,
+        action_rejection_rate: 0.02,
+        tool_call_error_rate: 0.11,
+        average_tool_latency_ms: 820,
+        average_trajectory_distance: 3.2,
+        peak_entity_count: 512,
+        peak_agent_count: 128,
+        capture_actions: 4,
+        summon_actions: 2,
+        gather_actions: 7,
+        loot_actions: 9,
+        notes: ["tool-call error rate exceeds 10%"]
+      }
+    });
+
+    const summary = parseShardIncidentSummary(document);
+    expect(summary.shard_id).toBe("alpha-1");
+    expect(summary.severity).toBe("Warning");
+    expect(summary.notes).toHaveLength(1);
+  });
+});

--- a/apps/pod-web/src/contracts.ts
+++ b/apps/pod-web/src/contracts.ts
@@ -1,3 +1,5 @@
+import { decode as decodeToon } from "@toon-format/toon";
+
 export type Vec3Tuple = [number, number, number];
 export type Vec4Tuple = [number, number, number, number];
 export type Vec2Tuple = [number, number];
@@ -231,34 +233,276 @@ export interface TickTelemetryEnvelope {
   recovery?: CatchUpDiagnostics | null;
 }
 
+export interface ReplayHeader {
+  name: string;
+  timestamp: number;
+  world_seed: number;
+  tick_count: number;
+  agent_count: number;
+  notes: string;
+}
+
+export interface ReplayActionOutcomeSummary {
+  submitted: number;
+  executed: number;
+  rejected: number;
+  queued: number;
+}
+
+export interface ReplayTrainingSample {
+  tick: number;
+  agent_id: string;
+  path_distance: number;
+  action_outcomes: ReplayActionOutcomeSummary;
+  encounter_transition?: Record<string, unknown> | null;
+  tool_call_latency_ms: number;
+  tool_call_error_count: number;
+}
+
+export interface ReplayDecisionTrace {
+  tick: number;
+  agent_id: string;
+  observation_hash: number;
+  prompt_sent: string;
+  raw_response: string;
+  actions_taken: Record<string, unknown>[];
+  tool_calls: TelemetryToolCallTrace[];
+  latency_ms: number;
+}
+
+export interface ReplayFileDocument {
+  header: ReplayHeader;
+  traces: ReplayDecisionTrace[][];
+  telemetry_windows: TickTelemetryFrame[];
+  training_samples: ReplayTrainingSample[];
+}
+
+export interface ReplaySummary {
+  name: string;
+  tickCount: number;
+  agentCount: number;
+  traceCount: number;
+  trainingSampleCount: number;
+  telemetryWindowCount: number;
+  toolCallCount: number;
+  toolCallErrors: number;
+  totalPathDistance: number;
+  notes: string;
+  latestTelemetryTick: number | null;
+}
+
+export interface ShardIncidentSummary {
+  shard_id: string;
+  latest_tick: number;
+  severity: string;
+  summary: string;
+  tick_budget_overrun_rate: number;
+  action_rejection_rate: number;
+  tool_call_error_rate: number;
+  average_tool_latency_ms: number;
+  average_trajectory_distance: number;
+  peak_entity_count: number;
+  peak_agent_count: number;
+  capture_actions: number;
+  summon_actions: number;
+  gather_actions: number;
+  loot_actions: number;
+  notes: string[];
+}
+
+interface ToonDocumentEnvelope<T = unknown> {
+  document_type: string;
+  payload: T;
+}
+
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function decodeStructuredString(value: string): unknown {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return decodeToon(value);
+  }
+}
+
+function documentEnvelope(value: unknown): ToonDocumentEnvelope | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  if (typeof value.document_type !== "string" || !("payload" in value)) {
+    return null;
+  }
+
+  return value as unknown as ToonDocumentEnvelope;
+}
+
+function directTickTelemetryFrame(value: unknown): TickTelemetryFrame | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  if (typeof value.tick !== "number" || !Array.isArray(value.agents)) {
+    return null;
+  }
+  return value as unknown as TickTelemetryFrame;
+}
+
+function directTickTelemetryEnvelope(value: unknown): TickTelemetryEnvelope | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const tickTelemetry = directTickTelemetryFrame(value.tickTelemetry);
+  if (tickTelemetry) {
+    return {
+      tickTelemetry,
+      recovery: (value.recovery as CatchUpDiagnostics | null | undefined) ?? null
+    };
+  }
+
+  const snakeCaseTickTelemetry = directTickTelemetryFrame(value.tick_telemetry);
+  if (snakeCaseTickTelemetry) {
+    return {
+      tickTelemetry: snakeCaseTickTelemetry,
+      recovery: (value.recovery as CatchUpDiagnostics | null | undefined) ?? null
+    };
+  }
+
+  return null;
+}
+
 export function parseTickTelemetryEnvelope(
   frame: string | TickTelemetryFrame | TickTelemetryEnvelope
 ): TickTelemetryEnvelope {
   const parsed =
     typeof frame === "string"
-      ? (JSON.parse(frame) as TickTelemetryFrame | TickTelemetryEnvelope)
+      ? decodeStructuredString(frame)
       : frame;
 
-  if ("agents" in parsed) {
-    return { tickTelemetry: parsed };
+  const envelopeDocument = documentEnvelope(parsed);
+  if (envelopeDocument) {
+    switch (envelopeDocument.document_type) {
+      case "tick_telemetry_envelope":
+        return parseTickTelemetryEnvelope(envelopeDocument.payload as TickTelemetryEnvelope);
+      case "tick_telemetry_frame":
+        return {
+          tickTelemetry: parseTickTelemetryEnvelope(
+            envelopeDocument.payload as TickTelemetryFrame
+          ).tickTelemetry,
+          recovery: null
+        };
+      case "versioned_tick_telemetry": {
+        const versioned = envelopeDocument.payload;
+        if (isRecord(versioned) && "payload" in versioned) {
+          return {
+            tickTelemetry: parseTickTelemetryEnvelope(
+              versioned.payload as TickTelemetryFrame
+            ).tickTelemetry,
+            recovery: null
+          };
+        }
+        break;
+      }
+    }
   }
 
-  if ("tickTelemetry" in parsed) {
-    return parsed;
+  const directEnvelope = directTickTelemetryEnvelope(parsed);
+  if (directEnvelope) {
+    return directEnvelope;
   }
 
-  const snakeCase = parsed as {
-    tick_telemetry?: TickTelemetryFrame;
-    recovery?: CatchUpDiagnostics | null;
-  };
-  if (snakeCase.tick_telemetry) {
-    return {
-      tickTelemetry: snakeCase.tick_telemetry,
-      recovery: snakeCase.recovery ?? null
-    };
+  const directFrame = directTickTelemetryFrame(parsed);
+  if (directFrame) {
+    return { tickTelemetry: directFrame };
   }
 
   throw new Error("Invalid tick telemetry payload");
+}
+
+export function parseReplayFile(
+  replay: string | ReplayFileDocument
+): ReplayFileDocument {
+  const parsed =
+    typeof replay === "string" ? decodeStructuredString(replay) : replay;
+  const replayDocument = documentEnvelope(parsed);
+
+  if (replayDocument?.document_type === "replay_file") {
+    return replayDocument.payload as ReplayFileDocument;
+  }
+
+  if (
+    isRecord(parsed) &&
+    isRecord(parsed.header) &&
+    Array.isArray(parsed.traces) &&
+    Array.isArray(parsed.telemetry_windows) &&
+    Array.isArray(parsed.training_samples)
+  ) {
+    return parsed as unknown as ReplayFileDocument;
+  }
+
+  throw new Error("Invalid replay payload");
+}
+
+export function summarizeReplayFile(replay: ReplayFileDocument): ReplaySummary {
+  const traces = replay.traces.flat();
+  const toolCallCount = traces.reduce(
+    (count, trace) => count + trace.tool_calls.length,
+    0
+  );
+  const toolCallErrors = traces.reduce(
+    (count, trace) =>
+      count +
+      trace.tool_calls.filter(
+        (toolCall) =>
+          toolCall.status !== "Succeeded" && toolCall.status !== "Requested"
+      ).length,
+    0
+  );
+  const totalPathDistance = replay.training_samples.reduce(
+    (distance, sample) => distance + sample.path_distance,
+    0
+  );
+
+  return {
+    name: replay.header.name,
+    tickCount: replay.header.tick_count,
+    agentCount: replay.header.agent_count,
+    traceCount: traces.length,
+    trainingSampleCount: replay.training_samples.length,
+    telemetryWindowCount: replay.telemetry_windows.length,
+    toolCallCount,
+    toolCallErrors,
+    totalPathDistance: Number(totalPathDistance.toFixed(2)),
+    notes: replay.header.notes,
+    latestTelemetryTick: replay.telemetry_windows.at(-1)?.tick ?? null
+  };
+}
+
+export function parseShardIncidentSummary(
+  summary: string | ShardIncidentSummary
+): ShardIncidentSummary {
+  const parsed =
+    typeof summary === "string" ? decodeStructuredString(summary) : summary;
+  const summaryDocument = documentEnvelope(parsed);
+
+  if (summaryDocument?.document_type === "shard_incident_summary") {
+    return summaryDocument.payload as ShardIncidentSummary;
+  }
+
+  if (
+    isRecord(parsed) &&
+    typeof parsed.shard_id === "string" &&
+    typeof parsed.latest_tick === "number" &&
+    typeof parsed.summary === "string"
+  ) {
+    return parsed as unknown as ShardIncidentSummary;
+  }
+
+  throw new Error("Invalid shard incident summary payload");
 }
 
 export function legacyFrameToThreeJsFrame(frame: RenderFrame): ThreeJsWebGpuFrame {

--- a/apps/pod-web/src/main.ts
+++ b/apps/pod-web/src/main.ts
@@ -1,7 +1,12 @@
 import {
   parseRenderFrame,
+  parseReplayFile,
+  parseShardIncidentSummary,
   parseThreeJsWebGpuFrame,
-  parseTickTelemetryEnvelope
+  parseTickTelemetryEnvelope,
+  summarizeReplayFile,
+  type ReplaySummary,
+  type ShardIncidentSummary
 } from "./contracts";
 import { PodThreeWorldRenderer } from "./renderer";
 import { createDemoFrame } from "./sample-frame";
@@ -21,11 +26,15 @@ declare global {
       render: (frame: string) => void;
       renderThreeJsWebGpuFrame: (frame: string) => void;
       renderTickTelemetry: (frame: string) => void;
+      renderReplayDocument: (document: string) => void;
+      renderShardIncidentSummary: (document: string) => void;
       resetTelemetry: () => void;
       resetDemo: () => void;
       getBackend: () => string;
       getStats: () => ReturnType<PodThreeWorldRenderer["getStats"]>;
       getTelemetryStats: () => ReturnType<typeof telemetryStats>;
+      getReplaySummary: () => ReplaySummary | null;
+      getIncidentSummary: () => ShardIncidentSummary | null;
     };
   }
 }
@@ -46,6 +55,9 @@ const telemetryRecoveryLabel =
   document.querySelector<HTMLElement>("#telemetry-recovery");
 const telemetrySummaryLabel =
   document.querySelector<HTMLElement>("#telemetry-summary");
+const replaySummaryLabel = document.querySelector<HTMLElement>("#replay-summary");
+const incidentSummaryLabel =
+  document.querySelector<HTMLElement>("#incident-summary");
 const telemetryPanel = document.querySelector<HTMLElement>("#telemetry-panel");
 const telemetryPrev = document.querySelector<HTMLButtonElement>("#telemetry-prev");
 const telemetryNext = document.querySelector<HTMLButtonElement>("#telemetry-next");
@@ -63,6 +75,8 @@ if (
   !telemetryToolsLabel ||
   !telemetryRecoveryLabel ||
   !telemetrySummaryLabel ||
+  !replaySummaryLabel ||
+  !incidentSummaryLabel ||
   !telemetryPanel ||
   !telemetryPrev ||
   !telemetryNext
@@ -77,6 +91,8 @@ const telemetryActionsNode = telemetryActionsLabel;
 const telemetryToolsNode = telemetryToolsLabel;
 const telemetryRecoveryNode = telemetryRecoveryLabel;
 const telemetrySummaryNode = telemetrySummaryLabel;
+const replaySummaryNode = replaySummaryLabel;
+const incidentSummaryNode = incidentSummaryLabel;
 const telemetryPanelNode = telemetryPanel;
 const telemetryPrevButton = telemetryPrev;
 const telemetryNextButton = telemetryNext;
@@ -90,6 +106,8 @@ const telemetryState = createTelemetryOverlayState(300);
 let liveFrameSource: "demo" | "legacy" | "threejs" = "demo";
 let latestFrameJson: string | null = null;
 let lastTelemetryRevision = -1;
+let latestReplaySummary: ReplaySummary | null = null;
+let latestIncidentSummary: ShardIncidentSummary | null = null;
 
 telemetryToggleButton.addEventListener("click", () => {
   setTelemetryEnabled(telemetryState, !telemetryState.enabled);
@@ -115,6 +133,12 @@ window.podRender = {
   renderTickTelemetry(frame: string) {
     applyTickTelemetry(telemetryState, parseTickTelemetryEnvelope(frame));
   },
+  renderReplayDocument(document: string) {
+    latestReplaySummary = summarizeReplayFile(parseReplayFile(document));
+  },
+  renderShardIncidentSummary(document: string) {
+    latestIncidentSummary = parseShardIncidentSummary(document);
+  },
   resetTelemetry() {
     resetTelemetry(telemetryState);
     renderer.clearTelemetryTrail();
@@ -132,6 +156,12 @@ window.podRender = {
   },
   getTelemetryStats() {
     return telemetryStats(telemetryState);
+  },
+  getReplaySummary() {
+    return latestReplaySummary;
+  },
+  getIncidentSummary() {
+    return latestIncidentSummary;
   }
 };
 
@@ -189,6 +219,14 @@ function renderTelemetryHud(): void {
     stats.tick == null
       ? "Waiting for authoritative telemetry."
       : `tick ${stats.tick} · ${stats.visibleEntities} visible · ${stats.audibleEvents} audible · ${stats.messages} messages`;
+  replaySummaryNode.textContent = latestReplaySummary
+    ? `${latestReplaySummary.name} · ${latestReplaySummary.traceCount} traces · ${latestReplaySummary.trainingSampleCount} samples · ${latestReplaySummary.totalPathDistance.toFixed(
+        2
+      )}u`
+    : "No replay summary loaded";
+  incidentSummaryNode.textContent = latestIncidentSummary
+    ? `${latestIncidentSummary.severity} · ${latestIncidentSummary.summary}`
+    : "No shard incident summary loaded";
 }
 
 void tick(performance.now());

--- a/crates/pod-core/src/lib.rs
+++ b/crates/pod-core/src/lib.rs
@@ -88,7 +88,10 @@ pub use telemetry::{
     AgentTrajectoryFrame, TelemetryArchive, TelemetryConfig, TickTelemetryFrame, ToolCallStatus,
     TrajectorySample,
 };
-pub use toon::{decode_toon_value, encode_toon_document, encode_toon_string};
+pub use toon::{
+    decode_toon_document, decode_toon_string, decode_toon_value, encode_toon_document,
+    encode_toon_string,
+};
 pub use world::World;
 
 /// Fixed tick rate — all agents operate on the same clock

--- a/crates/pod-core/src/toon.rs
+++ b/crates/pod-core/src/toon.rs
@@ -1,4 +1,4 @@
-use serde::Serialize;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value;
 use toon_format::{decode_default as decode_toon, encode_default as encode_toon};
 
@@ -6,6 +6,12 @@ use toon_format::{decode_default as decode_toon, encode_default as encode_toon};
 struct ToonDocument<'a, T: Serialize> {
     document_type: &'static str,
     payload: &'a T,
+}
+
+#[derive(Deserialize)]
+struct DecodedToonDocument<T> {
+    document_type: String,
+    payload: T,
 }
 
 /// Encode a serializable value using official TOON, with JSON fallback for
@@ -25,6 +31,27 @@ pub fn encode_toon_document<T: Serialize>(document_type: &'static str, payload: 
     })
 }
 
+/// Decode a TOON string into a typed payload.
+pub fn decode_toon_string<T: DeserializeOwned>(document: &str) -> Result<T, String> {
+    decode_toon(document).map_err(|error| error.to_string())
+}
+
+/// Decode a typed TOON document envelope and validate the expected document
+/// kind before returning the payload.
+pub fn decode_toon_document<T: DeserializeOwned>(
+    document: &str,
+    expected_document_type: &'static str,
+) -> Result<T, String> {
+    let decoded: DecodedToonDocument<T> = decode_toon_string(document)?;
+    if decoded.document_type != expected_document_type {
+        return Err(format!(
+            "Expected TOON document type `{expected_document_type}`, got `{}`",
+            decoded.document_type
+        ));
+    }
+    Ok(decoded.payload)
+}
+
 /// Decode a TOON document into JSON for tests and tooling that want to assert
 /// on structured content without depending on the TOON crate directly.
 pub fn decode_toon_value(document: &str) -> Result<Value, String> {
@@ -33,9 +60,9 @@ pub fn decode_toon_value(document: &str) -> Result<Value, String> {
 
 #[cfg(test)]
 mod tests {
-    use serde::Serialize;
+    use serde::{Deserialize, Serialize};
 
-    use super::{decode_toon_value, encode_toon_document};
+    use super::{decode_toon_document, decode_toon_value, encode_toon_document};
 
     #[derive(Serialize)]
     struct SamplePayload<'a> {
@@ -57,5 +84,32 @@ mod tests {
         assert_eq!(decoded["document_type"], "sample_payload");
         assert_eq!(decoded["payload"]["label"], "monster");
         assert_eq!(decoded["payload"]["count"], 2);
+    }
+
+    #[test]
+    fn typed_document_payloads_decode_with_expected_kind() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct SamplePayload {
+            label: String,
+            count: usize,
+        }
+
+        let document = encode_toon_document(
+            "sample_payload",
+            &serde_json::json!({
+                "label": "monster",
+                "count": 2,
+            }),
+        );
+
+        let decoded: SamplePayload =
+            decode_toon_document(&document, "sample_payload").expect("document should decode");
+        assert_eq!(
+            decoded,
+            SamplePayload {
+                label: "monster".to_string(),
+                count: 2,
+            }
+        );
     }
 }

--- a/crates/pod-editor/src/lib.rs
+++ b/crates/pod-editor/src/lib.rs
@@ -12,8 +12,9 @@
 use eframe::{App, Frame};
 use egui::{CentralPanel, Context, SidePanel, TopBottomPanel, Ui};
 use pod_core::{
-    encode_toon_document, ActionLifecycleStage, AgentTelemetryFrame, AgentType, CreatureIdentity,
-    CreatureTemperament, TelemetryConfig, TickTelemetryFrame, ToolCallStatus, TrajectorySample,
+    decode_toon_document, encode_toon_document, Action, ActionLifecycleStage, AgentTelemetryFrame,
+    AgentType, CreatureIdentity, CreatureTemperament, ReplayFile,
+    ShardIncidentSummary, TelemetryConfig, TickTelemetryFrame, ToolCallStatus, TrajectorySample,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
@@ -553,10 +554,18 @@ pub struct SpacetimeDashboardState {
     pub connected_players: u32,
     pub action_rejection_rate: f32,
     pub tool_call_error_rate: f32,
+    pub average_tool_latency_ms: f32,
+    pub average_trajectory_distance: f32,
     pub agent_summaries: Vec<TelemetryAgentSummary>,
     pub visible_entity_count: usize,
     pub audible_event_count: usize,
     pub message_count: usize,
+    pub capture_actions: usize,
+    pub summon_actions: usize,
+    pub gather_actions: usize,
+    pub loot_actions: usize,
+    #[serde(default)]
+    pub latest_incident_summary: Option<ShardIncidentSummary>,
     pub last_reducer_call: String,
     pub reducer_calls: u32,
 }
@@ -568,10 +577,17 @@ impl Default for SpacetimeDashboardState {
             connected_players: 0,
             action_rejection_rate: 0.0,
             tool_call_error_rate: 0.0,
+            average_tool_latency_ms: 0.0,
+            average_trajectory_distance: 0.0,
             agent_summaries: Vec::new(),
             visible_entity_count: 0,
             audible_event_count: 0,
             message_count: 0,
+            capture_actions: 0,
+            summon_actions: 0,
+            gather_actions: 0,
+            loot_actions: 0,
+            latest_incident_summary: None,
             last_reducer_call: "none".to_string(),
             reducer_calls: 0,
         }
@@ -645,6 +661,37 @@ impl SpacetimeDashboardState {
         } else {
             tool_errors as f32 / total_tool_calls as f32
         };
+        self.average_tool_latency_ms = if total_tool_calls == 0 {
+            0.0
+        } else {
+            frame
+                .agents
+                .iter()
+                .flat_map(|agent| agent.tool_calls.iter())
+                .map(|trace| trace.latency_ms as f32)
+                .sum::<f32>()
+                / total_tool_calls as f32
+        };
+        self.average_trajectory_distance = if frame.agents.is_empty() {
+            0.0
+        } else {
+            frame
+                .agents
+                .iter()
+                .map(|agent| {
+                    agent
+                        .trajectory
+                        .as_ref()
+                        .map(|trajectory| trajectory.distance_travelled)
+                        .unwrap_or_default()
+                })
+                .sum::<f32>()
+                / frame.agents.len() as f32
+        };
+        self.capture_actions = 0;
+        self.summon_actions = 0;
+        self.gather_actions = 0;
+        self.loot_actions = 0;
 
         self.agent_summaries = frame
             .agents
@@ -675,6 +722,36 @@ impl SpacetimeDashboardState {
                     .count(),
             })
             .collect();
+
+        for trace in frame
+            .agents
+            .iter()
+            .flat_map(|agent| agent.action_trace.iter())
+        {
+            if trace.stage != ActionLifecycleStage::Executed {
+                continue;
+            }
+            match &trace.action {
+                Action::CaptureCreature { .. } => self.capture_actions += 1,
+                Action::SummonCompanion { .. } => self.summon_actions += 1,
+                Action::GatherResource { .. } => self.gather_actions += 1,
+                Action::Loot { .. } => self.loot_actions += 1,
+                _ => {}
+            }
+        }
+    }
+
+    pub fn apply_incident_summary(&mut self, summary: ShardIncidentSummary) {
+        self.latest_tick = summary.latest_tick;
+        self.action_rejection_rate = summary.action_rejection_rate;
+        self.tool_call_error_rate = summary.tool_call_error_rate;
+        self.average_tool_latency_ms = summary.average_tool_latency_ms;
+        self.average_trajectory_distance = summary.average_trajectory_distance;
+        self.capture_actions = summary.capture_actions;
+        self.summon_actions = summary.summon_actions;
+        self.gather_actions = summary.gather_actions;
+        self.loot_actions = summary.loot_actions;
+        self.latest_incident_summary = Some(summary);
     }
 
     pub fn to_toon_document(&self) -> String {
@@ -707,6 +784,13 @@ impl TelemetryPanelState {
             self.timeline.pop_front();
         }
         self.timeline.push_back(frame);
+    }
+
+    pub fn replace_timeline(&mut self, frames: impl IntoIterator<Item = TickTelemetryFrame>) {
+        self.timeline.clear();
+        for frame in frames {
+            self.record_tick(frame);
+        }
     }
 
     pub fn latest(&self) -> Option<&TickTelemetryFrame> {
@@ -1535,6 +1619,8 @@ pub struct EditorState {
     pub telemetry: TelemetryPanelState,
     pub spacetime_dashboard: SpacetimeDashboardState,
     pub creator_catalog: CreatorCatalog,
+    #[serde(default)]
+    pub latest_replay: Option<ReplayFile>,
 }
 
 impl Default for EditorState {
@@ -1584,6 +1670,7 @@ impl Default for EditorState {
             telemetry: TelemetryPanelState::default(),
             spacetime_dashboard: SpacetimeDashboardState::default(),
             creator_catalog,
+            latest_replay: None,
         }
     }
 }
@@ -1604,6 +1691,7 @@ pub struct EditorSnapshotExport {
     pub fsm: FiniteStateMachine,
     pub latest_tick_telemetry: Option<TickTelemetryFrame>,
     pub spacetime_dashboard: SpacetimeDashboardState,
+    pub latest_replay: Option<ReplayFile>,
 }
 
 impl EditorSnapshotExport {
@@ -1636,6 +1724,7 @@ impl EditorSnapshotExport {
             fsm: state.fsm.clone(),
             latest_tick_telemetry: state.telemetry.latest().cloned(),
             spacetime_dashboard: state.spacetime_dashboard.clone(),
+            latest_replay: state.latest_replay.clone(),
         }
     }
 
@@ -1924,6 +2013,40 @@ impl PodEditorApp {
 
     pub fn export_snapshot_toon_document(&self) -> String {
         EditorSnapshotExport::from_state(&self.state).to_toon_document()
+    }
+
+    pub fn import_replay_toon_document(&mut self, document: &str) -> Result<(), String> {
+        let replay: ReplayFile = decode_toon_document(document, "replay_file")?;
+        let telemetry_windows = replay.telemetry_windows.clone();
+        let replay_name = replay.header.name.clone();
+
+        self.history.remember(self.state.clone());
+        self.state.latest_replay = Some(replay);
+        if !telemetry_windows.is_empty() {
+            self.state
+                .telemetry
+                .replace_timeline(telemetry_windows.clone());
+            if let Some(last_frame) = telemetry_windows.last() {
+                self.state
+                    .spacetime_dashboard
+                    .record_tick_telemetry(last_frame);
+            }
+        }
+        self.push_console(format!("Imported replay {replay_name}"));
+        Ok(())
+    }
+
+    pub fn import_shard_incident_toon_document(&mut self, document: &str) -> Result<(), String> {
+        let summary: ShardIncidentSummary =
+            decode_toon_document(document, "shard_incident_summary")?;
+        let shard_id = summary.shard_id.clone();
+
+        self.history.remember(self.state.clone());
+        self.state
+            .spacetime_dashboard
+            .apply_incident_summary(summary);
+        self.push_console(format!("Imported shard incident summary for {shard_id}"));
+        Ok(())
     }
 
     pub fn can_undo(&self) -> bool {
@@ -3038,7 +3161,8 @@ mod tests {
     use pod_core::{
         decode_toon_value, Action, ActionLifecycleStage, ActionSource, AgentCapabilities, AgentId,
         AgentRole, AgentRuntimeProfile, AgentTelemetryFrame, AgentToolCallTrace,
-        CreatureTemperament, EntityId, TickTelemetryFrame, ToolCallStatus,
+        CreatureTemperament, EntityId, ReplayFile, ReplayHeader, ShardIncidentSummary,
+        TickTelemetryFrame, ToolCallStatus,
     };
 
     fn sample_tick_telemetry(tick: u64, entity_id: u64) -> TickTelemetryFrame {
@@ -3103,6 +3227,21 @@ mod tests {
         TickTelemetryFrame {
             tick,
             agents: vec![agent],
+        }
+    }
+
+    fn sample_replay_file() -> ReplayFile {
+        ReplayFile {
+            header: ReplayHeader {
+                name: "flagship-mmo-loop".to_string(),
+                timestamp: 1_741_315_200,
+                world_seed: 42,
+                tick_count: 2,
+                agent_count: 1,
+                notes: "acceptance".to_string(),
+            },
+            traces: Vec::new(),
+            telemetry_windows: vec![sample_tick_telemetry(15, 1001)],
         }
     }
 
@@ -3470,6 +3609,66 @@ mod tests {
             "editor_spacetime_dashboard"
         );
         assert_eq!(dashboard_value["payload"]["latest_tick"], 14);
+    }
+
+    #[test]
+    fn editor_imports_replay_toon_into_existing_telemetry_surfaces() {
+        let mut app = PodEditorApp::default();
+        let replay = sample_replay_file();
+
+        app.import_replay_toon_document(&replay.to_toon_document())
+            .expect("replay TOON should import");
+
+        assert_eq!(
+            app.state
+                .latest_replay
+                .as_ref()
+                .expect("replay stored")
+                .header
+                .name,
+            "flagship-mmo-loop"
+        );
+        assert_eq!(
+            app.state.telemetry.latest().expect("telemetry synced").tick,
+            15
+        );
+        assert_eq!(app.state.spacetime_dashboard.latest_tick, 15);
+    }
+
+    #[test]
+    fn editor_imports_shard_incident_toon_into_dashboard_state() {
+        let mut app = PodEditorApp::default();
+        let summary = ShardIncidentSummary {
+            shard_id: "alpha-1".to_string(),
+            latest_tick: 240,
+            severity: pod_core::IncidentSeverity::Warning,
+            summary: "Shard alpha-1 requires attention".to_string(),
+            tick_budget_overrun_rate: 0.08,
+            action_rejection_rate: 0.02,
+            tool_call_error_rate: 0.11,
+            average_tool_latency_ms: 820.0,
+            average_trajectory_distance: 3.2,
+            peak_entity_count: 512,
+            peak_agent_count: 128,
+            capture_actions: 4,
+            summon_actions: 2,
+            gather_actions: 7,
+            loot_actions: 9,
+            notes: vec!["tool-call error rate exceeds 10%".to_string()],
+        };
+
+        app.import_shard_incident_toon_document(&summary.to_toon_document())
+            .expect("incident TOON should import");
+
+        let incident = app
+            .state
+            .spacetime_dashboard
+            .latest_incident_summary
+            .as_ref()
+            .expect("incident stored");
+        assert_eq!(incident.shard_id, "alpha-1");
+        assert_eq!(app.state.spacetime_dashboard.average_tool_latency_ms, 820.0);
+        assert_eq!(app.state.spacetime_dashboard.capture_actions, 4);
     }
 
     #[test]

--- a/crates/pod-net/src/client_native.rs
+++ b/crates/pod-net/src/client_native.rs
@@ -553,6 +553,10 @@ impl NativeClient {
         self.last_debug_telemetry_json.as_deref()
     }
 
+    pub fn last_debug_telemetry_document(&self) -> Option<&str> {
+        self.last_debug_telemetry_json()
+    }
+
     /// Inspect the local rollback/replay path from a chosen authoritative tick.
     pub fn rollback_preview(&self, rewind_tick: Option<u64>) -> Option<RollbackPreview> {
         let rewind_tick = rewind_tick.or_else(|| {
@@ -813,6 +817,7 @@ impl std::error::Error for ClientError {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pod_core::{TickTelemetryFrame, VersionedTickTelemetry};
 
     #[test]
     fn test_client_creation() {
@@ -984,12 +989,13 @@ mod tests {
         };
 
         let message = ServerMessage::TickTelemetry {
-            frame_json: "{\"tick_telemetry\":{\"tick\":4,\"agents\":[]}}".into(),
+            frame_json: VersionedTickTelemetry::new(TickTelemetryFrame::empty(4))
+                .to_toon_document(),
         };
         assert!(client.apply_server_message(&message));
-        assert_eq!(
-            client.last_debug_telemetry_json(),
-            Some("{\"tick_telemetry\":{\"tick\":4,\"agents\":[]}}")
-        );
+        assert!(client
+            .last_debug_telemetry_document()
+            .expect("debug telemetry stored")
+            .contains("versioned_tick_telemetry"));
     }
 }

--- a/crates/pod-net/src/client_stdb.rs
+++ b/crates/pod-net/src/client_stdb.rs
@@ -866,6 +866,10 @@ impl SpacetimeDBClient {
         self.last_debug_telemetry_json.as_deref()
     }
 
+    pub fn last_debug_telemetry_document(&self) -> Option<&str> {
+        self.last_debug_telemetry_json()
+    }
+
     /// Inspect the local rollback/replay path from a chosen retained tick.
     ///
     /// SpacetimeDB clients currently replay zero local prediction batches here;
@@ -1215,7 +1219,9 @@ fn convert_world_event(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pod_core::action::SpeakVolume as CoreSpeakVolume;
+    use pod_core::{
+        action::SpeakVolume as CoreSpeakVolume, TickTelemetryFrame, VersionedTickTelemetry,
+    };
 
     #[test]
     fn test_entity_to_snapshot_defaults() {
@@ -1569,19 +1575,19 @@ mod tests {
         client.inner_mut().receive_agent_telemetry_tick(
             12,
             44,
-            "{\"tick_telemetry\":{\"tick\":12,\"agents\":[]}}".into(),
+            VersionedTickTelemetry::new(TickTelemetryFrame::empty(12)).to_toon_document(),
         );
 
         let messages = client.poll_updates();
         assert!(messages.iter().any(|message| matches!(
             message,
             ServerMessage::TickTelemetry { frame_json }
-                if frame_json.contains("\"tick\":12")
+                if frame_json.contains("versioned_tick_telemetry")
         )));
-        assert_eq!(
-            client.last_debug_telemetry_json(),
-            Some("{\"tick_telemetry\":{\"tick\":12,\"agents\":[]}}")
-        );
+        assert!(client
+            .last_debug_telemetry_document()
+            .expect("debug telemetry stored")
+            .contains("versioned_tick_telemetry"));
     }
 
     #[test]

--- a/crates/pod-net/src/client_web.rs
+++ b/crates/pod-net/src/client_web.rs
@@ -486,6 +486,10 @@ impl WebClient {
         self.last_debug_telemetry_json.as_deref()
     }
 
+    pub fn last_debug_telemetry_document(&self) -> Option<&str> {
+        self.last_debug_telemetry_json()
+    }
+
     /// Inspect the local rollback/replay path from a chosen authoritative tick.
     pub fn rollback_preview(&self, rewind_tick: Option<u64>) -> Option<RollbackPreview> {
         let rewind_tick = rewind_tick.or_else(|| {

--- a/crates/pod-net/src/protocol.rs
+++ b/crates/pod-net/src/protocol.rs
@@ -213,6 +213,7 @@ impl Default for ClientConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pod_core::{decode_toon_value, TickTelemetryFrame, VersionedTickTelemetry};
 
     #[test]
     fn test_client_message_roundtrip() {
@@ -304,14 +305,18 @@ mod tests {
     #[test]
     fn test_tick_telemetry_json_roundtrip() {
         let msg = ServerMessage::TickTelemetry {
-            frame_json: "{\"tick_telemetry\":{\"tick\":7,\"agents\":[]}}".into(),
+            frame_json: VersionedTickTelemetry::new(TickTelemetryFrame::empty(7))
+                .to_toon_document(),
         };
         let json = msg.encode_json().unwrap();
         let decoded = ServerMessage::decode_json(&json).unwrap();
 
         match decoded {
             ServerMessage::TickTelemetry { frame_json } => {
-                assert!(frame_json.contains("\"tick\":7"));
+                let value =
+                    decode_toon_value(&frame_json).expect("tick telemetry TOON should decode");
+                assert_eq!(value["document_type"], "versioned_tick_telemetry");
+                assert_eq!(value["payload"]["payload"]["tick"], 7);
             }
             other => panic!("Wrong message type: {other:?}"),
         }

--- a/crates/pod-net/src/server.rs
+++ b/crates/pod-net/src/server.rs
@@ -13,8 +13,7 @@ use log::{debug, error, info, warn};
 use quinn::Endpoint;
 use tokio::sync::{mpsc, RwLock};
 
-use pod_core::{Action, IdleAgent, World};
-use serde_json::json;
+use pod_core::{Action, IdleAgent, VersionedTickTelemetry, World};
 
 use crate::protocol::{
     ClientId, ClientMessage, ReconnectToken, ServerConfig as ProtoServerConfig, ServerMessage,
@@ -219,10 +218,8 @@ impl GameServer {
 
         // Step the world
         let tick_result = self.world.step();
-        self.last_tick_telemetry_json = Some(
-            serde_json::to_string(&json!({ "tick_telemetry": tick_result.telemetry }))
-                .expect("tick telemetry should serialize"),
-        );
+        self.last_tick_telemetry_json =
+            Some(VersionedTickTelemetry::new(tick_result.telemetry.clone()).to_toon_document());
 
         debug!(
             "Tick {}: {} entities, {} agents",
@@ -777,6 +774,7 @@ impl std::error::Error for ServerError {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pod_core::decode_toon_value;
 
     #[tokio::test]
     async fn test_server_creation() {
@@ -846,7 +844,9 @@ mod tests {
             match message {
                 ServerMessage::TickTelemetry { frame_json } => {
                     saw_tick_telemetry = true;
-                    assert!(frame_json.contains("\"tick_telemetry\""));
+                    let value =
+                        decode_toon_value(&frame_json).expect("tick telemetry TOON should decode");
+                    assert_eq!(value["document_type"], "versioned_tick_telemetry");
                 }
                 _ => {}
             }

--- a/crates/pod-stdb/Cargo.toml
+++ b/crates/pod-stdb/Cargo.toml
@@ -49,3 +49,4 @@ rand = { workspace = true, optional = true }
 rand_chacha = { workspace = true, optional = true }
 
 [dev-dependencies]
+pod-core = { path = "../pod-core" }

--- a/crates/pod-stdb/src/client.rs
+++ b/crates/pod-stdb/src/client.rs
@@ -2098,15 +2098,21 @@ mod tests {
 
     #[test]
     fn test_receive_debug_telemetry_events() {
+        use pod_core::{AgentToolCallTrace, TickTelemetryFrame, VersionedTickTelemetry};
+
         let mut client = StdbClient::new(StdbClientConfig::default());
-        client.receive_agent_telemetry_tick(8, 41, "{\"tick_telemetry\":{\"tick\":8}}".into());
+        client.receive_agent_telemetry_tick(
+            8,
+            41,
+            VersionedTickTelemetry::new(TickTelemetryFrame::empty(8)).to_toon_document(),
+        );
         client.receive_agent_tool_call_event(
             8,
             41,
             "llm.complete".into(),
             "qwen".into(),
             "Succeeded".into(),
-            "{\"latency_ms\":12}".into(),
+            AgentToolCallTrace::success(8, "llm.complete", "qwen", 12, 24, 8).to_toon_document(),
         );
         client.receive_agent_tick_rollup(1, 60, 41, "{\"distance\":42.0}".into());
 

--- a/crates/pod-stdb/src/events.rs
+++ b/crates/pod-stdb/src/events.rs
@@ -131,8 +131,9 @@ pub struct WorldEventRow {
 /// Per-agent authoritative telemetry row for editor/debug consumers.
 ///
 /// These rows are transient and intended for short-lived tooling subscriptions.
-/// The detailed payload stays JSON-encoded so client tooling can evolve without
-/// forcing a second flattened schema for every new telemetry field.
+/// The detailed payload stays as a structured document string so client tooling
+/// can evolve without forcing a second flattened schema for every new telemetry
+/// field. Official TOON documents are preferred, with legacy JSON tolerated.
 #[spacetimedb::table(name = agent_telemetry_tick, public)]
 pub struct AgentTelemetryTickRow {
     #[primary_key]

--- a/crates/pod-stdb/tests/client_integration.rs
+++ b/crates/pod-stdb/tests/client_integration.rs
@@ -22,6 +22,7 @@
 
 #![cfg(feature = "client")]
 
+use pod_core::{AgentToolCallTrace, TickTelemetryFrame, VersionedTickTelemetry};
 use pod_stdb::client::*;
 use pod_stdb::types::*;
 
@@ -139,7 +140,7 @@ fn telemetry_events_are_constructible() {
     let tick = StdbEvent::AgentTelemetryTickReceived {
         tick: 12,
         agent_entity_id: 7,
-        frame_json: "{\"tick_telemetry\":{\"tick\":12}}".into(),
+        frame_json: VersionedTickTelemetry::new(TickTelemetryFrame::empty(12)).to_toon_document(),
     };
     let tool = StdbEvent::AgentToolCallEventReceived {
         tick: 12,
@@ -147,7 +148,8 @@ fn telemetry_events_are_constructible() {
         tool_name: "llm.complete".into(),
         provider: "qwen".into(),
         status: "Succeeded".into(),
-        data_json: "{\"request_units\":128}".into(),
+        data_json: AgentToolCallTrace::success(12, "llm.complete", "qwen", 18, 128, 64)
+            .to_toon_document(),
     };
     let rollup = StdbEvent::AgentTickRollupReceived {
         tick_start: 1,
@@ -916,7 +918,8 @@ fn stdb_event_all_18_variants_constructible() {
         StdbEvent::AgentTelemetryTickReceived {
             tick: 1,
             agent_entity_id: 5,
-            frame_json: "{\"tick_telemetry\":{\"tick\":1}}".into(),
+            frame_json: VersionedTickTelemetry::new(TickTelemetryFrame::empty(1))
+                .to_toon_document(),
         },
         StdbEvent::AgentToolCallEventReceived {
             tick: 1,
@@ -924,7 +927,8 @@ fn stdb_event_all_18_variants_constructible() {
             tool_name: "llm.complete".into(),
             provider: "qwen".into(),
             status: "Succeeded".into(),
-            data_json: "{\"request_units\":42}".into(),
+            data_json: AgentToolCallTrace::success(1, "llm.complete", "qwen", 12, 42, 10)
+                .to_toon_document(),
         },
         StdbEvent::AgentTickRollupReceived {
             tick_start: 1,


### PR DESCRIPTION
## Summary
- switch direct-connect debug telemetry payloads to versioned TOON documents and update pod-net/pod-stdb fixtures accordingly
- add official TOON parsing plus replay/incident summary consumption to the pod-web debug client
- let pod-editor import replay and shard incident TOON documents into the existing telemetry and dashboard surfaces

## Validation
- cargo test -p pod-core --lib
- cargo test -p pod-net --lib
- cargo test -p pod-net --features spacetimedb --lib
- cargo test -p pod-stdb --no-default-features --features client
- cargo test -p pod-editor --lib
- bun test
- bun run typecheck
- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added replay telemetry visualization to the debug HUD, displaying replay summaries with trace counts, training samples, and path distance metrics.
  * Added shard incident summary display to the telemetry HUD, showing incident severity and details.
  * Enhanced telemetry ingestion to support replay files and incident summaries for real-time dashboard analytics.

* **Tests**
  * Added test coverage for replay file parsing and incident summary ingestion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->