### PR TITLE
Add websocket direct-connect server runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1128,6 +1128,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
 name = "decorum"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3790,6 +3796,7 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "criterion",
+ "futures-util",
  "glam",
  "js-sys",
  "log",
@@ -3801,6 +3808,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-tungstenite",
  "uuid",
  "wasm-bindgen",
  "web-sys",
@@ -5270,6 +5278,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5414,6 +5434,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
 name = "type-map"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5492,6 +5530,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -626,5 +626,18 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cargo test -p pod-stdb --no-default-features --features client`
   - `cargo check -p pod-stdb --no-default-features --features module --target wasm32-unknown-unknown`
 
-**Last updated**: Iteration 68
-**Current focus**: Iteration 69 browser/editor live wiring for direct-connect shard debug streams plus MMO world/runtime slice completion beyond TOON telemetry parity
+### Iteration 69
+- [x] Implemented the missing direct-connect WebSocket server runtime in `pod-net::GameServer`, including browser-safe JSON message decode/encode on top of the existing authoritative world tick loop.
+- [x] Reused the same direct-connect session plumbing for QUIC and WebSocket clients so browser fallback clients receive `Welcome`, `StateDelta`, and live TOON `DebugDocument` messages over one authoritative runtime path.
+- [x] Wired `apps/pod-server` network mode to expose the WebSocket fallback by default in network runtime, with `POD_ENABLE_WEBSOCKET` and `POD_WEBSOCKET_PORT` overrides plus banner/runtime visibility for browser-first deployment.
+- [x] Added deterministic integration coverage for real `ws://` handshake, `Connect -> Welcome`, and debug-telemetry subscription delivery over the WebSocket fallback path.
+- [x] Added dedicated `pod-server` runtime coverage for bind parsing and default WebSocket port derivation from the bind address.
+- [x] Validated touched targets:
+  - `cargo test -p pod-net --lib`
+  - `cargo test -p pod-net --features spacetimedb --lib`
+  - `cargo check -p pod-net --target wasm32-unknown-unknown --lib`
+  - `cargo test -p pod-server --bin pod-server`
+  - `git diff --check`
+
+**Last updated**: Iteration 69
+**Current focus**: Iteration 70 browser/world vertical-slice completion on top of the real WebSocket direct-connect path, starting with streamed world payloads and the pod-web runtime hook-up for authoritative shard debug streams

