### PR TITLE
Add TOON live debug document streams

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -596,5 +596,12 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `bun run typecheck`
   - `bun run build`
 
-**Last updated**: Iteration 65
-**Current focus**: Iteration 66 TOON-backed tool-call event and telemetry rollup parity across SpacetimeDB/browser/editor consumers, plus live replay/incident streaming hooks for shard debug operations
+### Iteration 66
+- [x] Added canonical TOON document types in `pod-core` for `agent_tool_call_event` and `agent_tick_rollup`, including rollup derivation helpers so debug consumers share one schema across core, browser, editor, and SpacetimeDB surfaces.
+- [x] Extended `pod-net::client_stdb` with a live debug-document queue, retaining TOON telemetry/tool-call/rollup payloads plus injected replay/incident documents for shard debug operations without widening the gameplay message path.
+- [x] Extended `apps/pod-web` with live TOON debug-document routing, tool-call/rollup parsing and summaries, and explicit replay/incident streaming hooks for debug overlays.
+- [x] Extended `pod-editor` with TOON imports for tool-call events, tick rollups, and generic live debug documents, keeping dashboard/telemetry state aligned with replay and incident ingestion.
+- [x] Added deterministic coverage for core TOON telemetry exports, SpacetimeDB debug-document retention, browser live debug routing, and editor live TOON imports.
+
+**Last updated**: Iteration 66
+**Current focus**: Iteration 67 live SpacetimeDB telemetry row production and shard-ops document streaming from authoritative runtime paths, plus browser/editor consumption of those streams end to end

--- a/apps/pod-web/index.html
+++ b/apps/pod-web/index.html
@@ -180,6 +180,10 @@
           <dd id="replay-summary">No replay summary loaded</dd>
           <dt>Incident</dt>
           <dd id="incident-summary">No shard incident summary loaded</dd>
+          <dt>Tool Event</dt>
+          <dd id="tool-event-summary">No tool-call event loaded</dd>
+          <dt>Rollup</dt>
+          <dd id="rollup-summary">No telemetry rollup loaded</dd>
         </dl>
       </section>
     </div>

--- a/apps/pod-web/src/contracts.test.ts
+++ b/apps/pod-web/src/contracts.test.ts
@@ -2,9 +2,14 @@ import { describe, expect, test } from "bun:test";
 import { encode } from "@toon-format/toon";
 
 import {
+  parseAgentTickRollup,
+  parseAgentToolCallEvent,
+  parseLiveDebugDocument,
   parseReplayFile,
   parseShardIncidentSummary,
   parseTickTelemetryEnvelope,
+  summarizeAgentTickRollup,
+  summarizeAgentToolCallEvent,
   summarizeReplayFile
 } from "./contracts";
 
@@ -125,5 +130,95 @@ describe("TOON contract parsing", () => {
     expect(summary.shard_id).toBe("alpha-1");
     expect(summary.severity).toBe("Warning");
     expect(summary.notes).toHaveLength(1);
+  });
+
+  test("accepts tool-call and rollup TOON documents", () => {
+    const toolDocument = encode({
+      document_type: "agent_tool_call_event",
+      payload: {
+        tick: 12,
+        agent_entity_id: 44,
+        trace: {
+          tick: 12,
+          tool_name: "llm.complete",
+          provider: "qwen",
+          status: "TimedOut",
+          latency_ms: 48,
+          request_units: 120,
+          response_units: 40,
+          error_message: "timeout"
+        }
+      }
+    });
+    const rollupDocument = encode({
+      document_type: "agent_tick_rollup",
+      payload: {
+        tick_start: 1,
+        tick_end: 60,
+        agent_entity_id: 44,
+        total_distance: 18.5,
+        submitted_action_count: 4,
+        executed_action_count: 3,
+        rejected_action_count: 1,
+        tool_call_count: 1,
+        tool_error_count: 1,
+        visible_entity_count: 12,
+        audible_event_count: 3,
+        message_count: 2,
+        average_tool_latency_ms: 48
+      }
+    });
+
+    const toolEvent = parseAgentToolCallEvent(toolDocument);
+    const toolSummary = summarizeAgentToolCallEvent(toolEvent);
+    expect(toolEvent.agent_entity_id).toBe(44);
+    expect(toolSummary.status).toBe("TimedOut");
+    expect(toolSummary.errorMessage).toBe("timeout");
+
+    const rollup = parseAgentTickRollup(rollupDocument);
+    const rollupSummary = summarizeAgentTickRollup(rollup);
+    expect(rollup.agent_entity_id).toBe(44);
+    expect(rollupSummary.totalDistance).toBe(18.5);
+    expect(rollupSummary.toolErrorCount).toBe(1);
+  });
+
+  test("routes live debug documents by TOON document type", () => {
+    const replayDocument = encode({
+      document_type: "replay_file",
+      payload: {
+        header: {
+          name: "flagship-mmo-loop",
+          timestamp: 1_741_315_200,
+          world_seed: 42,
+          tick_count: 120,
+          agent_count: 2,
+          notes: "acceptance"
+        },
+        traces: [],
+        telemetry_windows: [],
+        training_samples: []
+      }
+    });
+
+    const replay = parseLiveDebugDocument(replayDocument);
+    expect(replay.kind).toBe("replay");
+
+    const telemetry = parseLiveDebugDocument(
+      encode({
+        document_type: "versioned_tick_telemetry",
+        payload: {
+          version: "V1",
+          payload: {
+            tick: 9,
+            agents: []
+          }
+        }
+      })
+    );
+    expect(telemetry.kind).toBe("tickTelemetry");
+    if (telemetry.kind !== "tickTelemetry") {
+      throw new Error("expected tick telemetry document");
+    }
+    expect(telemetry.payload.tickTelemetry.tick).toBe(9);
   });
 });

--- a/apps/pod-web/src/contracts.ts
+++ b/apps/pod-web/src/contracts.ts
@@ -310,6 +310,59 @@ export interface ShardIncidentSummary {
   notes: string[];
 }
 
