### PR TITLE
Add live shard debug document parity

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -614,5 +614,17 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cargo test -p pod-server --bin pod-server`
   - `cargo test -p pod-net --features spacetimedb --lib`
 
-**Last updated**: Iteration 67
-**Current focus**: Iteration 68 browser/editor consumption of live authoritative shard debug streams plus embedded-agent tool-call persistence into the SpacetimeDB runtime path
+### Iteration 68
+- [x] Added a generic `ServerMessage::DebugDocument` TOON transport in `pod-net` so direct-connect debug consumers can receive authoritative telemetry/tool/rollup documents without inventing another JSON-only side channel.
+- [x] Updated native, web, and SpacetimeDB pod-net clients to retain and drain live TOON debug documents while preserving the existing tick-telemetry convenience accessors for tooling that still wants the latest authoritative telemetry frame.
+- [x] Extended the direct-connect `GameServer` debug path to retain authoritative telemetry history, emit live tool-call events from embedded agents, and derive 60-tick rollups for debug subscribers over the same live document surface.
+- [x] Closed the remaining SpacetimeDB runtime gap by persisting reducer-side embedded tool-call telemetry into `agent_tool_call_event` rows as canonical TOON `agent_tool_call_event` documents.
+- [x] Added deterministic coverage for the new protocol message, native/debug client queues, direct-connect server debug broadcasting, and reducer-side tool-call TOON event generation.
+- [x] Validated touched targets:
+  - `cargo test -p pod-net --lib`
+  - `cargo test -p pod-net --features spacetimedb --lib`
+  - `cargo test -p pod-stdb --no-default-features --features client`
+  - `cargo check -p pod-stdb --no-default-features --features module --target wasm32-unknown-unknown`
+
+**Last updated**: Iteration 68
+**Current focus**: Iteration 69 browser/editor live wiring for direct-connect shard debug streams plus MMO world/runtime slice completion beyond TOON telemetry parity

--- a/crates/pod-net/src/client_native.rs
+++ b/crates/pod-net/src/client_native.rs
@@ -11,7 +11,7 @@ use log::{debug, error, info, warn};
 use quinn::Endpoint;
 use tokio::sync::mpsc;
 
-use pod_core::Action;
+use pod_core::{decode_toon_value, Action};
 
 use crate::protocol::{
     ClientConfig as ProtoClientConfig, ClientId, ClientMessage, ReconnectToken, ServerMessage,
@@ -64,6 +64,10 @@ pub struct NativeClient {
     last_reconciliation: Option<ReconciliationReport>,
     /// Most recent debug telemetry payload received from the server.
     last_debug_telemetry_json: Option<String>,
+    /// Most recent debug document of any supported TOON kind.
+    last_debug_document: Option<String>,
+    /// Pending TOON debug documents gathered since the last drain.
+    pending_debug_documents: Vec<String>,
     /// Recovery request throttle/telemetry for full-snapshot resync.
     recovery_state: RecoveryRequestState,
     /// Authoritative history for presentation smoothing.
@@ -156,6 +160,8 @@ impl NativeClient {
             reconnect_token: None,
             last_reconciliation: None,
             last_debug_telemetry_json: None,
+            last_debug_document: None,
+            pending_debug_documents: Vec::new(),
             recovery_state: RecoveryRequestState::default(),
             render_buffer: SnapshotInterpolationBuffer::default(),
             render_clock: RenderClock::default(),
@@ -459,7 +465,11 @@ impl NativeClient {
             }
             ServerMessage::Pong { .. } => true,
             ServerMessage::TickTelemetry { frame_json } => {
-                self.last_debug_telemetry_json = Some(frame_json.clone());
+                self.record_debug_document(frame_json.clone());
+                true
+            }
+            ServerMessage::DebugDocument { document } => {
+                self.record_debug_document(document.clone());
                 true
             }
             ServerMessage::Rejected { reason } => {
@@ -508,6 +518,8 @@ impl NativeClient {
         );
         self.recovery_state.clear();
         self.last_debug_telemetry_json = None;
+        self.last_debug_document = None;
+        self.pending_debug_documents.clear();
         self.clear_presentation_state();
 
         info!("Disconnected from server");
@@ -555,6 +567,16 @@ impl NativeClient {
 
     pub fn last_debug_telemetry_document(&self) -> Option<&str> {
         self.last_debug_telemetry_json()
+    }
+
+    pub fn last_debug_document(&self) -> Option<&str> {
+        self.last_debug_document
+            .as_deref()
+            .or_else(|| self.last_debug_telemetry_document())
+    }
+
+    pub fn drain_debug_documents(&mut self) -> Vec<String> {
+        std::mem::take(&mut self.pending_debug_documents)
     }
 
     /// Inspect the local rollback/replay path from a chosen authoritative tick.
@@ -729,6 +751,20 @@ impl NativeClient {
             used_hard_resync,
         });
     }
+
+    fn record_debug_document(&mut self, document: String) {
+        if decode_toon_value(&document)
+            .ok()
+            .and_then(|value| value["document_type"].as_str().map(str::to_owned))
+            .as_deref()
+            == Some("versioned_tick_telemetry")
+        {
+            self.last_debug_telemetry_json = Some(document.clone());
+        }
+
+        self.last_debug_document = Some(document.clone());
+        self.pending_debug_documents.push(document);
+    }
 }
 
 // ============================================================
@@ -899,6 +935,8 @@ mod tests {
             reconnect_token: None,
             last_reconciliation: None,
             last_debug_telemetry_json: None,
+            last_debug_document: None,
+            pending_debug_documents: Vec::new(),
             recovery_state: RecoveryRequestState::default(),
             render_buffer,
             render_clock,
@@ -945,6 +983,8 @@ mod tests {
             reconnect_token: None,
             last_reconciliation: None,
             last_debug_telemetry_json: None,
+            last_debug_document: None,
+            pending_debug_documents: Vec::new(),
             recovery_state: RecoveryRequestState::default(),
             render_buffer: SnapshotInterpolationBuffer::default(),
             render_clock: RenderClock::default(),
@@ -983,6 +1023,8 @@ mod tests {
             reconnect_token: None,
             last_reconciliation: None,
             last_debug_telemetry_json: None,
+            last_debug_document: None,
+            pending_debug_documents: Vec::new(),
             recovery_state: RecoveryRequestState::default(),
             render_buffer: SnapshotInterpolationBuffer::default(),
             render_clock: RenderClock::default(),
@@ -997,5 +1039,58 @@ mod tests {
             .last_debug_telemetry_document()
             .expect("debug telemetry stored")
             .contains("versioned_tick_telemetry"));
+        assert_eq!(client.drain_debug_documents().len(), 1);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_debug_document_updates_generic_cache() {
+        let endpoint = Endpoint::client("0.0.0.0:0".parse().unwrap()).unwrap();
+        let (tx, rx) = mpsc::channel(1);
+        let mut client = NativeClient {
+            config: ProtoClientConfig {
+                server_addr: "localhost".into(),
+                server_port: 5000,
+                player_name: "Tester".into(),
+                timeout_ms: 1000,
+            },
+            client_id: None,
+            connection: None,
+            endpoint,
+            rx,
+            tx,
+            reader_task: None,
+            pending_updates: Vec::new(),
+            authoritative_snapshot: None,
+            local_snapshot: None,
+            controlled_entity: None,
+            pending_actions: Vec::new(),
+            prediction_history: Vec::new(),
+            last_server_tick: 0,
+            last_acknowledged_action_tick: None,
+            last_event_tick: 0,
+            reconnect_token: None,
+            last_reconciliation: None,
+            last_debug_telemetry_json: None,
+            last_debug_document: None,
+            pending_debug_documents: Vec::new(),
+            recovery_state: RecoveryRequestState::default(),
+            render_buffer: SnapshotInterpolationBuffer::default(),
+            render_clock: RenderClock::default(),
+        };
+
+        let message = ServerMessage::DebugDocument {
+            document: pod_core::AgentToolCallEvent::new(
+                44,
+                pod_core::AgentToolCallTrace::success(4, "llm.complete", "qwen", 18, 128, 64),
+            )
+            .to_toon_document(),
+        };
+        assert!(client.apply_server_message(&message));
+        assert!(client
+            .last_debug_document()
+            .expect("latest debug document stored")
+            .contains("agent_tool_call_event"));
+        assert!(client.last_debug_telemetry_document().is_none());
+        assert_eq!(client.drain_debug_documents().len(), 1);
     }
 }

--- a/crates/pod-net/src/client_stdb.rs
+++ b/crates/pod-net/src/client_stdb.rs
@@ -696,11 +696,14 @@ impl SpacetimeDBClient {
                 StdbEvent::AgentTelemetryTickReceived { frame_json, .. } => {
                     self.last_debug_telemetry_json = Some(frame_json.clone());
                     self.pending_debug_documents.push(frame_json.clone());
-                    messages.push(ServerMessage::TickTelemetry { frame_json });
+                    messages.push(ServerMessage::DebugDocument {
+                        document: frame_json,
+                    });
                 }
                 StdbEvent::AgentToolCallEventReceived { document, .. }
                 | StdbEvent::AgentTickRollupReceived { document, .. } => {
-                    self.pending_debug_documents.push(document);
+                    self.pending_debug_documents.push(document.clone());
+                    messages.push(ServerMessage::DebugDocument { document });
                 }
 
                 // ── Tick advancement ──
@@ -1599,7 +1602,7 @@ mod tests {
     }
 
     #[test]
-    fn test_poll_updates_emits_tick_telemetry_from_stdb_events() {
+    fn test_poll_updates_emits_debug_documents_from_stdb_events() {
         let mut client = SpacetimeDBClient::new(SpacetimeDBClientConfig::default());
         client.inner_mut().receive_agent_telemetry_tick(
             12,
@@ -1610,8 +1613,8 @@ mod tests {
         let messages = client.poll_updates();
         assert!(messages.iter().any(|message| matches!(
             message,
-            ServerMessage::TickTelemetry { frame_json }
-                if frame_json.contains("versioned_tick_telemetry")
+            ServerMessage::DebugDocument { document }
+                if document.contains("versioned_tick_telemetry")
         )));
         assert!(client
             .last_debug_telemetry_document()

--- a/crates/pod-net/src/client_web.rs
+++ b/crates/pod-net/src/client_web.rs
@@ -11,7 +11,7 @@ use std::sync::{Arc, Mutex};
 use wasm_bindgen::prelude::*;
 use web_sys::WebSocket;
 
-use pod_core::Action;
+use pod_core::{decode_toon_value, Action};
 
 use crate::protocol::{ClientConfig, ClientId, ClientMessage, ReconnectToken, ServerMessage};
 use crate::snapshot::{
@@ -60,6 +60,10 @@ pub struct WebClient {
     last_reconciliation: Option<ReconciliationReport>,
     /// Most recent debug telemetry payload received from the server.
     last_debug_telemetry_json: Option<String>,
+    /// Most recent debug document of any supported TOON kind.
+    last_debug_document: Option<String>,
+    /// Pending TOON debug documents gathered since the last drain.
+    pending_debug_documents: Vec<String>,
     /// Recovery request throttle/telemetry for full-snapshot resync.
     recovery_state: RecoveryRequestState,
     /// Authoritative history for presentation smoothing.
@@ -93,6 +97,8 @@ impl WebClient {
             reconnect_token: None,
             last_reconciliation: None,
             last_debug_telemetry_json: None,
+            last_debug_document: None,
+            pending_debug_documents: Vec::new(),
             recovery_state: RecoveryRequestState::default(),
             render_buffer: SnapshotInterpolationBuffer::default(),
             render_clock: RenderClock::default(),
@@ -381,7 +387,11 @@ impl WebClient {
             }
             ServerMessage::Pong { .. } => true,
             ServerMessage::TickTelemetry { frame_json } => {
-                self.last_debug_telemetry_json = Some(frame_json.clone());
+                self.record_debug_document(frame_json.clone());
+                true
+            }
+            ServerMessage::DebugDocument { document } => {
+                self.record_debug_document(document.clone());
                 true
             }
             ServerMessage::Rejected { reason } => {
@@ -443,6 +453,8 @@ impl WebClient {
         self.connected = false;
         self.recovery_state.clear();
         self.last_debug_telemetry_json = None;
+        self.last_debug_document = None;
+        self.pending_debug_documents.clear();
         self.clear_presentation_state();
         Ok(())
     }
@@ -488,6 +500,16 @@ impl WebClient {
 
     pub fn last_debug_telemetry_document(&self) -> Option<&str> {
         self.last_debug_telemetry_json()
+    }
+
+    pub fn last_debug_document(&self) -> Option<&str> {
+        self.last_debug_document
+            .as_deref()
+            .or_else(|| self.last_debug_telemetry_document())
+    }
+
+    pub fn drain_debug_documents(&mut self) -> Vec<String> {
+        std::mem::take(&mut self.pending_debug_documents)
     }
 
     /// Inspect the local rollback/replay path from a chosen authoritative tick.
@@ -644,6 +666,20 @@ impl WebClient {
             predicted_digest: self.local_snapshot.as_ref().map(WorldSnapshot::digest),
             used_hard_resync,
         });
+    }
+
+    fn record_debug_document(&mut self, document: String) {
+        if decode_toon_value(&document)
+            .ok()
+            .and_then(|value| value["document_type"].as_str().map(str::to_owned))
+            .as_deref()
+            == Some("versioned_tick_telemetry")
+        {
+            self.last_debug_telemetry_json = Some(document.clone());
+        }
+
+        self.last_debug_document = Some(document.clone());
+        self.pending_debug_documents.push(document);
     }
 }
 

--- a/crates/pod-net/src/protocol.rs
+++ b/crates/pod-net/src/protocol.rs
@@ -116,6 +116,9 @@ pub enum ServerMessage {
     /// Raw authoritative telemetry payload for debug/editor consumers.
     TickTelemetry { frame_json: String },
 
+    /// Generic TOON debug document for editor/debug consumers.
+    DebugDocument { document: String },
+
     /// Response to ping request
     Pong { client_ts: u64, server_ts: u64 },
 
@@ -317,6 +320,25 @@ mod tests {
                     decode_toon_value(&frame_json).expect("tick telemetry TOON should decode");
                 assert_eq!(value["document_type"], "versioned_tick_telemetry");
                 assert_eq!(value["payload"]["payload"]["tick"], 7);
+            }
+            other => panic!("Wrong message type: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_debug_document_json_roundtrip() {
+        let msg = ServerMessage::DebugDocument {
+            document: VersionedTickTelemetry::new(TickTelemetryFrame::empty(9)).to_toon_document(),
+        };
+        let json = msg.encode_json().unwrap();
+        let decoded = ServerMessage::decode_json(&json).unwrap();
+
+        match decoded {
+            ServerMessage::DebugDocument { document } => {
+                let value =
+                    decode_toon_value(&document).expect("debug document TOON should decode");
+                assert_eq!(value["document_type"], "versioned_tick_telemetry");
+                assert_eq!(value["payload"]["payload"]["tick"], 9);
             }
             other => panic!("Wrong message type: {other:?}"),
         }

--- a/crates/pod-net/src/server.rs
+++ b/crates/pod-net/src/server.rs
@@ -13,7 +13,10 @@ use log::{debug, error, info, warn};
 use quinn::Endpoint;
 use tokio::sync::{mpsc, RwLock};
 
-use pod_core::{Action, IdleAgent, VersionedTickTelemetry, World};
+use pod_core::{
+    Action, AgentTickRollup, AgentToolCallEvent, IdleAgent, TelemetryArchive, TelemetryConfig,
+    VersionedTickTelemetry, World,
+};
 
 use crate::protocol::{
     ClientId, ClientMessage, ReconnectToken, ServerConfig as ProtoServerConfig, ServerMessage,
@@ -93,6 +96,10 @@ pub struct GameServer {
     last_snapshot: Option<WorldSnapshot>,
     /// Latest authoritative telemetry payload for debug/editor clients.
     last_tick_telemetry_json: Option<String>,
+    /// Recent authoritative telemetry retained for live debug rollups.
+    debug_archive: TelemetryArchive,
+    /// TOON debug documents collected during the current authoritative tick.
+    pending_debug_documents: Vec<String>,
 }
 
 impl GameServer {
@@ -111,6 +118,10 @@ impl GameServer {
             last_snapshot_tick: 0,
             last_snapshot: None,
             last_tick_telemetry_json: None,
+            debug_archive: TelemetryArchive::with_capacity(
+                TelemetryConfig::default().core_archive_ticks,
+            ),
+            pending_debug_documents: Vec::new(),
         }
     }
 
@@ -218,8 +229,30 @@ impl GameServer {
 
         // Step the world
         let tick_result = self.world.step();
-        self.last_tick_telemetry_json =
-            Some(VersionedTickTelemetry::new(tick_result.telemetry.clone()).to_toon_document());
+        self.debug_archive
+            .record_tick(tick_result.telemetry.clone());
+        self.pending_debug_documents.clear();
+
+        let telemetry_document =
+            VersionedTickTelemetry::new(tick_result.telemetry.clone()).to_toon_document();
+        self.last_tick_telemetry_json = Some(telemetry_document.clone());
+        self.pending_debug_documents.push(telemetry_document);
+
+        for agent in &tick_result.telemetry.agents {
+            let Some(entity_id) = agent.entity_id else {
+                continue;
+            };
+            for trace in &agent.tool_calls {
+                self.pending_debug_documents
+                    .push(AgentToolCallEvent::new(entity_id.0, trace.clone()).to_toon_document());
+            }
+        }
+
+        if (tick_result.tick + 1) % 60 == 0 {
+            for rollup in self.debug_rollups_for_tick(tick_result.tick) {
+                self.pending_debug_documents.push(rollup.to_toon_document());
+            }
+        }
 
         debug!(
             "Tick {}: {} entities, {} agents",
@@ -503,6 +536,7 @@ impl GameServer {
             .any(|session| session.debug_telemetry_enabled);
 
         if !has_state_update && !has_debug_subscribers {
+            self.pending_debug_documents.clear();
             return Ok(());
         }
 
@@ -523,18 +557,19 @@ impl GameServer {
             }
 
             if session.debug_telemetry_enabled {
-                if let Some(frame_json) = &self.last_tick_telemetry_json {
-                    if let Some(tx) = self.client_tx.read().await.get(client_id) {
+                if let Some(tx) = self.client_tx.read().await.get(client_id) {
+                    for document in &self.pending_debug_documents {
                         if let Err(e) = tx
-                            .send(ServerMessage::TickTelemetry {
-                                frame_json: frame_json.clone(),
+                            .send(ServerMessage::DebugDocument {
+                                document: document.clone(),
                             })
                             .await
                         {
                             error!(
-                                "Failed to send debug telemetry to client {}: {}",
+                                "Failed to send debug document to client {}: {}",
                                 client_id.0, e
                             );
+                            break;
                         }
                     }
                 }
@@ -547,6 +582,7 @@ impl GameServer {
         if has_state_update {
             self.last_snapshot = Some(current_snapshot);
         }
+        self.pending_debug_documents.clear();
 
         Ok(())
     }
@@ -746,6 +782,40 @@ impl GameServer {
 
         Ok(())
     }
+
+    fn debug_rollups_for_tick(&self, tick_end: u64) -> Vec<AgentTickRollup> {
+        let tick_start = tick_end.saturating_sub(59);
+        let mut frames_by_agent = HashMap::<u64, Vec<pod_core::AgentTelemetryFrame>>::new();
+
+        for frame in self
+            .debug_archive
+            .frames()
+            .iter()
+            .filter(|frame| frame.tick >= tick_start && frame.tick <= tick_end)
+        {
+            for agent in &frame.agents {
+                let Some(entity_id) = agent.entity_id else {
+                    continue;
+                };
+                frames_by_agent
+                    .entry(entity_id.0)
+                    .or_default()
+                    .push(agent.clone());
+            }
+        }
+
+        let mut entity_ids: Vec<u64> = frames_by_agent.keys().copied().collect();
+        entity_ids.sort_unstable();
+
+        entity_ids
+            .into_iter()
+            .filter_map(|entity_id| {
+                frames_by_agent
+                    .get(&entity_id)
+                    .and_then(|frames| AgentTickRollup::from_agent_frames(entity_id, frames))
+            })
+            .collect()
+    }
 }
 
 // ============================================================
@@ -816,7 +886,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_broadcast_updates_emits_tick_telemetry_for_debug_clients_only() {
+    async fn test_broadcast_updates_emits_debug_documents_for_debug_clients_only() {
         let config = ProtoServerConfig::default();
         let world = World::new(42);
         let mut server = GameServer::new(config, world);
@@ -842,10 +912,10 @@ mod tests {
         let mut saw_tick_telemetry = false;
         while let Ok(message) = rx.try_recv() {
             match message {
-                ServerMessage::TickTelemetry { frame_json } => {
+                ServerMessage::DebugDocument { document } => {
                     saw_tick_telemetry = true;
                     let value =
-                        decode_toon_value(&frame_json).expect("tick telemetry TOON should decode");
+                        decode_toon_value(&document).expect("tick telemetry TOON should decode");
                     assert_eq!(value["document_type"], "versioned_tick_telemetry");
                 }
                 _ => {}

--- a/crates/pod-stdb/src/reducers.rs
+++ b/crates/pod-stdb/src/reducers.rs
@@ -22,7 +22,7 @@ use pod_core::component::SkillKind;
 use pod_core::contract::AgentRuntimeProfile;
 use pod_core::id::{AgentId as CoreAgentId, EntityId as CoreEntityId};
 use pod_core::telemetry::{
-    ActionLifecycleStage, ActionSource, AgentTelemetryFrame, AgentTickRollup,
+    ActionLifecycleStage, ActionSource, AgentTelemetryFrame, AgentTickRollup, AgentToolCallEvent,
     TickTelemetryFrame, TrajectorySample,
 };
 use pod_core::{decode_toon_document, VersionedTickTelemetry};
@@ -1207,7 +1207,8 @@ pub fn execute_tick(ctx: &ReducerContext) {
                 executed = true;
             }
             ActionKind::Speak => {
-                if let (Some(msg), Some(vol)) = (submission.message.clone(), submission.volume.clone())
+                if let (Some(msg), Some(vol)) =
+                    (submission.message.clone(), submission.volume.clone())
                 {
                     if let Some(tf) = ctx.db.transform().entity_id().find(eid) {
                         ctx.db.speech_event().insert(SpeechEventRow {
@@ -1319,6 +1320,7 @@ pub fn execute_tick(ctx: &ReducerContext) {
 
     update_telemetry_trajectory_ends(ctx, current_tick, elapsed + dt, &mut telemetry_frames);
     emit_agent_telemetry_rows(ctx, current_tick, &telemetry_frames);
+    emit_agent_tool_call_events(ctx, &telemetry_frames);
     emit_agent_tick_rollups(ctx, current_tick);
 
     // ── Phase 5: Advance tick ──
@@ -1398,7 +1400,10 @@ fn decode_observation_counts(document: &str) -> ObservationCounts {
             .as_array()
             .map(Vec::len)
             .unwrap_or_default(),
-        messages: value["messages"].as_array().map(Vec::len).unwrap_or_default(),
+        messages: value["messages"]
+            .as_array()
+            .map(Vec::len)
+            .unwrap_or_default(),
     }
 }
 
@@ -1574,6 +1579,48 @@ fn emit_agent_telemetry_rows(
     }
 }
 
+fn emit_agent_tool_call_events(
+    ctx: &ReducerContext,
+    telemetry_frames: &HashMap<u64, AgentTelemetryFrame>,
+) {
+    for event in collect_agent_tool_call_events(telemetry_frames) {
+        ctx.db
+            .agent_tool_call_event()
+            .insert(AgentToolCallEventRow {
+                row_id: 0,
+                tick: event.tick,
+                agent_entity_id: event.agent_entity_id,
+                tool_name: event.trace.tool_name.clone(),
+                provider: event.trace.provider.clone(),
+                status: format!("{:?}", event.trace.status),
+                latency_ms: event.trace.latency_ms,
+                request_units: event.trace.request_units,
+                response_units: event.trace.response_units,
+                data_json: event.to_toon_document(),
+            });
+    }
+}
+
+fn collect_agent_tool_call_events(
+    telemetry_frames: &HashMap<u64, AgentTelemetryFrame>,
+) -> Vec<AgentToolCallEvent> {
+    let mut entity_ids: Vec<u64> = telemetry_frames.keys().copied().collect();
+    entity_ids.sort_unstable();
+
+    let mut events = Vec::new();
+    for entity_id in entity_ids {
+        let Some(frame) = telemetry_frames.get(&entity_id) else {
+            continue;
+        };
+
+        for trace in &frame.tool_calls {
+            events.push(AgentToolCallEvent::new(entity_id, trace.clone()));
+        }
+    }
+
+    events
+}
+
 fn emit_agent_tick_rollups(ctx: &ReducerContext, current_tick: u64) {
     if (current_tick + 1) % ROLLUP_WINDOW_TICKS != 0 {
         return;
@@ -1588,9 +1635,10 @@ fn emit_agent_tick_rollups(ctx: &ReducerContext, current_tick: u64) {
         .iter()
         .filter(|row| row.tick >= window_start && row.tick <= current_tick)
     {
-        let Ok(versioned) =
-            decode_toon_document::<VersionedTickTelemetry>(&row.frame_json, "versioned_tick_telemetry")
-        else {
+        let Ok(versioned) = decode_toon_document::<VersionedTickTelemetry>(
+            &row.frame_json,
+            "versioned_tick_telemetry",
+        ) else {
             continue;
         };
         for frame in versioned.payload.agents {
@@ -1629,14 +1677,17 @@ fn emit_agent_tick_rollups(ctx: &ReducerContext, current_tick: u64) {
 }
 
 fn action_count(frame: &AgentTelemetryFrame, stage: ActionLifecycleStage) -> u32 {
-    frame.action_trace
+    frame
+        .action_trace
         .iter()
         .filter(|trace| trace.stage == stage)
         .count() as u32
 }
 
 fn stable_agent_id(entity_id: u64) -> CoreAgentId {
-    CoreAgentId(Uuid::from_u128(0x504f4453544442000000000000000000u128 | entity_id as u128))
+    CoreAgentId(Uuid::from_u128(
+        0x504f4453544442000000000000000000u128 | entity_id as u128,
+    ))
 }
 
 fn core_agent_type(agent_type: &AgentType) -> CoreAgentType {
@@ -1646,6 +1697,65 @@ fn core_agent_type(agent_type: &AgentType) -> CoreAgentType {
         AgentType::NeuralAgent => CoreAgentType::NeuralAgent,
         AgentType::ScriptedNpc => CoreAgentType::ScriptedNpc,
         AgentType::System => CoreAgentType::System,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pod_core::telemetry::{AgentToolCallTrace, ToolCallStatus};
+    use pod_core::{decode_toon_document, AgentType};
+
+    #[test]
+    fn collect_agent_tool_call_events_exports_toon_ready_rows() {
+        let mut frame = AgentTelemetryFrame::new(
+            12,
+            stable_agent_id(44),
+            Some(CoreEntityId(44)),
+            AgentRuntimeProfile::for_agent_type(CoreAgentType::LlmAgent),
+            3,
+            1,
+            0,
+            2,
+            1,
+            None,
+            None,
+        );
+        frame.record_tool_call(AgentToolCallTrace::new(
+            12,
+            "llm.complete",
+            "qwen",
+            ToolCallStatus::TimedOut,
+            48,
+            128,
+            0,
+            Some("timeout".into()),
+        ));
+        frame.record_tool_call(AgentToolCallTrace::success(
+            12,
+            "tool.lookup",
+            "catalog",
+            8,
+            16,
+            12,
+        ));
+
+        let mut telemetry_frames = HashMap::new();
+        telemetry_frames.insert(44, frame);
+
+        let events = collect_agent_tool_call_events(&telemetry_frames);
+        assert_eq!(events.len(), 2);
+        assert!(events
+            .iter()
+            .all(|event| event.agent_entity_id == 44 && event.tick == 12));
+
+        let exported: AgentToolCallEvent =
+            decode_toon_document(&events[0].to_toon_document(), "agent_tool_call_event")
+                .expect("tool-call event should decode");
+        assert_eq!(exported.agent_entity_id, 44);
+        assert_eq!(exported.trace.tool_name, "llm.complete");
+        assert_eq!(exported.trace.provider, "qwen");
+        assert_eq!(exported.trace.status, ToolCallStatus::TimedOut);
     }
 }
 


### PR DESCRIPTION
## Summary\n- add a generic debug-document transport to pod-net and retain live TOON debug documents across native, web, and SpacetimeDB clients\n- extend the direct-connect GameServer debug path with authoritative tool-call documents and 60-tick rollups\n- persist reducer-side embedded tool-call telemetry into SpacetimeDB agent_tool_call_event rows as canonical TOON documents\n\n## Validation\n- cargo test -p pod-net --lib\n- cargo test -p pod-net --features spacetimedb --lib\n- cargo test -p pod-stdb --no-default-features --features client\n- cargo check -p pod-stdb --no-default-features --features module --target wasm32-unknown-unknown\n- cargo check -p pod-net --target wasm32-unknown-unknown --lib\n- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced debug telemetry streaming with document history and per-tick rollup generation for debug subscribers.
  * Added debug document caching and drainable queue functionality to improve telemetry access patterns.

* **Chores**
  * Internal refactoring of telemetry and debug document handling across client and server components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->