--- a/apps/pod-server/src/main.rs
+++ b/apps/pod-server/src/main.rs
@@ -30,6 +30,10 @@ mod config {
     pub struct ServerConfig {
         /// Address to bind to (e.g., "0.0.0.0:7777")
         pub bind_address: String,
+        /// Whether to expose the WebSocket fallback for browser direct-connect clients.
+        pub enable_websocket: bool,
+        /// Port for the WebSocket fallback endpoint.
+        pub websocket_port: u16,
         /// Maximum number of concurrent clients
         pub max_clients: usize,
         /// Target tick rate in Hz (e.g., 60)
@@ -48,6 +52,11 @@ mod config {
             // For now, use defaults or simple environment variable override.
             let bind_address =
                 std::env::var("POD_BIND_ADDRESS").unwrap_or_else(|_| "0.0.0.0:7777".to_string());
+            let default_websocket_port = bind_address
+                .rsplit_once(':')
+                .and_then(|(_, port)| port.parse::<u16>().ok())
+                .and_then(|port| port.checked_add(1))
+                .unwrap_or(7778);
 
             let tick_rate = std::env::var("POD_TICK_RATE")
                 .ok()
@@ -67,9 +76,23 @@ mod config {
             let map_name = std::env::var("POD_MAP_NAME").unwrap_or_else(|_| "default".to_string());
             let runtime_mode =
                 std::env::var("POD_RUNTIME_MODE").unwrap_or_else(|_| "network".to_string());
+            let enable_websocket = std::env::var("POD_ENABLE_WEBSOCKET")
+                .ok()
+                .and_then(|value| match value.to_ascii_lowercase().as_str() {
+                    "1" | "true" | "yes" | "on" => Some(true),
+                    "0" | "false" | "no" | "off" => Some(false),
+                    _ => None,
+                })
+                .unwrap_or_else(|| runtime_mode.eq_ignore_ascii_case("network"));
+            let websocket_port = std::env::var("POD_WEBSOCKET_PORT")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(default_websocket_port);
 
             ServerConfig {
                 bind_address,
+                enable_websocket,
+                websocket_port,
                 tick_rate,
                 max_clients,
                 world_seed,
@@ -489,15 +512,15 @@ mod stats {
                     continue;
                 };
                 for trace in &agent.tool_calls {
-                    self.pending_documents
-                        .push_back(AgentToolCallEvent::new(entity_id.0, trace.clone()).to_toon_document());
+                    self.pending_documents.push_back(
+                        AgentToolCallEvent::new(entity_id.0, trace.clone()).to_toon_document(),
+                    );
                 }
             }
 
             if (tick_result.tick + 1) % ROLLUP_WINDOW_TICKS == 0 {
                 for rollup in self.rollups_for_tick(tick_result.tick) {
-                    self.pending_documents
-                        .push_back(rollup.to_toon_document());
+                    self.pending_documents.push_back(rollup.to_toon_document());
                 }
             }
 
@@ -708,26 +731,18 @@ mod stats {
             }
 
             let documents = stream.drain_documents();
-            assert!(documents
-                .iter()
-                .any(|document| decode_toon_value(document)
-                    .map(|value| value["document_type"] == "versioned_tick_telemetry")
-                    .unwrap_or(false)));
-            assert!(documents
-                .iter()
-                .any(|document| decode_toon_value(document)
-                    .map(|value| value["document_type"] == "agent_tool_call_event")
-                    .unwrap_or(false)));
-            assert!(documents
-                .iter()
-                .any(|document| decode_toon_value(document)
-                    .map(|value| value["document_type"] == "agent_tick_rollup")
-                    .unwrap_or(false)));
-            assert!(documents
-                .iter()
-                .any(|document| decode_toon_value(document)
-                    .map(|value| value["document_type"] == "shard_incident_summary")
-                    .unwrap_or(false)));
+            assert!(documents.iter().any(|document| decode_toon_value(document)
+                .map(|value| value["document_type"] == "versioned_tick_telemetry")
+                .unwrap_or(false)));
+            assert!(documents.iter().any(|document| decode_toon_value(document)
+                .map(|value| value["document_type"] == "agent_tool_call_event")
+                .unwrap_or(false)));
+            assert!(documents.iter().any(|document| decode_toon_value(document)
+                .map(|value| value["document_type"] == "agent_tick_rollup")
+                .unwrap_or(false)));
+            assert!(documents.iter().any(|document| decode_toon_value(document)
+                .map(|value| value["document_type"] == "shard_incident_summary")
+                .unwrap_or(false)));
         }
     }
 }
@@ -892,8 +907,8 @@ async fn run_network_server(
         snapshot_interval: 10,
         bind_addr,
         bind_port,
-        enable_websocket: false,
-        websocket_port: 0,
+        enable_websocket: config.enable_websocket,
+        websocket_port: config.websocket_port,
     };
 
     let mut server = pod_net::GameServer::new(net_config, world);
@@ -938,6 +953,7 @@ fn print_banner(config: &ServerConfig) {
         r#"
 Configuration:
   Bind Address:   {}
+  WebSocket:      {}{}
   Tick Rate:      {} Hz
   Max Clients:    {}
   World Seed:     {}
@@ -946,10 +962,62 @@ Configuration:
 
 "#,
         config.bind_address,
+        if config.enable_websocket {
+            "enabled"
+        } else {
+            "disabled"
+        },
+        if config.enable_websocket {
+            format!(" (port {})", config.websocket_port)
+        } else {
+            String::new()
+        },
         config.tick_rate,
         config.max_clients,
         config.world_seed,
         config.map_name,
         config.runtime_mode
     );
+}
+
+#[cfg(test)]
+mod runtime_tests {
+    use super::{config::ServerConfig, parse_bind_target};
+
+    #[test]
+    fn parse_bind_target_splits_host_and_port() {
+        let (host, port) = parse_bind_target("127.0.0.1:7000").expect("bind target should parse");
+        assert_eq!(host, "127.0.0.1");
+        assert_eq!(port, 7000);
+    }
+
+    #[test]
+    fn server_config_defaults_websocket_to_bind_port_plus_one_in_network_mode() {
+        let original_bind = std::env::var_os("POD_BIND_ADDRESS");
+        let original_runtime = std::env::var_os("POD_RUNTIME_MODE");
+        let original_ws_enabled = std::env::var_os("POD_ENABLE_WEBSOCKET");
+        let original_ws_port = std::env::var_os("POD_WEBSOCKET_PORT");
+
+        std::env::set_var("POD_BIND_ADDRESS", "127.0.0.1:8123");
+        std::env::set_var("POD_RUNTIME_MODE", "network");
+        std::env::remove_var("POD_ENABLE_WEBSOCKET");
+        std::env::remove_var("POD_WEBSOCKET_PORT");
+
+        let config = ServerConfig::from_env();
+        assert!(config.enable_websocket);
+        assert_eq!(config.websocket_port, 8124);
+
+        restore_var("POD_BIND_ADDRESS", original_bind);
+        restore_var("POD_RUNTIME_MODE", original_runtime);
+        restore_var("POD_ENABLE_WEBSOCKET", original_ws_enabled);
+        restore_var("POD_WEBSOCKET_PORT", original_ws_port);
+    }
+
+    fn restore_var(key: &str, value: Option<std::ffi::OsString>) {
+        if let Some(value) = value {
+            std::env::set_var(key, value);
+        } else {
+            std::env::remove_var(key);
+        }
+    }
 }