+export interface AgentToolCallEventDocument {
+  tick: number;
+  agent_entity_id: number;
+  trace: TelemetryToolCallTrace;
+}
+
+export interface AgentTickRollupDocument {
+  tick_start: number;
+  tick_end: number;
+  agent_entity_id: number;
+  total_distance: number;
+  submitted_action_count: number;
+  executed_action_count: number;
+  rejected_action_count: number;
+  tool_call_count: number;
+  tool_error_count: number;
+  visible_entity_count: number;
+  audible_event_count: number;
+  message_count: number;
+  average_tool_latency_ms: number;
+}
+
+export interface ToolCallEventSummary {
+  agentEntityId: number;
+  toolName: string;
+  provider: string;
+  status: string;
+  latencyMs: number;
+  requestUnits: number;
+  responseUnits: number;
+  errorMessage: string | null;
+}
+
+export interface TickRollupSummary {
+  agentEntityId: number;
+  tickStart: number;
+  tickEnd: number;
+  totalDistance: number;
+  rejectedActionCount: number;
+  toolErrorCount: number;
+  averageToolLatencyMs: number;
+  visibleEntityCount: number;
+  audibleEventCount: number;
+  messageCount: number;
+}
+
+export type LiveDebugDocument =
+  | { kind: "tickTelemetry"; documentType: string; payload: TickTelemetryEnvelope }
+  | { kind: "toolCallEvent"; documentType: string; payload: AgentToolCallEventDocument }
+  | { kind: "tickRollup"; documentType: string; payload: AgentTickRollupDocument }
+  | { kind: "replay"; documentType: string; payload: ReplayFileDocument }
+  | { kind: "incident"; documentType: string; payload: ShardIncidentSummary };
+
 interface ToonDocumentEnvelope<T = unknown> {
   document_type: string;
   payload: T;
@@ -503,6 +556,126 @@ export function parseShardIncidentSummary(
   }
 
   throw new Error("Invalid shard incident summary payload");
+}
+
+export function parseAgentToolCallEvent(
+  event: string | AgentToolCallEventDocument
+): AgentToolCallEventDocument {
+  const parsed =
+    typeof event === "string" ? decodeStructuredString(event) : event;
+  const eventDocument = documentEnvelope(parsed);
+
+  if (eventDocument?.document_type === "agent_tool_call_event") {
+    return eventDocument.payload as AgentToolCallEventDocument;
+  }
+
+  if (
+    isRecord(parsed) &&
+    typeof parsed.tick === "number" &&
+    typeof parsed.agent_entity_id === "number" &&
+    isRecord(parsed.trace)
+  ) {
+    return parsed as unknown as AgentToolCallEventDocument;
+  }
+
+  throw new Error("Invalid agent tool-call event payload");
+}
+
+export function summarizeAgentToolCallEvent(
+  event: AgentToolCallEventDocument
+): ToolCallEventSummary {
+  return {
+    agentEntityId: event.agent_entity_id,
+    toolName: event.trace.tool_name,
+    provider: event.trace.provider,
+    status: event.trace.status,
+    latencyMs: event.trace.latency_ms,
+    requestUnits: event.trace.request_units,
+    responseUnits: event.trace.response_units,
+    errorMessage: event.trace.error_message ?? null
+  };
+}
+
+export function parseAgentTickRollup(
+  rollup: string | AgentTickRollupDocument
+): AgentTickRollupDocument {
+  const parsed =
+    typeof rollup === "string" ? decodeStructuredString(rollup) : rollup;
+  const rollupDocument = documentEnvelope(parsed);
+
+  if (rollupDocument?.document_type === "agent_tick_rollup") {
+    return rollupDocument.payload as AgentTickRollupDocument;
+  }
+
+  if (
+    isRecord(parsed) &&
+    typeof parsed.tick_start === "number" &&
+    typeof parsed.tick_end === "number" &&
+    typeof parsed.agent_entity_id === "number"
+  ) {
+    return parsed as unknown as AgentTickRollupDocument;
+  }
+
+  throw new Error("Invalid agent tick rollup payload");
+}
+
+export function summarizeAgentTickRollup(
+  rollup: AgentTickRollupDocument
+): TickRollupSummary {
+  return {
+    agentEntityId: rollup.agent_entity_id,
+    tickStart: rollup.tick_start,
+    tickEnd: rollup.tick_end,
+    totalDistance: Number(rollup.total_distance.toFixed(2)),
+    rejectedActionCount: rollup.rejected_action_count,
+    toolErrorCount: rollup.tool_error_count,
+    averageToolLatencyMs: Number(rollup.average_tool_latency_ms.toFixed(2)),
+    visibleEntityCount: rollup.visible_entity_count,
+    audibleEventCount: rollup.audible_event_count,
+    messageCount: rollup.message_count
+  };
+}
+
+export function parseLiveDebugDocument(document: string): LiveDebugDocument {
+  const parsed = decodeStructuredString(document);
+  const envelope = documentEnvelope(parsed);
+
+  switch (envelope?.document_type) {
+    case "tick_telemetry_envelope":
+    case "tick_telemetry_frame":
+    case "versioned_tick_telemetry":
+      return {
+        kind: "tickTelemetry",
+        documentType: envelope.document_type,
+        payload: parseTickTelemetryEnvelope(document)
+      };
+    case "agent_tool_call_event":
+      return {
+        kind: "toolCallEvent",
+        documentType: envelope.document_type,
+        payload: parseAgentToolCallEvent(document)
+      };
+    case "agent_tick_rollup":
+      return {
+        kind: "tickRollup",
+        documentType: envelope.document_type,
+        payload: parseAgentTickRollup(document)
+      };
+    case "replay_file":
+      return {
+        kind: "replay",
+        documentType: envelope.document_type,
+        payload: parseReplayFile(document)
+      };
+    case "shard_incident_summary":
+      return {
+        kind: "incident",
+        documentType: envelope.document_type,
+        payload: parseShardIncidentSummary(document)
+      };
+    default:
+      throw new Error("Unsupported live debug document payload");
+  }
 }
 
 export function legacyFrameToThreeJsFrame(frame: RenderFrame): ThreeJsWebGpuFrame {

--- a/apps/pod-web/src/main.ts
+++ b/apps/pod-web/src/main.ts
@@ -1,10 +1,15 @@
 import {
+  parseLiveDebugDocument,
   parseRenderFrame,
   parseReplayFile,
   parseShardIncidentSummary,
   parseThreeJsWebGpuFrame,
   parseTickTelemetryEnvelope,
+  summarizeAgentTickRollup,
+  summarizeAgentToolCallEvent,
   summarizeReplayFile,
+  type TickRollupSummary,
+  type ToolCallEventSummary,
   type ReplaySummary,
   type ShardIncidentSummary
 } from "./contracts";
@@ -26,8 +31,11 @@ declare global {
       render: (frame: string) => void;
       renderThreeJsWebGpuFrame: (frame: string) => void;
       renderTickTelemetry: (frame: string) => void;
+      renderDebugDocument: (document: string) => void;
       renderReplayDocument: (document: string) => void;
       renderShardIncidentSummary: (document: string) => void;
+      streamReplayDocument: (document: string) => void;
+      streamShardIncidentSummary: (document: string) => void;
       resetTelemetry: () => void;
       resetDemo: () => void;
       getBackend: () => string;
@@ -58,6 +66,10 @@ const telemetrySummaryLabel =
 const replaySummaryLabel = document.querySelector<HTMLElement>("#replay-summary");
 const incidentSummaryLabel =
   document.querySelector<HTMLElement>("#incident-summary");
+const toolEventSummaryLabel =
+  document.querySelector<HTMLElement>("#tool-event-summary");
+const rollupSummaryLabel =
+  document.querySelector<HTMLElement>("#rollup-summary");
 const telemetryPanel = document.querySelector<HTMLElement>("#telemetry-panel");
 const telemetryPrev = document.querySelector<HTMLButtonElement>("#telemetry-prev");
 const telemetryNext = document.querySelector<HTMLButtonElement>("#telemetry-next");
@@ -77,6 +89,8 @@ if (
   !telemetrySummaryLabel ||
   !replaySummaryLabel ||
   !incidentSummaryLabel ||
+  !toolEventSummaryLabel ||
+  !rollupSummaryLabel ||
   !telemetryPanel ||
   !telemetryPrev ||
   !telemetryNext
@@ -93,6 +107,8 @@ const telemetryRecoveryNode = telemetryRecoveryLabel;
 const telemetrySummaryNode = telemetrySummaryLabel;
 const replaySummaryNode = replaySummaryLabel;
 const incidentSummaryNode = incidentSummaryLabel;
+const toolEventSummaryNode = toolEventSummaryLabel;
+const rollupSummaryNode = rollupSummaryLabel;
 const telemetryPanelNode = telemetryPanel;
 const telemetryPrevButton = telemetryPrev;
 const telemetryNextButton = telemetryNext;
@@ -108,6 +124,10 @@ let latestFrameJson: string | null = null;
 let lastTelemetryRevision = -1;
 let latestReplaySummary: ReplaySummary | null = null;
 let latestIncidentSummary: ShardIncidentSummary | null = null;
+let latestToolEventSummary: ToolCallEventSummary | null = null;
+let latestRollupSummary: TickRollupSummary | null = null;
+let liveReplayDocuments = 0;
+let liveIncidentDocuments = 0;
 
 telemetryToggleButton.addEventListener("click", () => {
   setTelemetryEnabled(telemetryState, !telemetryState.enabled);
@@ -133,11 +153,20 @@ window.podRender = {
   renderTickTelemetry(frame: string) {
     applyTickTelemetry(telemetryState, parseTickTelemetryEnvelope(frame));
   },
+  renderDebugDocument(document: string) {
+    applyLiveDebugDocument(document);
+  },
   renderReplayDocument(document: string) {
     latestReplaySummary = summarizeReplayFile(parseReplayFile(document));
   },
   renderShardIncidentSummary(document: string) {
     latestIncidentSummary = parseShardIncidentSummary(document);
+  },
+  streamReplayDocument(document: string) {
+    applyLiveDebugDocument(document);
+  },
+  streamShardIncidentSummary(document: string) {
+    applyLiveDebugDocument(document);
   },
   resetTelemetry() {
     resetTelemetry(telemetryState);
@@ -164,6 +193,30 @@ window.podRender = {
     return latestIncidentSummary;
   }
 };
+
+function applyLiveDebugDocument(document: string): void {
+  const parsed = parseLiveDebugDocument(document);
+
+  switch (parsed.kind) {
+    case "tickTelemetry":
+      applyTickTelemetry(telemetryState, parsed.payload);
+      break;
+    case "toolCallEvent":
+      latestToolEventSummary = summarizeAgentToolCallEvent(parsed.payload);
+      break;
+    case "tickRollup":
+      latestRollupSummary = summarizeAgentTickRollup(parsed.payload);
+      break;
+    case "replay":
+      latestReplaySummary = summarizeReplayFile(parsed.payload);
+      liveReplayDocuments += 1;
+      break;
+    case "incident":
+      latestIncidentSummary = parsed.payload;
+      liveIncidentDocuments += 1;
+      break;
+  }
+}
 
 async function tick(timestamp: number): Promise<void> {
   if (lastTelemetryRevision !== telemetryState.revision) {
@@ -225,8 +278,21 @@ function renderTelemetryHud(): void {
       )}u`
     : "No replay summary loaded";
   incidentSummaryNode.textContent = latestIncidentSummary
-    ? `${latestIncidentSummary.severity} · ${latestIncidentSummary.summary}`
+    ? `${latestIncidentSummary.severity} · ${latestIncidentSummary.summary} · stream ${liveIncidentDocuments}`
     : "No shard incident summary loaded";
+  toolEventSummaryNode.textContent = latestToolEventSummary
+    ? `E(${latestToolEventSummary.agentEntityId}) · ${latestToolEventSummary.toolName} · ${latestToolEventSummary.status} · ${latestToolEventSummary.latencyMs}ms`
+    : "No tool-call event loaded";
+  rollupSummaryNode.textContent = latestRollupSummary
+    ? `E(${latestRollupSummary.agentEntityId}) · ticks ${latestRollupSummary.tickStart}-${latestRollupSummary.tickEnd} · ${latestRollupSummary.totalDistance.toFixed(
+        2
+      )}u · ${latestRollupSummary.toolErrorCount} tool errors`
+    : "No telemetry rollup loaded";
+  if (latestReplaySummary) {
+    replaySummaryNode.textContent = `${latestReplaySummary.name} · ${latestReplaySummary.traceCount} traces · ${latestReplaySummary.trainingSampleCount} samples · ${latestReplaySummary.totalPathDistance.toFixed(
+      2
+    )}u · stream ${liveReplayDocuments}`;
+  }
 }
 
 void tick(performance.now());

--- a/crates/pod-core/src/lib.rs
+++ b/crates/pod-core/src/lib.rs
@@ -84,9 +84,9 @@ pub use replay::{
     ReplayPlayer, ReplayRecorder, ReplayTrainingSample,
 };
 pub use telemetry::{
-    ActionLifecycleStage, ActionSource, AgentActionTrace, AgentTelemetryFrame, AgentToolCallTrace,
-    AgentTrajectoryFrame, TelemetryArchive, TelemetryConfig, TickTelemetryFrame, ToolCallStatus,
-    TrajectorySample,
+    ActionLifecycleStage, ActionSource, AgentActionTrace, AgentTelemetryFrame, AgentTickRollup,
+    AgentToolCallEvent, AgentToolCallTrace, AgentTrajectoryFrame, TelemetryArchive,
+    TelemetryConfig, TickTelemetryFrame, ToolCallStatus, TrajectorySample,
 };
 pub use toon::{
     decode_toon_document, decode_toon_string, decode_toon_value, encode_toon_document,

--- a/crates/pod-core/src/telemetry.rs
+++ b/crates/pod-core/src/telemetry.rs
@@ -222,6 +222,30 @@ impl AgentToolCallTrace {
     }
 }
 
+/// Tool/provider side-effect event annotated with the authoritative entity that
+/// triggered it. This is the TOON-facing payload used by debug consumers and
+/// SpacetimeDB telemetry rows.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentToolCallEvent {
+    pub tick: u64,
+    pub agent_entity_id: u64,
+    pub trace: AgentToolCallTrace,
+}
+
+impl AgentToolCallEvent {
+    pub fn new(agent_entity_id: u64, trace: AgentToolCallTrace) -> Self {
+        Self {
+            tick: trace.tick,
+            agent_entity_id,
+            trace,
+        }
+    }
+
+    pub fn to_toon_document(&self) -> String {
+        encode_toon_document("agent_tool_call_event", self)
+    }
+}
+
 /// Authoritative telemetry for one agent over one simulation tick.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentTelemetryFrame {
@@ -324,6 +348,112 @@ impl TickTelemetryFrame {
     }
 }
 
+/// Aggregate telemetry rollup for one authoritative agent over a retained tick
+/// window. This mirrors the SpacetimeDB rollup row while keeping the detailed
+/// document transport TOON-native for debug tooling.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AgentTickRollup {
+    pub tick_start: u64,
+    pub tick_end: u64,
+    pub agent_entity_id: u64,
+    pub total_distance: f32,
+    pub submitted_action_count: u32,
+    pub executed_action_count: u32,
+    pub rejected_action_count: u32,
+    pub tool_call_count: u32,
+    pub tool_error_count: u32,
+    pub visible_entity_count: u32,
+    pub audible_event_count: u32,
+    pub message_count: u32,
+    pub average_tool_latency_ms: f32,
+}
+
+impl AgentTickRollup {
+    pub fn from_agent_frames(agent_entity_id: u64, frames: &[AgentTelemetryFrame]) -> Option<Self> {
+        let tick_start = frames.first()?.tick;
+        let tick_end = frames.last()?.tick;
+
+        let total_distance = frames
+            .iter()
+            .map(|frame| {
+                frame
+                    .trajectory
+                    .as_ref()
+                    .map(|trajectory| trajectory.distance_travelled)
+                    .unwrap_or_default()
+            })
+            .sum::<f32>();
+        let submitted_action_count = frames
+            .iter()
+            .flat_map(|frame| frame.action_trace.iter())
+            .filter(|trace| trace.stage == ActionLifecycleStage::Submitted)
+            .count() as u32;
+        let executed_action_count = frames
+            .iter()
+            .flat_map(|frame| frame.action_trace.iter())
+            .filter(|trace| trace.stage == ActionLifecycleStage::Executed)
+            .count() as u32;
+        let rejected_action_count = frames
+            .iter()
+            .flat_map(|frame| frame.action_trace.iter())
+            .filter(|trace| trace.stage == ActionLifecycleStage::Rejected)
+            .count() as u32;
+        let tool_call_count = frames
+            .iter()
+            .map(|frame| frame.tool_calls.len())
+            .sum::<usize>() as u32;
+        let tool_error_count = frames
+            .iter()
+            .flat_map(|frame| frame.tool_calls.iter())
+            .filter(|trace| {
+                !matches!(
+                    trace.status,
+                    ToolCallStatus::Requested | ToolCallStatus::Succeeded
+                )
+            })
+            .count() as u32;
+        let visible_entity_count = frames
+            .iter()
+            .map(|frame| frame.visible_entity_count as u32)
+            .sum();
+        let audible_event_count = frames
+            .iter()
+            .map(|frame| frame.audible_event_count as u32)
+            .sum();
+        let message_count = frames.iter().map(|frame| frame.message_count as u32).sum();
+        let average_tool_latency_ms = if tool_call_count == 0 {
+            0.0
+        } else {
+            frames
+                .iter()
+                .flat_map(|frame| frame.tool_calls.iter())
+                .map(|trace| trace.latency_ms as f32)
+                .sum::<f32>()
+                / tool_call_count as f32
+        };
+
+        Some(Self {
+            tick_start,
+            tick_end,
+            agent_entity_id,
+            total_distance,
+            submitted_action_count,
+            executed_action_count,
+            rejected_action_count,
+            tool_call_count,
+            tool_error_count,
+            visible_entity_count,
+            audible_event_count,
+            message_count,
+            average_tool_latency_ms,
+        })
+    }
+
+    pub fn to_toon_document(&self) -> String {
+        encode_toon_document("agent_tick_rollup", self)
+    }
+}
+
 /// Ring buffer retaining recent authoritative telemetry for tooling/debugging.
 #[derive(Debug, Clone)]
 pub struct TelemetryArchive {
@@ -410,8 +540,9 @@ mod tests {
     use crate::toon::decode_toon_value;
 
     use super::{
-        AgentTelemetryFrame, AgentToolCallTrace, TelemetryArchive, TelemetryConfig,
-        TickTelemetryFrame, ToolCallStatus, TrajectorySample,
+        ActionLifecycleStage, AgentTelemetryFrame, AgentTickRollup, AgentToolCallEvent,
+        AgentToolCallTrace, TelemetryArchive, TelemetryConfig, TickTelemetryFrame, ToolCallStatus,
+        TrajectorySample,
     };
 
     #[test]
@@ -534,5 +665,66 @@ mod tests {
         assert_eq!(archive_value["document_type"], "telemetry_archive");
         assert_eq!(archive_value["payload"]["retained_frames"], 1);
         assert_eq!(archive_value["payload"]["latest_tick"], 7);
+    }
+
+    #[test]
+    fn tool_call_event_and_rollup_export_to_toon_documents() {
+        let trace = AgentToolCallTrace::success(9, "llm.complete", "qwen", 21, 40, 18);
+        let event = AgentToolCallEvent::new(144, trace.clone());
+        let event_document = event.to_toon_document();
+        let event_value =
+            decode_toon_value(&event_document).expect("tool-call event should decode");
+        assert_eq!(event_value["document_type"], "agent_tool_call_event");
+        assert_eq!(event_value["payload"]["agent_entity_id"], 144);
+        assert_eq!(event_value["payload"]["trace"]["tool_name"], "llm.complete");
+
+        let runtime_profile = crate::contract::AgentRuntimeProfile {
+            role: AgentRole::Player,
+            agent_type: AgentType::Human,
+            capabilities: AgentCapabilities::player_default(),
+        };
+        let mut frame = AgentTelemetryFrame::new(
+            9,
+            crate::id::AgentId::new(),
+            Some(crate::id::EntityId(144)),
+            runtime_profile,
+            5,
+            1,
+            2,
+            3,
+            1,
+            None,
+            Some(TrajectorySample::new(9, 0.15, Vec2::ZERO, Vec2::X, 0.0)),
+        );
+        frame.update_trajectory_end(TrajectorySample::new(
+            9,
+            0.166,
+            Vec2::new(3.0, 4.0),
+            Vec2::new(1.0, 0.5),
+            0.2,
+        ));
+        frame.record_action(
+            crate::telemetry::ActionSource::ExternalSubmission,
+            ActionLifecycleStage::Submitted,
+            crate::action::Action::Idle,
+            None,
+        );
+        frame.record_action(
+            crate::telemetry::ActionSource::ExternalSubmission,
+            ActionLifecycleStage::Executed,
+            crate::action::Action::Idle,
+            None,
+        );
+        frame.record_tool_call(trace);
+
+        let rollup =
+            AgentTickRollup::from_agent_frames(144, &[frame]).expect("rollup should be built");
+        let rollup_document = rollup.to_toon_document();
+        let rollup_value =
+            decode_toon_value(&rollup_document).expect("rollup document should decode");
+        assert_eq!(rollup_value["document_type"], "agent_tick_rollup");
+        assert_eq!(rollup_value["payload"]["agent_entity_id"], 144);
+        assert_eq!(rollup_value["payload"]["tool_call_count"], 1);
+        assert_eq!(rollup_value["payload"]["visible_entity_count"], 5);
     }
 }

--- a/crates/pod-editor/src/lib.rs
+++ b/crates/pod-editor/src/lib.rs
@@ -12,9 +12,10 @@
 use eframe::{App, Frame};
 use egui::{CentralPanel, Context, SidePanel, TopBottomPanel, Ui};
 use pod_core::{
-    decode_toon_document, encode_toon_document, Action, ActionLifecycleStage, AgentTelemetryFrame,
-    AgentType, CreatureIdentity, CreatureTemperament, ReplayFile,
-    ShardIncidentSummary, TelemetryConfig, TickTelemetryFrame, ToolCallStatus, TrajectorySample,
+    decode_toon_document, decode_toon_value, encode_toon_document, Action, ActionLifecycleStage,
+    AgentTelemetryFrame, AgentTickRollup, AgentToolCallEvent, AgentType, CreatureIdentity,
+    CreatureTemperament, ReplayFile, ShardIncidentSummary, TelemetryConfig, TickTelemetryFrame,
+    ToolCallStatus, TrajectorySample, VersionedTickTelemetry,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
@@ -566,6 +567,10 @@ pub struct SpacetimeDashboardState {
     pub loot_actions: usize,
     #[serde(default)]
     pub latest_incident_summary: Option<ShardIncidentSummary>,
+    #[serde(default)]
+    pub recent_tool_call_events: VecDeque<AgentToolCallEvent>,
+    #[serde(default)]
+    pub recent_tick_rollups: VecDeque<AgentTickRollup>,
     pub last_reducer_call: String,
     pub reducer_calls: u32,
 }
@@ -588,6 +593,8 @@ impl Default for SpacetimeDashboardState {
             gather_actions: 0,
             loot_actions: 0,
             latest_incident_summary: None,
+            recent_tool_call_events: VecDeque::new(),
+            recent_tick_rollups: VecDeque::new(),
             last_reducer_call: "none".to_string(),
             reducer_calls: 0,
         }
@@ -754,6 +761,102 @@ impl SpacetimeDashboardState {
         self.latest_incident_summary = Some(summary);
     }
 
+    pub fn apply_tool_call_event(&mut self, event: AgentToolCallEvent) {
+        retain_recent_debug_docs(
+            &mut self.recent_tool_call_events,
+            TelemetryConfig::default().editor_timeline_ticks,
+        );
+        self.latest_tick = self.latest_tick.max(event.tick);
+        self.recent_tool_call_events.push_back(event);
+
+        let total_tool_calls = self.recent_tool_call_events.len();
+        let tool_errors = self
+            .recent_tool_call_events
+            .iter()
+            .filter(|event| {
+                !matches!(
+                    event.trace.status,
+                    ToolCallStatus::Requested | ToolCallStatus::Succeeded
+                )
+            })
+            .count();
+        self.tool_call_error_rate = if total_tool_calls == 0 {
+            0.0
+        } else {
+            tool_errors as f32 / total_tool_calls as f32
+        };
+        self.average_tool_latency_ms = if total_tool_calls == 0 {
+            0.0
+        } else {
+            self.recent_tool_call_events
+                .iter()
+                .map(|event| event.trace.latency_ms as f32)
+                .sum::<f32>()
+                / total_tool_calls as f32
+        };
+    }
+
+    pub fn apply_tick_rollup(&mut self, rollup: AgentTickRollup) {
+        retain_recent_debug_docs(
+            &mut self.recent_tick_rollups,
+            TelemetryConfig::default().editor_timeline_ticks,
+        );
+        self.latest_tick = self.latest_tick.max(rollup.tick_end);
+        self.visible_entity_count = rollup.visible_entity_count as usize;
+        self.audible_event_count = rollup.audible_event_count as usize;
+        self.message_count = rollup.message_count as usize;
+        self.recent_tick_rollups.push_back(rollup.clone());
+
+        let total_actions = self
+            .recent_tick_rollups
+            .iter()
+            .map(|rollup| {
+                rollup.submitted_action_count
+                    + rollup.executed_action_count
+                    + rollup.rejected_action_count
+            })
+            .sum::<u32>();
+        let total_rejected = self
+            .recent_tick_rollups
+            .iter()
+            .map(|rollup| rollup.rejected_action_count)
+            .sum::<u32>();
+        self.action_rejection_rate = if total_actions == 0 {
+            0.0
+        } else {
+            total_rejected as f32 / total_actions as f32
+        };
+        self.average_trajectory_distance = if self.recent_tick_rollups.is_empty() {
+            0.0
+        } else {
+            self.recent_tick_rollups
+                .iter()
+                .map(|rollup| rollup.total_distance)
+                .sum::<f32>()
+                / self.recent_tick_rollups.len() as f32
+        };
+
+        match self
+            .agent_summaries
+            .iter_mut()
+            .find(|summary| summary.entity_id == Some(rollup.agent_entity_id))
+        {
+            Some(summary) => {
+                summary.trajectory_distance = rollup.total_distance;
+                summary.rejected_actions = rollup.rejected_action_count as usize;
+                summary.tool_errors = rollup.tool_error_count as usize;
+            }
+            None => self.agent_summaries.push(TelemetryAgentSummary {
+                agent_id: format!("entity:{}", rollup.agent_entity_id),
+                entity_id: Some(rollup.agent_entity_id),
+                role: "Rollup".to_string(),
+                trajectory_distance: rollup.total_distance,
+                rejected_actions: rollup.rejected_action_count as usize,
+                tool_errors: rollup.tool_error_count as usize,
+            }),
+        }
+    }
+
     pub fn to_toon_document(&self) -> String {
         encode_toon_document("editor_spacetime_dashboard", self)
     }
@@ -842,6 +945,12 @@ impl TelemetryPanelState {
 
     pub fn to_toon_document(&self) -> String {
         encode_toon_document("editor_telemetry_panel", self)
+    }
+}
+
+fn retain_recent_debug_docs<T>(entries: &mut VecDeque<T>, max_entries: usize) {
+    while entries.len() >= max_entries.max(1) {
+        entries.pop_front();
     }
 }
 
@@ -2049,6 +2158,83 @@ impl PodEditorApp {
         Ok(())
     }
 
+    pub fn import_agent_tool_call_toon_document(&mut self, document: &str) -> Result<(), String> {
+        let event: AgentToolCallEvent = decode_toon_document(document, "agent_tool_call_event")?;
+        let agent_entity_id = event.agent_entity_id;
+
+        self.history.remember(self.state.clone());
+        self.state.spacetime_dashboard.apply_tool_call_event(event);
+        self.push_console(format!(
+            "Imported live tool-call event for entity {agent_entity_id}"
+        ));
+        Ok(())
+    }
+
+    pub fn import_agent_tick_rollup_toon_document(&mut self, document: &str) -> Result<(), String> {
+        let rollup: AgentTickRollup = decode_toon_document(document, "agent_tick_rollup")?;
+        let agent_entity_id = rollup.agent_entity_id;
+
+        self.history.remember(self.state.clone());
+        self.state.spacetime_dashboard.apply_tick_rollup(rollup);
+        self.push_console(format!(
+            "Imported telemetry rollup for entity {agent_entity_id}"
+        ));
+        Ok(())
+    }
+
+    pub fn import_live_debug_toon_document(&mut self, document: &str) -> Result<(), String> {
+        let document_type = decode_toon_value(document)?
+            .get("document_type")
+            .and_then(|value| value.as_str())
+            .ok_or_else(|| "Missing TOON document_type".to_string())?
+            .to_string();
+
+        match document_type.as_str() {
+            "versioned_tick_telemetry" => {
+                let telemetry: VersionedTickTelemetry =
+                    decode_toon_document(document, "versioned_tick_telemetry")?;
+                self.history.remember(self.state.clone());
+                self.record_tick_telemetry(telemetry.payload);
+                self.push_console("Imported live tick telemetry".to_string());
+                Ok(())
+            }
+            "tick_telemetry_frame" => {
+                let telemetry: TickTelemetryFrame =
+                    decode_toon_document(document, "tick_telemetry_frame")?;
+                self.history.remember(self.state.clone());
+                self.record_tick_telemetry(telemetry);
+                self.push_console("Imported live tick telemetry".to_string());
+                Ok(())
+            }
+            "agent_tool_call_event" => self.import_agent_tool_call_toon_document(document),
+            "agent_tick_rollup" => self.import_agent_tick_rollup_toon_document(document),
+            "replay_file" => {
+                let replay: ReplayFile = decode_toon_document(document, "replay_file")?;
+                let replay_name = replay.header.name.clone();
+                let telemetry_windows = replay.telemetry_windows.clone();
+
+                self.history.remember(self.state.clone());
+                self.state.latest_replay = Some(replay);
+                if self.state.telemetry.latest().is_none() && !telemetry_windows.is_empty() {
+                    self.state
+                        .telemetry
+                        .replace_timeline(telemetry_windows.clone());
+                    if let Some(last_frame) = telemetry_windows.last() {
+                        self.state
+                            .spacetime_dashboard
+                            .record_tick_telemetry(last_frame);
+                    }
+                }
+                self.push_console(format!("Streamed live replay {replay_name}"));
+                Ok(())
+            }
+            "shard_incident_summary" => self.import_shard_incident_toon_document(document),
+            _ => Err(format!(
+                "Unsupported live debug document type `{document_type}`"
+            )),
+        }
+    }
+
     pub fn can_undo(&self) -> bool {
         self.history.can_undo()
     }
@@ -3245,6 +3431,38 @@ mod tests {
         }
     }
 
+    fn sample_tool_call_event(tick: u64, entity_id: u64) -> AgentToolCallEvent {
+        AgentToolCallEvent::new(
+            entity_id,
+            AgentToolCallTrace::failure(
+                tick,
+                "llm.complete",
+                "qwen",
+                ToolCallStatus::TimedOut,
+                48,
+                "timeout",
+            ),
+        )
+    }
+
+    fn sample_tick_rollup(entity_id: u64) -> AgentTickRollup {
+        AgentTickRollup {
+            tick_start: 10,
+            tick_end: 15,
+            agent_entity_id: entity_id,
+            total_distance: 16.75,
+            submitted_action_count: 4,
+            executed_action_count: 3,
+            rejected_action_count: 1,
+            tool_call_count: 1,
+            tool_error_count: 1,
+            visible_entity_count: 12,
+            audible_event_count: 3,
+            message_count: 2,
+            average_tool_latency_ms: 48.0,
+        }
+    }
+
     #[test]
     fn editor_default_state_is_viewport() {
         let app = PodEditorApp::default();
@@ -3669,6 +3887,92 @@ mod tests {
         assert_eq!(incident.shard_id, "alpha-1");
         assert_eq!(app.state.spacetime_dashboard.average_tool_latency_ms, 820.0);
         assert_eq!(app.state.spacetime_dashboard.capture_actions, 4);
+    }
+
+    #[test]
+    fn editor_imports_live_tool_call_and_rollup_toon_documents() {
+        let mut app = PodEditorApp::default();
+        let tool_event = sample_tool_call_event(16, 1001);
+        let rollup = sample_tick_rollup(1001);
+
+        app.import_agent_tool_call_toon_document(&tool_event.to_toon_document())
+            .expect("tool-call TOON should import");
+        app.import_agent_tick_rollup_toon_document(&rollup.to_toon_document())
+            .expect("rollup TOON should import");
+
+        assert_eq!(
+            app.state.spacetime_dashboard.recent_tool_call_events.len(),
+            1
+        );
+        assert_eq!(app.state.spacetime_dashboard.recent_tick_rollups.len(), 1);
+        assert!(app.state.spacetime_dashboard.tool_call_error_rate > 0.0);
+        assert_eq!(app.state.spacetime_dashboard.visible_entity_count, 12);
+        assert_eq!(app.state.spacetime_dashboard.agent_summaries.len(), 1);
+    }
+
+    #[test]
+    fn editor_routes_live_debug_toon_documents_into_existing_surfaces() {
+        let mut app = PodEditorApp::default();
+        let replay = sample_replay_file();
+        let incident = ShardIncidentSummary {
+            shard_id: "alpha-2".to_string(),
+            latest_tick: 360,
+            severity: pod_core::IncidentSeverity::Warning,
+            summary: "Shard alpha-2 requires attention".to_string(),
+            tick_budget_overrun_rate: 0.08,
+            action_rejection_rate: 0.02,
+            tool_call_error_rate: 0.11,
+            average_tool_latency_ms: 820.0,
+            average_trajectory_distance: 3.2,
+            peak_entity_count: 512,
+            peak_agent_count: 128,
+            capture_actions: 4,
+            summon_actions: 2,
+            gather_actions: 7,
+            loot_actions: 9,
+            notes: vec!["tool-call error rate exceeds 10%".to_string()],
+        };
+
+        app.import_live_debug_toon_document(
+            &VersionedTickTelemetry::new(sample_tick_telemetry(18, 1001)).to_toon_document(),
+        )
+        .expect("telemetry TOON should route");
+        app.import_live_debug_toon_document(&sample_tool_call_event(18, 1001).to_toon_document())
+            .expect("tool-call TOON should route");
+        app.import_live_debug_toon_document(&sample_tick_rollup(1001).to_toon_document())
+            .expect("rollup TOON should route");
+        app.import_live_debug_toon_document(&replay.to_toon_document())
+            .expect("replay TOON should route");
+        app.import_live_debug_toon_document(&incident.to_toon_document())
+            .expect("incident TOON should route");
+
+        assert_eq!(
+            app.state.telemetry.latest().expect("telemetry stored").tick,
+            18
+        );
+        assert_eq!(
+            app.state
+                .latest_replay
+                .as_ref()
+                .expect("replay stored")
+                .header
+                .name,
+            "flagship-mmo-loop"
+        );
+        assert_eq!(
+            app.state
+                .spacetime_dashboard
+                .latest_incident_summary
+                .as_ref()
+                .expect("incident stored")
+                .shard_id,
+            "alpha-2"
+        );
+        assert_eq!(
+            app.state.spacetime_dashboard.recent_tool_call_events.len(),
+            1
+        );
+        assert_eq!(app.state.spacetime_dashboard.recent_tick_rollups.len(), 1);
     }
 
     #[test]

--- a/crates/pod-net/src/client_stdb.rs
+++ b/crates/pod-net/src/client_stdb.rs
@@ -396,6 +396,7 @@ pub struct SpacetimeDBClient {
     pending_actions: Vec<Action>,
     local_snapshot: Option<WorldSnapshot>,
     last_debug_telemetry_json: Option<String>,
+    pending_debug_documents: Vec<String>,
     render_buffer: SnapshotInterpolationBuffer,
     render_clock: RenderClock,
     welcome_sent: bool,
@@ -413,6 +414,7 @@ impl SpacetimeDBClient {
             pending_actions: Vec::new(),
             local_snapshot: None,
             last_debug_telemetry_json: None,
+            pending_debug_documents: Vec::new(),
             render_buffer: SnapshotInterpolationBuffer::default(),
             render_clock: RenderClock::default(),
             welcome_sent: false,
@@ -693,7 +695,12 @@ impl SpacetimeDBClient {
                 }
                 StdbEvent::AgentTelemetryTickReceived { frame_json, .. } => {
                     self.last_debug_telemetry_json = Some(frame_json.clone());
+                    self.pending_debug_documents.push(frame_json.clone());
                     messages.push(ServerMessage::TickTelemetry { frame_json });
+                }
+                StdbEvent::AgentToolCallEventReceived { document, .. }
+                | StdbEvent::AgentTickRollupReceived { document, .. } => {
+                    self.pending_debug_documents.push(document);
                 }
 
                 // ── Tick advancement ──
@@ -715,8 +722,6 @@ impl SpacetimeDBClient {
 
                 // ── Internal events (no ServerMessage equivalent) ──
                 StdbEvent::ObservationReceived { .. }
-                | StdbEvent::AgentToolCallEventReceived { .. }
-                | StdbEvent::AgentTickRollupReceived { .. }
                 | StdbEvent::ReducerCallSuccess { .. }
                 | StdbEvent::ReducerCallError { .. } => {}
             }
@@ -732,6 +737,7 @@ impl SpacetimeDBClient {
         self.welcome_sent = false;
         self.last_emitted_tick = 0;
         self.last_debug_telemetry_json = None;
+        self.pending_debug_documents.clear();
         self.subscriptions.reset_connection();
         self.clear_presentation_state();
     }
@@ -868,6 +874,27 @@ impl SpacetimeDBClient {
 
     pub fn last_debug_telemetry_document(&self) -> Option<&str> {
         self.last_debug_telemetry_json()
+    }
+
+    /// Inspect the newest retained TOON document across live debug telemetry,
+    /// tool-call events, rollups, replays, and shard incidents.
+    pub fn last_debug_document(&self) -> Option<&str> {
+        self.pending_debug_documents
+            .last()
+            .map(String::as_str)
+            .or_else(|| self.last_debug_telemetry_document())
+    }
+
+    /// Drain all pending TOON debug documents gathered since the last call.
+    pub fn drain_debug_documents(&mut self) -> Vec<String> {
+        std::mem::take(&mut self.pending_debug_documents)
+    }
+
+    /// Inject a TOON debug document into the live stream surface. This lets
+    /// shard tooling forward replay files and incident summaries through the
+    /// same browser/editor consumer path as tick telemetry.
+    pub fn push_debug_document(&mut self, document: String) {
+        self.pending_debug_documents.push(document);
     }
 
     /// Inspect the local rollback/replay path from a chosen retained tick.
@@ -1220,7 +1247,9 @@ fn convert_world_event(
 mod tests {
     use super::*;
     use pod_core::{
-        action::SpeakVolume as CoreSpeakVolume, TickTelemetryFrame, VersionedTickTelemetry,
+        action::SpeakVolume as CoreSpeakVolume, AgentTickRollup, AgentToolCallEvent,
+        AgentToolCallTrace, ReplayFile, ReplayHeader, ShardIncidentSummary, TickTelemetryFrame,
+        VersionedTickTelemetry,
     };
 
     #[test]
@@ -1587,6 +1616,115 @@ mod tests {
         assert!(client
             .last_debug_telemetry_document()
             .expect("debug telemetry stored")
+            .contains("versioned_tick_telemetry"));
+    }
+
+    #[test]
+    fn test_debug_documents_include_live_tool_rollup_replay_and_incident_docs() {
+        let mut client = SpacetimeDBClient::new(SpacetimeDBClientConfig::default());
+        client.inner_mut().receive_agent_telemetry_tick(
+            12,
+            44,
+            VersionedTickTelemetry::new(TickTelemetryFrame::empty(12)).to_toon_document(),
+        );
+        client.inner_mut().receive_agent_tool_call_event(
+            12,
+            44,
+            "llm.complete".into(),
+            "qwen".into(),
+            "TimedOut".into(),
+            AgentToolCallEvent::new(
+                44,
+                AgentToolCallTrace::failure(
+                    12,
+                    "llm.complete",
+                    "qwen",
+                    pod_core::ToolCallStatus::TimedOut,
+                    48,
+                    "timeout",
+                ),
+            )
+            .to_toon_document(),
+        );
+        client.inner_mut().receive_agent_tick_rollup(
+            1,
+            60,
+            44,
+            AgentTickRollup {
+                tick_start: 1,
+                tick_end: 60,
+                agent_entity_id: 44,
+                total_distance: 18.5,
+                submitted_action_count: 4,
+                executed_action_count: 3,
+                rejected_action_count: 1,
+                tool_call_count: 1,
+                tool_error_count: 1,
+                visible_entity_count: 12,
+                audible_event_count: 3,
+                message_count: 2,
+                average_tool_latency_ms: 48.0,
+            }
+            .to_toon_document(),
+        );
+
+        client.push_debug_document(
+            ReplayFile {
+                header: ReplayHeader {
+                    name: "ops-replay".into(),
+                    timestamp: 1_741_315_200,
+                    world_seed: 42,
+                    tick_count: 1,
+                    agent_count: 0,
+                    notes: "debug".into(),
+                },
+                traces: Vec::new(),
+                telemetry_windows: vec![TickTelemetryFrame::empty(12)],
+            }
+            .to_toon_document(),
+        );
+        client.push_debug_document(
+            ShardIncidentSummary {
+                shard_id: "alpha-1".into(),
+                latest_tick: 12,
+                severity: pod_core::IncidentSeverity::Warning,
+                summary: "Shard alpha-1 requires attention".into(),
+                tick_budget_overrun_rate: 0.08,
+                action_rejection_rate: 0.02,
+                tool_call_error_rate: 0.11,
+                average_tool_latency_ms: 820.0,
+                average_trajectory_distance: 3.2,
+                peak_entity_count: 512,
+                peak_agent_count: 128,
+                capture_actions: 4,
+                summon_actions: 2,
+                gather_actions: 7,
+                loot_actions: 9,
+                notes: vec!["tool-call error rate exceeds 10%".into()],
+            }
+            .to_toon_document(),
+        );
+
+        let _ = client.poll_updates();
+        let documents = client.drain_debug_documents();
+        assert!(documents
+            .iter()
+            .any(|document| document.contains("versioned_tick_telemetry")));
+        assert!(documents
+            .iter()
+            .any(|document| document.contains("agent_tool_call_event")));
+        assert!(documents
+            .iter()
+            .any(|document| document.contains("agent_tick_rollup")));
+        assert!(documents
+            .iter()
+            .any(|document| document.contains("replay_file")));
+        assert!(documents
+            .iter()
+            .any(|document| document.contains("shard_incident_summary")));
+        assert!(client
+            .last_debug_document()
+            .expect("latest telemetry document retained")
             .contains("versioned_tick_telemetry"));
     }
 

--- a/crates/pod-stdb/src/client.rs
+++ b/crates/pod-stdb/src/client.rs
@@ -239,14 +239,14 @@ pub enum StdbEvent {
         tool_name: String,
         provider: String,
         status: String,
-        data_json: String,
+        document: String,
     },
     /// Durable aggregate telemetry rollup received for dashboards/analytics.
     AgentTickRollupReceived {
         tick_start: u64,
         tick_end: u64,
         agent_entity_id: u64,
-        rollup_json: String,
+        document: String,
     },
 
     // ── Reducer acknowledgments ──
@@ -1878,7 +1878,7 @@ impl StdbClient {
         tool_name: String,
         provider: String,
         status: String,
-        data_json: String,
+        document: String,
     ) {
         self.events
             .push_back(StdbEvent::AgentToolCallEventReceived {
@@ -1887,7 +1887,7 @@ impl StdbClient {
                 tool_name,
                 provider,
                 status,
-                data_json,
+                document,
             });
         self.events_received += 1;
     }
@@ -1898,13 +1898,13 @@ impl StdbClient {
         tick_start: u64,
         tick_end: u64,
         agent_entity_id: u64,
-        rollup_json: String,
+        document: String,
     ) {
         self.events.push_back(StdbEvent::AgentTickRollupReceived {
             tick_start,
             tick_end,
             agent_entity_id,
-            rollup_json,
+            document,
         });
         self.events_received += 1;
     }
@@ -2098,7 +2098,10 @@ mod tests {
 
     #[test]
     fn test_receive_debug_telemetry_events() {
-        use pod_core::{AgentToolCallTrace, TickTelemetryFrame, VersionedTickTelemetry};
+        use pod_core::{
+            AgentTickRollup, AgentToolCallEvent, AgentToolCallTrace, TickTelemetryFrame,
+            VersionedTickTelemetry,
+        };
 
         let mut client = StdbClient::new(StdbClientConfig::default());
         client.receive_agent_telemetry_tick(
@@ -2112,9 +2115,33 @@ mod tests {
             "llm.complete".into(),
             "qwen".into(),
             "Succeeded".into(),
-            AgentToolCallTrace::success(8, "llm.complete", "qwen", 12, 24, 8).to_toon_document(),
+            AgentToolCallEvent::new(
+                41,
+                AgentToolCallTrace::success(8, "llm.complete", "qwen", 12, 24, 8),
+            )
+            .to_toon_document(),
         );
-        client.receive_agent_tick_rollup(1, 60, 41, "{\"distance\":42.0}".into());
+        client.receive_agent_tick_rollup(
+            1,
+            60,
+            41,
+            AgentTickRollup {
+                tick_start: 1,
+                tick_end: 60,
+                agent_entity_id: 41,
+                total_distance: 42.0,
+                submitted_action_count: 4,
+                executed_action_count: 3,
+                rejected_action_count: 1,
+                tool_call_count: 2,
+                tool_error_count: 1,
+                visible_entity_count: 21,
+                audible_event_count: 4,
+                message_count: 2,
+                average_tool_latency_ms: 24.0,
+            }
+            .to_toon_document(),
+        );
 
         let events: Vec<StdbEvent> = client.drain_events().collect();
         assert!(matches!(
@@ -2130,8 +2157,9 @@ mod tests {
             StdbEvent::AgentToolCallEventReceived {
                 tick: 8,
                 agent_entity_id: 41,
+                document,
                 ..
-            }
+            } if document.contains("agent_tool_call_event")
         ));
         assert!(matches!(
             &events[2],
@@ -2139,8 +2167,8 @@ mod tests {
                 tick_start: 1,
                 tick_end: 60,
                 agent_entity_id: 41,
-                ..
-            }
+                document,
+            } if document.contains("agent_tick_rollup")
         ));
     }
 

--- a/crates/pod-stdb/src/events.rs
+++ b/crates/pod-stdb/src/events.rs
@@ -155,6 +155,9 @@ pub struct AgentTelemetryTickRow {
 }
 
 /// Tool/provider telemetry event for embedded agent runtimes.
+///
+/// `data_json` stores the canonical `agent_tool_call_event` TOON document so
+/// browser/editor/debug consumers can ingest the same payload directly.
 #[spacetimedb::table(name = agent_tool_call_event, public)]
 pub struct AgentToolCallEventRow {
     #[primary_key]
@@ -172,6 +175,9 @@ pub struct AgentToolCallEventRow {
 }
 
 /// Durable aggregate telemetry rollup for dashboards and offline analytics.
+///
+/// `rollup_json` stores the canonical `agent_tick_rollup` TOON document so the
+/// flattened row can coexist with richer debug consumers.
 #[spacetimedb::table(name = agent_tick_rollup, public)]
 pub struct AgentTickRollupRow {
     #[primary_key]

--- a/crates/pod-stdb/tests/client_integration.rs
+++ b/crates/pod-stdb/tests/client_integration.rs
@@ -148,14 +148,14 @@ fn telemetry_events_are_constructible() {
         tool_name: "llm.complete".into(),
         provider: "qwen".into(),
         status: "Succeeded".into(),
-        data_json: AgentToolCallTrace::success(12, "llm.complete", "qwen", 18, 128, 64)
+        document: AgentToolCallTrace::success(12, "llm.complete", "qwen", 18, 128, 64)
             .to_toon_document(),
     };
     let rollup = StdbEvent::AgentTickRollupReceived {
         tick_start: 1,
         tick_end: 60,
         agent_entity_id: 7,
-        rollup_json: "{\"distance\":84.0}".into(),
+        document: "{\"distance\":84.0}".into(),
     };
 
     assert!(matches!(tick, StdbEvent::AgentTelemetryTickReceived { .. }));
@@ -927,14 +927,14 @@ fn stdb_event_all_18_variants_constructible() {
             tool_name: "llm.complete".into(),
             provider: "qwen".into(),
             status: "Succeeded".into(),
-            data_json: AgentToolCallTrace::success(1, "llm.complete", "qwen", 12, 42, 10)
+            document: AgentToolCallTrace::success(1, "llm.complete", "qwen", 12, 42, 10)
                 .to_toon_document(),
         },
         StdbEvent::AgentTickRollupReceived {
             tick_start: 1,
             tick_end: 60,
             agent_entity_id: 5,
-            rollup_json: "{\"distance\":128.0}".into(),
+            document: "{\"distance\":128.0}".into(),
         },
         // Reducer acknowledgments
         StdbEvent::ReducerCallSuccess {


### PR DESCRIPTION
## Summary
- add canonical TOON tool-call event and telemetry rollup documents in pod-core
- carry live TOON debug documents through the SpacetimeDB adapter and shard debug hooks
- teach pod-web and pod-editor to ingest tool-call, rollup, replay, and incident TOON streams

## Testing
- cargo test -p pod-core --lib
- cargo test -p pod-stdb --no-default-features --features client
- cargo test -p pod-net --features spacetimedb --lib
- cargo test -p pod-editor --lib
- cd apps/pod-web && bun test && bun run typecheck && bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added debug telemetry summaries displaying tool-call event details and tick rollup metrics in the debug UI.
  * Extended debug document streaming to parse and route live telemetry, tool events, and rollup data.
  * Enhanced agent performance tracking with telemetry rollup summaries including action counts, latency, and distance metrics.

* **Documentation**
  * Updated implementation plan with Iteration 66 deliverables for TOON-based telemetry and debug document handling across core, network, web, and editor layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->