--- a/crates/pod-net/Cargo.toml
+++ b/crates/pod-net/Cargo.toml
@@ -28,6 +28,8 @@ js-sys = "0.3"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio.workspace = true
 quinn.workspace = true
+futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
+tokio-tungstenite = "0.24"
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 rcgen = "0.13"
 

--- a/crates/pod-net/src/protocol.rs
+++ b/crates/pod-net/src/protocol.rs
@@ -82,6 +82,16 @@ impl ClientMessage {
     pub fn decode(bytes: &[u8]) -> Result<Self, bincode::Error> {
         bincode::deserialize(bytes)
     }
+
+    /// Encode to JSON (for WebSocket clients)
+    pub fn encode_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string(self)
+    }
+
+    /// Decode from JSON (for WebSocket clients)
+    pub fn decode_json(json: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(json)
+    }
 }
 
 // ============================================================
@@ -271,6 +281,25 @@ mod tests {
 
         match decoded {
             ClientMessage::SetDebugTelemetry { enabled } => assert!(enabled),
+            other => panic!("Wrong message type: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_client_message_json_roundtrip() {
+        let msg = ClientMessage::ActionBatch {
+            tick: 22,
+            actions: vec![Action::Idle],
+        };
+        let json = msg.encode_json().unwrap();
+        let decoded = ClientMessage::decode_json(&json).unwrap();
+
+        match decoded {
+            ClientMessage::ActionBatch { tick, actions } => {
+                assert_eq!(tick, 22);
+                assert_eq!(actions.len(), 1);
+                assert!(matches!(actions.first(), Some(Action::Idle)));
+            }
             other => panic!("Wrong message type: {other:?}"),
         }
     }

--- a/crates/pod-net/src/server.rs
+++ b/crates/pod-net/src/server.rs
@@ -9,9 +9,12 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
+use futures_util::{SinkExt, StreamExt};
 use log::{debug, error, info, warn};
 use quinn::Endpoint;
+use tokio::net::TcpListener;
 use tokio::sync::{mpsc, RwLock};
+use tokio_tungstenite::{accept_async, tungstenite::Message};
 
 use pod_core::{
     Action, AgentTickRollup, AgentToolCallEvent, IdleAgent, TelemetryArchive, TelemetryConfig,
@@ -88,6 +91,8 @@ pub struct GameServer {
     inbound_rx: mpsc::Receiver<InboundPacket>,
     /// QUIC endpoint
     endpoint: Option<Endpoint>,
+    /// Optional WebSocket fallback listener for browser clients.
+    websocket_listener: Option<TcpListener>,
     /// Current tick counter
     tick: u64,
     /// Last tick when snapshot was sent
@@ -114,6 +119,7 @@ impl GameServer {
             inbound_tx,
             inbound_rx,
             endpoint: None,
+            websocket_listener: None,
             tick: 0,
             last_snapshot_tick: 0,
             last_snapshot: None,
@@ -156,6 +162,17 @@ impl GameServer {
         let endpoint = Endpoint::server(server_config, addr)?;
 
         self.endpoint = Some(endpoint);
+
+        if self.config.enable_websocket {
+            let websocket_addr: SocketAddr =
+                format!("{}:{}", self.config.bind_addr, self.config.websocket_port).parse()?;
+            let listener = TcpListener::bind(websocket_addr).await?;
+            self.websocket_listener = Some(listener);
+            info!(
+                "WebSocket fallback initialized on {}:{}",
+                self.config.bind_addr, self.config.websocket_port
+            );
+        }
 
         info!(
             "GameServer initialized on {}:{}",
@@ -264,16 +281,160 @@ impl GameServer {
         Ok(())
     }
 
+    async fn register_pending_client(
+        &mut self,
+        client_id: ClientId,
+    ) -> mpsc::Receiver<ServerMessage> {
+        let (outbound_tx, outbound_rx) = mpsc::channel::<ServerMessage>(256);
+        self.client_tx.write().await.insert(client_id, outbound_tx);
+        self.clients
+            .write()
+            .await
+            .insert(client_id, ClientSession::new("pending".into()));
+        outbound_rx
+    }
+
     /// Accept incoming client connections
     async fn handle_connections(&mut self) -> Result<(), Box<dyn std::error::Error>> {
-        if let Some(endpoint) = &self.endpoint {
+        loop {
+            let websocket_accepted = {
+                let Some(listener) = self.websocket_listener.as_ref() else {
+                    break;
+                };
+                match tokio::time::timeout(Duration::from_millis(1), listener.accept()).await {
+                    Ok(Ok(accepted)) => accepted,
+                    Ok(Err(err)) => {
+                        warn!("Failed to accept websocket client: {err}");
+                        break;
+                    }
+                    Err(_) => break,
+                }
+            };
+
+            let (stream, _remote_addr) = websocket_accepted;
+
+            let websocket = match accept_async(stream).await {
+                Ok(websocket) => websocket,
+                Err(err) => {
+                    warn!("Failed to complete websocket handshake: {err}");
+                    continue;
+                }
+            };
+
+            let client_id = ClientId::new();
+            info!("Accepted new websocket client connection: {}", client_id.0);
+
+            let mut outbound_rx = self.register_pending_client(client_id).await;
+            let inbound_tx = self.inbound_tx.clone();
+            let (mut ws_write, mut ws_read) = websocket.split();
+
+            tokio::spawn(async move {
+                while let Some(message) = ws_read.next().await {
+                    match message {
+                        Ok(Message::Text(text)) => {
+                            let message = match ClientMessage::decode_json(text.as_ref()) {
+                                Ok(message) => message,
+                                Err(err) => {
+                                    warn!(
+                                        "WebSocket client {} sent invalid JSON message: {}",
+                                        client_id.0, err
+                                    );
+                                    continue;
+                                }
+                            };
+
+                            if inbound_tx
+                                .send(InboundPacket::Message { client_id, message })
+                                .await
+                                .is_err()
+                            {
+                                break;
+                            }
+                        }
+                        Ok(Message::Binary(bytes)) => {
+                            let text = match String::from_utf8(bytes.to_vec()) {
+                                Ok(text) => text,
+                                Err(err) => {
+                                    warn!(
+                                        "WebSocket client {} sent non-UTF8 binary payload: {}",
+                                        client_id.0, err
+                                    );
+                                    continue;
+                                }
+                            };
+                            let message = match ClientMessage::decode_json(&text) {
+                                Ok(message) => message,
+                                Err(err) => {
+                                    warn!(
+                                        "WebSocket client {} sent invalid binary JSON message: {}",
+                                        client_id.0, err
+                                    );
+                                    continue;
+                                }
+                            };
+
+                            if inbound_tx
+                                .send(InboundPacket::Message { client_id, message })
+                                .await
+                                .is_err()
+                            {
+                                break;
+                            }
+                        }
+                        Ok(Message::Close(frame)) => {
+                            let reason = frame
+                                .map(|frame| frame.reason.to_string())
+                                .unwrap_or_else(|| "websocket closed".to_string());
+                            let _ = inbound_tx
+                                .send(InboundPacket::Disconnected { client_id, reason })
+                                .await;
+                            break;
+                        }
+                        Ok(Message::Ping(_)) | Ok(Message::Pong(_)) => {}
+                        Ok(Message::Frame(_)) => {}
+                        Err(err) => {
+                            let _ = inbound_tx
+                                .send(InboundPacket::Disconnected {
+                                    client_id,
+                                    reason: format!("websocket receive failed: {err}"),
+                                })
+                                .await;
+                            break;
+                        }
+                    }
+                }
+            });
+
+            tokio::spawn(async move {
+                while let Some(message) = outbound_rx.recv().await {
+                    let payload = match message.encode_json() {
+                        Ok(payload) => payload,
+                        Err(err) => {
+                            error!("Failed to encode websocket outbound message: {}", err);
+                            continue;
+                        }
+                    };
+
+                    if let Err(err) = ws_write.send(Message::Text(payload.into())).await {
+                        error!("Failed to send websocket outbound message: {}", err);
+                        break;
+                    }
+                }
+
+                let _ = ws_write.close().await;
+            });
+        }
+
+        if self.endpoint.is_some() {
             loop {
-                let incoming =
+                let incoming = {
+                    let endpoint = self.endpoint.as_ref().expect("checked above");
                     match tokio::time::timeout(Duration::from_millis(1), endpoint.accept()).await {
                         Ok(Some(incoming)) => incoming,
                         Ok(None) => break,
                         Err(_) => break,
-                    };
+                    }
+                };
 
                 let connection = match incoming.await {
                     Ok(conn) => conn,
@@ -286,12 +447,7 @@ impl GameServer {
                 let client_id = ClientId::new();
                 info!("Accepted new client connection: {}", client_id.0);
 
-                let (outbound_tx, mut outbound_rx) = mpsc::channel::<ServerMessage>(256);
-                self.client_tx.write().await.insert(client_id, outbound_tx);
-                self.clients
-                    .write()
-                    .await
-                    .insert(client_id, ClientSession::new("pending".into()));
+                let mut outbound_rx = self.register_pending_client(client_id).await;
 
                 let read_conn = connection.clone();
                 let write_conn = connection.clone();
@@ -845,6 +1001,25 @@ impl std::error::Error for ServerError {}
 mod tests {
     use super::*;
     use pod_core::decode_toon_value;
+    use tokio_tungstenite::{connect_async, tungstenite::Message};
+
+    fn next_available_port() -> u16 {
+        std::net::TcpListener::bind("127.0.0.1:0")
+            .expect("ephemeral port bind")
+            .local_addr()
+            .expect("local addr")
+            .port()
+    }
+
+    async fn drive_server_for(mut server: GameServer, iterations: usize) {
+        for _ in 0..iterations {
+            server.handle_connections().await.unwrap();
+            server.step_tick().await.unwrap();
+            server.broadcast_updates().await.unwrap();
+            tokio::time::sleep(Duration::from_millis(5)).await;
+            server.tick += 1;
+        }
+    }
 
     #[tokio::test]
     async fn test_server_creation() {
@@ -923,5 +1098,141 @@ mod tests {
         }
 
         assert!(saw_tick_telemetry);
+    }
+
+    #[tokio::test]
+    async fn test_websocket_connect_receives_welcome() {
+        let bind_port = next_available_port();
+        let websocket_port = next_available_port();
+        let config = ProtoServerConfig {
+            bind_addr: "127.0.0.1".into(),
+            bind_port,
+            enable_websocket: true,
+            websocket_port,
+            ..ProtoServerConfig::default()
+        };
+
+        let mut server = GameServer::new(config, World::new(42));
+        server.initialize().await.unwrap();
+        let client_task = async move {
+            let (mut websocket, _) = connect_async(format!("ws://127.0.0.1:{websocket_port}"))
+                .await
+                .expect("websocket connection");
+            websocket
+                .send(Message::Text(
+                    ClientMessage::Connect {
+                        player_name: "WebPlayer".into(),
+                        reconnect_token: None,
+                    }
+                    .encode_json()
+                    .unwrap()
+                    .into(),
+                ))
+                .await
+                .expect("send connect");
+
+            let mut welcome = None;
+            for _ in 0..40 {
+                let next_message =
+                    tokio::time::timeout(Duration::from_millis(50), websocket.next()).await;
+                if let Ok(Some(message)) = next_message {
+                    let message = message.expect("websocket message");
+                    if let Message::Text(text) = message {
+                        if let Ok(ServerMessage::Welcome { .. }) =
+                            ServerMessage::decode_json(text.as_ref())
+                        {
+                            welcome = Some(text.to_string());
+                            break;
+                        }
+                    }
+                }
+            }
+
+            welcome.expect("welcome message")
+        };
+
+        let (_, welcome) = tokio::join!(drive_server_for(server, 200), client_task);
+        match ServerMessage::decode_json(&welcome).unwrap() {
+            ServerMessage::Welcome {
+                controlled_entity,
+                snapshot,
+                ..
+            } => {
+                assert!(controlled_entity.is_some());
+                assert!(!snapshot.entities.is_empty());
+            }
+            other => panic!("unexpected websocket server message: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_websocket_debug_subscriber_receives_debug_document() {
+        let bind_port = next_available_port();
+        let websocket_port = next_available_port();
+        let config = ProtoServerConfig {
+            bind_addr: "127.0.0.1".into(),
+            bind_port,
+            enable_websocket: true,
+            websocket_port,
+            ..ProtoServerConfig::default()
+        };
+
+        let mut server = GameServer::new(config, World::new(42));
+        server.initialize().await.unwrap();
+        let client_task = async move {
+            let (mut websocket, _) = connect_async(format!("ws://127.0.0.1:{websocket_port}"))
+                .await
+                .expect("websocket connection");
+
+            websocket
+                .send(Message::Text(
+                    ClientMessage::Connect {
+                        player_name: "DebugPlayer".into(),
+                        reconnect_token: None,
+                    }
+                    .encode_json()
+                    .unwrap()
+                    .into(),
+                ))
+                .await
+                .expect("send connect");
+
+            websocket
+                .send(Message::Text(
+                    ClientMessage::SetDebugTelemetry { enabled: true }
+                        .encode_json()
+                        .unwrap()
+                        .into(),
+                ))
+                .await
+                .expect("enable debug telemetry");
+
+            let mut documents = Vec::new();
+            for _ in 0..16 {
+                let next_message =
+                    tokio::time::timeout(Duration::from_millis(50), websocket.next()).await;
+                if let Ok(Some(message)) = next_message {
+                    let message = message.expect("websocket message");
+                    if let Message::Text(text) = message {
+                        documents.push(text.to_string());
+                    }
+                }
+            }
+            documents
+        };
+
+        let (_, documents) = tokio::join!(drive_server_for(server, 200), client_task);
+
+        let decoded: Vec<ServerMessage> = documents
+            .iter()
+            .filter_map(|document| ServerMessage::decode_json(document).ok())
+            .collect();
+        assert!(decoded.iter().any(|message| matches!(
+            message,
+            ServerMessage::DebugDocument { document }
+            if decode_toon_value(document)
+                .map(|value| value["document_type"] == "versioned_tick_telemetry")
+                .unwrap_or(false)
+        )));
     }
 }


### PR DESCRIPTION
## Summary
- add the missing websocket fallback server runtime to pod-net so browser direct-connect clients can use the authoritative server path
- wire pod-server network mode to expose websocket config and defaults for browser-first deployment
- add websocket integration tests for welcome and debug document delivery plus runtime config coverage

## Validation
- cargo test -p pod-net --lib
- cargo test -p pod-net --features spacetimedb --lib
- cargo check -p pod-net --target wasm32-unknown-unknown --lib
- cargo test -p pod-server --bin pod-server
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WebSocket endpoint support as an alternative connection method, complementing existing network protocols.
  * Introduced configuration options via environment variables to enable/disable WebSocket and customize its port.
  * Added JSON message encoding and decoding capabilities for improved client communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->