### PR TITLE
Add authoritative pod-web websocket runtime

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -639,5 +639,19 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cargo test -p pod-server --bin pod-server`
   - `git diff --check`
 
-**Last updated**: Iteration 69
-**Current focus**: Iteration 70 browser/world vertical-slice completion on top of the real WebSocket direct-connect path, starting with streamed world payloads and the pod-web runtime hook-up for authoritative shard debug streams
+### Iteration 70
+- [x] Added typed direct-connect protocol parsing in `apps/pod-web` for authoritative `Welcome`, `StateDelta`, `TickTelemetry`, `DebugDocument`, `Rejected`, and `Pong` websocket payloads emitted by the Rust server.
+- [x] Added browser-side authoritative snapshot handling in `apps/pod-web`, including full-snapshot recovery requests, reconnect-token aware websocket reconnects, and opt-in live debug-telemetry subscriptions on the same direct-connect socket.
+- [x] Added live world-to-frame adaptation in `apps/pod-web` so authoritative world snapshots and deltas render as stylized WebGPU `ThreeJsWebGpuFrame` content instead of leaving the browser client in demo-only mode.
+- [x] Wired the existing browser telemetry overlay to live authoritative websocket debug documents, and surfaced connection/world status directly in the HUD for browser-first shard inspection.
+- [x] Added deterministic Bun coverage for browser-side direct-connect config parsing, Rust enum-tagged message parsing, authoritative delta application, browser frame generation, and websocket client message encoding.
+- [x] Verified the browser runtime against a real live `pod-server` session over `ws://127.0.0.1:7778`, confirming authoritative rendering and live TOON telemetry ingestion in the browser HUD.
+- [x] Validated touched targets:
+  - `cd apps/pod-web && bun test`
+  - `cd apps/pod-web && bun run typecheck`
+  - `cd apps/pod-web && bun run build`
+  - live browser smoke via Playwright against `cargo run -p pod-server --bin pod-server`
+  - `git diff --check`
+
+**Last updated**: Iteration 70
+**Current focus**: Iteration 71 MMO world/runtime completion beyond snapshot visualization, starting with browser-side action submission, chat/combat loop interaction, and richer streamed world presentation on top of the live authoritative socket

--- a/apps/pod-web/README.md
+++ b/apps/pod-web/README.md
@@ -12,6 +12,7 @@ It consumes the `pod-render` browser frame contract and provides:
 - ACES tone mapping, tuned shadows, cached materials, and a richer atmospheric scene baseline
 - a 2D overlay scene for the legacy `RenderFrame` contract
 - a demo bridge via `window.podRender.*` so the app is useful before the Rust wasm entrypoint is wired in
+- direct browser websocket connection to the authoritative `pod-server` runtime using `Welcome` / `StateDelta` / `DebugDocument` JSON messages
 
 ## Run
 
@@ -20,6 +21,16 @@ cd apps/pod-web
 bun install
 bun run dev
 ```
+
+### Connect to a live shard
+
+Start the authoritative server in network mode, then open:
+
+```text
+http://127.0.0.1:5173/?server=127.0.0.1:7778&player=WebPlayer&debug=1
+```
+
+`server` may be `host:port`, `ws://host:port`, or `wss://host:port`.
 
 ## Validate
 
@@ -38,3 +49,5 @@ bun run build
   - accepts the batched `ThreeJsWebGpuFrame` JSON from `pod-render`
 - `window.podRender.resetDemo()`
   - returns the app to its built-in demo scene
+- `?server=127.0.0.1:7778&debug=1`
+  - connects the browser directly to the authoritative websocket runtime and enables live TOON debug documents

--- a/apps/pod-web/index.html
+++ b/apps/pod-web/index.html
@@ -143,6 +143,10 @@
         <dl>
           <dt>Backend</dt>
           <dd id="backend-label">starting…</dd>
+          <dt>Connection</dt>
+          <dd id="connection-label">offline demo / bridge mode</dd>
+          <dt>World</dt>
+          <dd id="world-label">demo scene</dd>
           <dt>Quality</dt>
           <dd id="quality-label">auto</dd>
           <dt>Source</dt>
@@ -150,7 +154,7 @@
           <dt>Stats</dt>
           <dd id="stats-label">warming up…</dd>
           <dt>Bridge</dt>
-          <dd><code>window.podRender.renderThreeJsWebGpuFrame(...)</code></dd>
+          <dd><code>window.podRender.renderThreeJsWebGpuFrame(...)</code> or <code>?server=127.0.0.1:7778&amp;debug=1</code></dd>
         </dl>
       </section>
       <section class="hud hud--telemetry" id="telemetry-panel" data-telemetry-enabled="false">

--- a/apps/pod-web/src/contracts.test.ts
+++ b/apps/pod-web/src/contracts.test.ts
@@ -2,8 +2,15 @@ import { describe, expect, test } from "bun:test";
 import { encode } from "@toon-format/toon";
 
 import {
+  applyNetworkStateDelta,
+  buildAuthoritativeWorldFrame,
+  encodeDirectConnectConnectMessage,
+  encodeDirectConnectDebugTelemetryMessage,
+  encodeDirectConnectFullSnapshotRequest,
+  type NetworkWorldSnapshot,
   parseAgentTickRollup,
   parseAgentToolCallEvent,
+  parseDirectConnectServerMessage,
   parseLiveDebugDocument,
   parseReplayFile,
   parseShardIncidentSummary,
@@ -220,5 +227,151 @@ describe("TOON contract parsing", () => {
       throw new Error("expected tick telemetry document");
     }
     expect(telemetry.payload.tickTelemetry.tick).toBe(9);
+  });
+
+  test("parses direct-connect welcome and delta messages", () => {
+    const welcome = parseDirectConnectServerMessage(
+      JSON.stringify({
+        Welcome: {
+          client_id: "client-1",
+          reconnect_token: "reconnect-1",
+          tick: 12,
+          controlled_entity: 44,
+          authoritative_digest: 991,
+          snapshot: {
+            tick: 12,
+            entities: [
+              {
+                id: 44,
+                position: [12, 18],
+                velocity: [1, 0],
+                rotation: 0.4,
+                label: "Hero"
+              }
+            ]
+          }
+        }
+      })
+    );
+
+    expect(welcome.kind).toBe("welcome");
+    if (welcome.kind !== "welcome") {
+      throw new Error("expected welcome");
+    }
+    expect(welcome.snapshot.entities[0]?.position).toEqual([12, 18]);
+
+    const delta = parseDirectConnectServerMessage(
+      JSON.stringify({
+        StateDelta: {
+          tick: 13,
+          acknowledged_action_tick: 12,
+          authoritative_digest: 992,
+          is_full_snapshot: false,
+          delta: {
+            tick: 13,
+            updated: [
+              {
+                id: 44,
+                position: { x: 14, y: 19 },
+                velocity: [2, 0],
+                rotation: 0.55,
+                label: "Hero"
+              }
+            ],
+            destroyed: [99]
+          }
+        }
+      })
+    );
+
+    expect(delta.kind).toBe("stateDelta");
+    if (delta.kind !== "stateDelta") {
+      throw new Error("expected delta");
+    }
+    expect(delta.delta.updated[0]?.position).toEqual([14, 19]);
+    expect(delta.acknowledgedActionTick).toBe(12);
+  });
+
+  test("applies authoritative state deltas and builds a live world frame", () => {
+    const baseline: NetworkWorldSnapshot = {
+      tick: 10,
+      entities: [
+        {
+          id: 1,
+          position: [10, 10],
+          velocity: [0, 0],
+          rotation: 0,
+          label: "Hero"
+        },
+        {
+          id: 2,
+          position: [20, 12],
+          velocity: [0, 0],
+          rotation: 0,
+          label: "Wall-East"
+        }
+      ]
+    };
+
+    const next = applyNetworkStateDelta(
+      baseline,
+      {
+        tick: 11,
+        updated: [
+          {
+            id: 1,
+            position: [14, 12],
+            velocity: [4, 0],
+            rotation: 0.3,
+            label: "Hero"
+          },
+          {
+            id: 3,
+            position: [18, 20],
+            velocity: [0, 0],
+            rotation: 0,
+            label: "Monster-Wolf"
+          }
+        ],
+        destroyed: [2]
+      },
+      false
+    );
+
+    expect(next.tick).toBe(11);
+    expect(next.entities.map((entity) => entity.id)).toEqual([1, 3]);
+
+    const frame = buildAuthoritativeWorldFrame(next, {
+      controlledEntity: 1,
+      viewportWidth: 1440,
+      viewportHeight: 900
+    });
+
+    expect(frame.camera.viewportWidth).toBe(1440);
+    expect(frame.meshBatches.some((batch) => batch.mesh.includes("adventurer"))).toBe(true);
+    expect(frame.meshBatches.some((batch) => batch.mesh.includes("rift-beast"))).toBe(true);
+    expect(frame.spriteBatches.some((batch) => batch.texture === "selection-ring")).toBe(true);
+  });
+
+  test("encodes browser direct-connect client messages with Rust enum tags", () => {
+    expect(JSON.parse(encodeDirectConnectConnectMessage("WebPlayer", "resume-1"))).toEqual({
+      Connect: {
+        player_name: "WebPlayer",
+        reconnect_token: "resume-1"
+      }
+    });
+
+    expect(JSON.parse(encodeDirectConnectDebugTelemetryMessage(true))).toEqual({
+      SetDebugTelemetry: {
+        enabled: true
+      }
+    });
+
+    expect(JSON.parse(encodeDirectConnectFullSnapshotRequest(42, 99))).toEqual({
+      RequestFullSnapshot: {
+        last_known_tick: 42,
+        last_known_digest: 99
+      }
+    });
   });
 });

--- a/apps/pod-web/src/contracts.ts
+++ b/apps/pod-web/src/contracts.ts
@@ -363,6 +363,59 @@ export type LiveDebugDocument =
   | { kind: "replay"; documentType: string; payload: ReplayFileDocument }
   | { kind: "incident"; documentType: string; payload: ShardIncidentSummary };
 
+export interface NetworkEntitySnapshot {
+  id: number;
+  position: Vec2Tuple;
+  velocity: Vec2Tuple;
+  rotation: number;
+  health?: number | null;
+  maxHealth?: number | null;
+  movementSpeed?: number | null;
+  label?: string | null;
+}
+
+export interface NetworkWorldSnapshot {
+  tick: number;
+  entities: NetworkEntitySnapshot[];
+}
+
+export interface NetworkStateDelta {
+  tick: number;
+  updated: NetworkEntitySnapshot[];
+  destroyed: number[];
+}
+
+export type DirectConnectServerMessage =
+  | {
+      kind: "welcome";
+      clientId: string;
+      reconnectToken: string;
+      tick: number;
+      controlledEntity: number | null;
+      authoritativeDigest: number;
+      snapshot: NetworkWorldSnapshot;
+    }
+  | {
+      kind: "stateDelta";
+      tick: number;
+      acknowledgedActionTick: number | null;
+      authoritativeDigest: number;
+      isFullSnapshot: boolean;
+      delta: NetworkStateDelta;
+    }
+  | { kind: "eventBatch"; tick: number; events: unknown[] }
+  | { kind: "tickTelemetry"; frameJson: string }
+  | { kind: "debugDocument"; document: string }
+  | { kind: "pong"; clientTimestamp: number; serverTimestamp: number }
+  | { kind: "rejected"; reason: string };
+
+export interface AuthoritativeWorldFrameOptions {
+  controlledEntity?: number | null;
+  viewportWidth?: number;
+  viewportHeight?: number;
+  backgroundColor?: RgbaTuple;
+}
+
 interface ToonDocumentEnvelope<T = unknown> {
   document_type: string;
   payload: T;
@@ -372,6 +425,55 @@ type JsonRecord = Record<string, unknown>;
 
 function isRecord(value: unknown): value is JsonRecord {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function optionalNumber(value: unknown): number | null | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value === null) {
+    return null;
+  }
+  return asNumber(value);
+}
+
+function optionalString(value: unknown): string | null | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value === null) {
+    return null;
+  }
+  return asString(value);
+}
+
+function vec2Tuple(value: unknown): Vec2Tuple | null {
+  if (
+    Array.isArray(value) &&
+    value.length >= 2 &&
+    typeof value[0] === "number" &&
+    typeof value[1] === "number"
+  ) {
+    return [value[0], value[1]];
+  }
+
+  if (isRecord(value)) {
+    const x = asNumber(value.x);
+    const y = asNumber(value.y);
+    if (x != null && y != null) {
+      return [x, y];
+    }
+  }
+
+  return null;
 }
 
 function decodeStructuredString(value: string): unknown {
@@ -392,6 +494,81 @@ function documentEnvelope(value: unknown): ToonDocumentEnvelope | null {
   }
 
   return value as unknown as ToonDocumentEnvelope;
+}
+
+function variantPayload(value: unknown, variant: string): unknown | null {
+  if (!isRecord(value) || !(variant in value)) {
+    return null;
+  }
+
+  return value[variant];
+}
+
+function parseNetworkEntitySnapshot(value: unknown): NetworkEntitySnapshot | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const id = asNumber(value.id);
+  const position = vec2Tuple(value.position);
+  const velocity = vec2Tuple(value.velocity);
+  const rotation = asNumber(value.rotation);
+
+  if (id == null || position == null || velocity == null || rotation == null) {
+    return null;
+  }
+
+  return {
+    id,
+    position,
+    velocity,
+    rotation,
+    health: optionalNumber(value.health),
+    maxHealth: optionalNumber(value.max_health ?? value.maxHealth),
+    movementSpeed: optionalNumber(value.movement_speed ?? value.movementSpeed),
+    label: optionalString(value.label) ?? null
+  };
+}
+
+function parseNetworkWorldSnapshot(value: unknown): NetworkWorldSnapshot | null {
+  if (!isRecord(value) || typeof value.tick !== "number" || !Array.isArray(value.entities)) {
+    return null;
+  }
+
+  const entities = value.entities
+    .map((entity) => parseNetworkEntitySnapshot(entity))
+    .filter((entity): entity is NetworkEntitySnapshot => entity != null)
+    .sort((left, right) => left.id - right.id);
+
+  return {
+    tick: value.tick,
+    entities
+  };
+}
+
+function parseNetworkStateDelta(value: unknown): NetworkStateDelta | null {
+  if (!isRecord(value) || typeof value.tick !== "number") {
+    return null;
+  }
+
+  const updated = Array.isArray(value.updated)
+    ? value.updated
+        .map((entity) => parseNetworkEntitySnapshot(entity))
+        .filter((entity): entity is NetworkEntitySnapshot => entity != null)
+    : null;
+  const destroyed = Array.isArray(value.destroyed)
+    ? value.destroyed.filter((entityId): entityId is number => typeof entityId === "number")
+    : null;
+
+  if (updated == null || destroyed == null) {
+    return null;
+  }
+
+  return {
+    tick: value.tick,
+    updated,
+    destroyed
+  };
 }
 
 function directTickTelemetryFrame(value: unknown): TickTelemetryFrame | null {
@@ -678,6 +855,483 @@ export function parseLiveDebugDocument(document: string): LiveDebugDocument {
   }
 }
 
+export function parseDirectConnectServerMessage(
+  message: string | DirectConnectServerMessage
+): DirectConnectServerMessage {
+  if (typeof message !== "string") {
+    return message;
+  }
+
+  const parsed = decodeStructuredString(message);
+
+  const welcome = variantPayload(parsed, "Welcome");
+  if (isRecord(welcome)) {
+    const snapshot = parseNetworkWorldSnapshot(welcome.snapshot);
+    if (
+      snapshot &&
+      typeof welcome.client_id === "string" &&
+      typeof welcome.reconnect_token === "string" &&
+      typeof welcome.tick === "number" &&
+      typeof welcome.authoritative_digest === "number"
+    ) {
+      return {
+        kind: "welcome",
+        clientId: welcome.client_id,
+        reconnectToken: welcome.reconnect_token,
+        tick: welcome.tick,
+        controlledEntity: optionalNumber(welcome.controlled_entity) ?? null,
+        authoritativeDigest: welcome.authoritative_digest,
+        snapshot
+      };
+    }
+  }
+
+  const stateDelta = variantPayload(parsed, "StateDelta");
+  if (isRecord(stateDelta)) {
+    const delta = parseNetworkStateDelta(stateDelta.delta);
+    if (
+      delta &&
+      typeof stateDelta.tick === "number" &&
+      typeof stateDelta.authoritative_digest === "number" &&
+      typeof stateDelta.is_full_snapshot === "boolean"
+    ) {
+      return {
+        kind: "stateDelta",
+        tick: stateDelta.tick,
+        acknowledgedActionTick: optionalNumber(stateDelta.acknowledged_action_tick) ?? null,
+        authoritativeDigest: stateDelta.authoritative_digest,
+        isFullSnapshot: stateDelta.is_full_snapshot,
+        delta
+      };
+    }
+  }
+
+  const eventBatch = variantPayload(parsed, "EventBatch");
+  if (
+    isRecord(eventBatch) &&
+    typeof eventBatch.tick === "number" &&
+    Array.isArray(eventBatch.events)
+  ) {
+    return {
+      kind: "eventBatch",
+      tick: eventBatch.tick,
+      events: eventBatch.events
+    };
+  }
+
+  const tickTelemetry = variantPayload(parsed, "TickTelemetry");
+  if (isRecord(tickTelemetry) && typeof tickTelemetry.frame_json === "string") {
+    return {
+      kind: "tickTelemetry",
+      frameJson: tickTelemetry.frame_json
+    };
+  }
+
+  const debugDocument = variantPayload(parsed, "DebugDocument");
+  if (isRecord(debugDocument) && typeof debugDocument.document === "string") {
+    return {
+      kind: "debugDocument",
+      document: debugDocument.document
+    };
+  }
+
+  const pong = variantPayload(parsed, "Pong");
+  if (
+    isRecord(pong) &&
+    typeof pong.client_ts === "number" &&
+    typeof pong.server_ts === "number"
+  ) {
+    return {
+      kind: "pong",
+      clientTimestamp: pong.client_ts,
+      serverTimestamp: pong.server_ts
+    };
+  }
+
+  const rejected = variantPayload(parsed, "Rejected");
+  if (isRecord(rejected) && typeof rejected.reason === "string") {
+    return {
+      kind: "rejected",
+      reason: rejected.reason
+    };
+  }
+
+  throw new Error("Invalid direct-connect server message payload");
+}
+
+export function encodeDirectConnectConnectMessage(
+  playerName: string,
+  reconnectToken?: string | null
+): string {
+  return JSON.stringify({
+    Connect: {
+      player_name: playerName,
+      reconnect_token: reconnectToken ?? null
+    }
+  });
+}
+
+export function encodeDirectConnectDebugTelemetryMessage(enabled: boolean): string {
+  return JSON.stringify({
+    SetDebugTelemetry: {
+      enabled
+    }
+  });
+}
+
+export function encodeDirectConnectFullSnapshotRequest(
+  lastKnownTick?: number | null,
+  lastKnownDigest?: number | null
+): string {
+  return JSON.stringify({
+    RequestFullSnapshot: {
+      last_known_tick: lastKnownTick ?? null,
+      last_known_digest: lastKnownDigest ?? null
+    }
+  });
+}
+
+export function applyNetworkStateDelta(
+  currentSnapshot: NetworkWorldSnapshot | null,
+  delta: NetworkStateDelta,
+  isFullSnapshot: boolean
+): NetworkWorldSnapshot {
+  if (isFullSnapshot) {
+    return {
+      tick: delta.tick,
+      entities: delta.updated.slice().sort((left, right) => left.id - right.id)
+    };
+  }
+
+  if (currentSnapshot == null) {
+    throw new Error("Cannot apply delta update without a baseline snapshot");
+  }
+
+  const entitiesById = new Map<number, NetworkEntitySnapshot>();
+  for (const entity of currentSnapshot.entities) {
+    entitiesById.set(entity.id, entity);
+  }
+  for (const entity of delta.updated) {
+    entitiesById.set(entity.id, entity);
+  }
+  for (const entityId of delta.destroyed) {
+    entitiesById.delete(entityId);
+  }
+
+  return {
+    tick: delta.tick,
+    entities: Array.from(entitiesById.values()).sort((left, right) => left.id - right.id)
+  };
+}
+
+const WORLD_TO_RENDER_SCALE = 0.08;
+const GROUND_RING_ROTATION: Vec4Tuple = [-Math.SQRT1_2, 0, 0, Math.SQRT1_2];
+
+interface EntityRenderProfile {
+  mesh: string;
+  material: string;
+  tint: RgbaTuple;
+  emissive: Vec3Tuple;
+  scale: Vec3Tuple;
+  layer: number;
+  renderOrder: number;
+  roughness: number;
+  metallic: number;
+}
+
+function yawQuaternion(yaw: number): Vec4Tuple {
+  return [0, Math.sin(yaw * 0.5), 0, Math.cos(yaw * 0.5)];
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function defaultViewportWidth(): number {
+  if (typeof window === "undefined") {
+    return 1280;
+  }
+  return window.innerWidth;
+}
+
+function defaultViewportHeight(): number {
+  if (typeof window === "undefined") {
+    return 720;
+  }
+  return window.innerHeight;
+}
+
+function defaultFrameHints(): ThreeJsWebGpuHints {
+  return {
+    renderer: "three/webgpu",
+    preferredBackend: "webgpu",
+    fallbackBackend: "webgl2",
+    useInstancing: true,
+    sortMetric: "world-z",
+    sortOpaqueFrontToBack: true,
+    preserveInstanceOrder: true,
+    sortTransparentBackToFront: true,
+    transparentInstancingStrategy: "shared-sort-depth",
+    opaqueDepthWrite: true,
+    transparentDepthWrite: false,
+    maxPixelRatio: 2
+  };
+}
+
+function healthBand(entity: NetworkEntitySnapshot): "healthy" | "wounded" | "critical" | "neutral" {
+  if (entity.health == null || entity.maxHealth == null || entity.maxHealth <= 0) {
+    return "neutral";
+  }
+
+  const ratio = entity.health / entity.maxHealth;
+  if (ratio < 0.35) {
+    return "critical";
+  }
+  if (ratio < 0.7) {
+    return "wounded";
+  }
+  return "healthy";
+}
+
+function entityRenderProfile(
+  entity: NetworkEntitySnapshot,
+  controlledEntity: number | null
+): EntityRenderProfile {
+  const label = entity.label?.toLowerCase() ?? "";
+  const band = healthBand(entity);
+
+  if (label.includes("wall")) {
+    return {
+      mesh: "basalt-column",
+      material: "obsidian-wall",
+      tint: [0.24, 0.3, 0.38, 1],
+      emissive: [0.01, 0.02, 0.03],
+      scale: [3.8, 3.4, 1.1],
+      layer: 0,
+      renderOrder: 0,
+      roughness: 0.94,
+      metallic: 0.06
+    };
+  }
+
+  if (label.includes("obstacle") || label.includes("rock") || label.includes("boulder")) {
+    return {
+      mesh: "weathered-boulder",
+      material: "arena-stone",
+      tint: [0.5, 0.42, 0.32, 1],
+      emissive: [0.02, 0.015, 0.01],
+      scale: [2.1, 1.6, 2.1],
+      layer: 1,
+      renderOrder: 1,
+      roughness: 0.96,
+      metallic: 0.04
+    };
+  }
+
+  if (
+    label.includes("monster") ||
+    label.includes("creature") ||
+    label.includes("beast") ||
+    label.includes("npc")
+  ) {
+    return {
+      mesh: "rift-beast",
+      material: `rift-hide:${band}`,
+      tint:
+        band === "critical"
+          ? [0.86, 0.34, 0.28, 1]
+          : band === "wounded"
+            ? [0.82, 0.56, 0.34, 1]
+            : [0.72, 0.52, 0.4, 1],
+      emissive: band === "critical" ? [0.12, 0.03, 0.02] : [0.04, 0.02, 0.01],
+      scale: [1.6, 1.9, 1.6],
+      layer: 2,
+      renderOrder: 2,
+      roughness: 0.82,
+      metallic: 0.08
+    };
+  }
+
+  if (
+    label.includes("companion") ||
+    label.includes("pet") ||
+    label.includes("summon") ||
+    label.includes("spirit")
+  ) {
+    return {
+      mesh: "spirit-companion",
+      material: `summon-shell:${band}`,
+      tint: [0.42, 0.88, 0.74, 1],
+      emissive: [0.06, 0.16, 0.12],
+      scale: [1.0, 1.35, 1.0],
+      layer: 3,
+      renderOrder: 3,
+      roughness: 0.42,
+      metallic: 0.12
+    };
+  }
+
+  const isControlled = controlledEntity != null && entity.id === controlledEntity;
+  return {
+    mesh: isControlled ? "adventurer-hero" : "adventurer-avatar",
+    material: `traveler-cloth:${band}:${isControlled ? "hero" : "party"}`,
+    tint: isControlled
+      ? [0.92, 0.84, 0.58, 1]
+      : band === "critical"
+        ? [0.82, 0.38, 0.34, 1]
+        : band === "wounded"
+          ? [0.44, 0.76, 0.92, 1]
+          : [0.36, 0.66, 0.88, 1],
+    emissive: isControlled ? [0.08, 0.06, 0.02] : [0.02, 0.03, 0.05],
+    scale: isControlled ? [1.2, 2.0, 1.2] : [1.05, 1.85, 1.05],
+    layer: 4,
+    renderOrder: 4,
+    roughness: 0.64,
+    metallic: 0.08
+  };
+}
+
+function meshBatchKey(profile: EntityRenderProfile): string {
+  return [
+    profile.mesh,
+    profile.material,
+    profile.layer,
+    profile.renderOrder,
+    profile.tint.join(":")
+  ].join("|");
+}
+
+export function buildAuthoritativeWorldFrame(
+  snapshot: NetworkWorldSnapshot,
+  options: AuthoritativeWorldFrameOptions = {}
+): ThreeJsWebGpuFrame {
+  const controlledEntity = options.controlledEntity ?? null;
+  const controlled = snapshot.entities.find((entity) => entity.id === controlledEntity) ?? null;
+  const focus = controlled ?? snapshot.entities[0] ?? null;
+  const focusPosition = focus
+    ? [focus.position[0] * WORLD_TO_RENDER_SCALE, focus.position[1] * WORLD_TO_RENDER_SCALE]
+    : [0, 0];
+
+  let maxDistance = 10;
+  for (const entity of snapshot.entities) {
+    const dx = (entity.position[0] * WORLD_TO_RENDER_SCALE) - focusPosition[0];
+    const dz = (entity.position[1] * WORLD_TO_RENDER_SCALE) - focusPosition[1];
+    maxDistance = Math.max(maxDistance, Math.hypot(dx, dz));
+  }
+
+  const meshBatches = new Map<string, ThreeJsMeshBatch>();
+  const spriteBatches = new Array<ThreeJsSpriteBatch>();
+
+  for (const entity of snapshot.entities) {
+    const profile = entityRenderProfile(entity, controlledEntity);
+    const position: Vec3Tuple = [
+      entity.position[0] * WORLD_TO_RENDER_SCALE,
+      profile.scale[1] * 0.5,
+      entity.position[1] * WORLD_TO_RENDER_SCALE
+    ];
+    const instance: ThreeJsInstance = {
+      position,
+      rotation: yawQuaternion(entity.rotation),
+      scale: profile.scale,
+      sourceEntity: entity.id
+    };
+
+    const batchKey = meshBatchKey(profile);
+    const batch = meshBatches.get(batchKey);
+    if (batch) {
+      batch.instances.push(instance);
+    } else {
+      meshBatches.set(batchKey, {
+        mesh: profile.mesh,
+        material: profile.material,
+        layer: profile.layer,
+        phase: "opaque",
+        sortDepth: 0,
+        renderOrder: profile.renderOrder,
+        transparent: false,
+        doubleSided: false,
+        castShadows: true,
+        receiveShadows: true,
+        tint: profile.tint,
+        roughness: profile.roughness,
+        metallic: profile.metallic,
+        emissive: profile.emissive,
+        depthWrite: true,
+        depthTest: true,
+        instances: [instance]
+      });
+    }
+
+    const band = healthBand(entity);
+    if (controlledEntity != null && entity.id === controlledEntity) {
+      spriteBatches.push({
+        texture: "selection-ring",
+        frame: 0,
+        layer: 8,
+        billboard: false,
+        phase: "transparent",
+        sortDepth: position[2],
+        renderOrder: 24,
+        transparent: true,
+        depthWrite: false,
+        depthTest: true,
+        instances: [
+          {
+            position: [position[0], 0.08, position[2]],
+            rotation: GROUND_RING_ROTATION,
+            scale: [2.6, 2.6, 1],
+            color: [0.62, 0.98, 0.84, 0.34],
+            sourceEntity: entity.id
+          }
+        ]
+      });
+    } else if (band === "critical") {
+      spriteBatches.push({
+        texture: "danger-ring",
+        frame: 0,
+        layer: 7,
+        billboard: false,
+        phase: "transparent",
+        sortDepth: position[2],
+        renderOrder: 20,
+        transparent: true,
+        depthWrite: false,
+        depthTest: true,
+        instances: [
+          {
+            position: [position[0], 0.06, position[2]],
+            rotation: GROUND_RING_ROTATION,
+            scale: [2.1, 2.1, 1],
+            color: [0.92, 0.34, 0.3, 0.22],
+            sourceEntity: entity.id
+          }
+        ]
+      });
+    }
+  }
+
+  return {
+    camera: {
+      x: focusPosition[0],
+      y: focusPosition[1],
+      zoom: clamp(1.45 - maxDistance * 0.025, 0.6, 1.45),
+      rotation: focus?.rotation ?? 0.35,
+      viewportWidth: options.viewportWidth ?? defaultViewportWidth(),
+      viewportHeight: options.viewportHeight ?? defaultViewportHeight()
+    },
+    backgroundColor: options.backgroundColor ?? [0.04, 0.06, 0.1, 1],
+    overlayCommands: [],
+    meshBatches: Array.from(meshBatches.values()).sort((left, right) => {
+      if (left.renderOrder !== right.renderOrder) {
+        return left.renderOrder - right.renderOrder;
+      }
+      return left.material.localeCompare(right.material);
+    }),
+    spriteBatches,
+    hints: defaultFrameHints()
+  };
+}
+
 export function legacyFrameToThreeJsFrame(frame: RenderFrame): ThreeJsWebGpuFrame {
   return {
     camera: frame.camera,
@@ -685,19 +1339,6 @@ export function legacyFrameToThreeJsFrame(frame: RenderFrame): ThreeJsWebGpuFram
     overlayCommands: frame.commands.filter((command) => command.visible),
     meshBatches: [],
     spriteBatches: [],
-    hints: {
-      renderer: "three/webgpu",
-      preferredBackend: "webgpu",
-      fallbackBackend: "webgl2",
-      useInstancing: true,
-      sortMetric: "world-z",
-      sortOpaqueFrontToBack: true,
-      preserveInstanceOrder: true,
-      sortTransparentBackToFront: true,
-      transparentInstancingStrategy: "shared-sort-depth",
-      opaqueDepthWrite: true,
-      transparentDepthWrite: false,
-      maxPixelRatio: 2
-    }
+    hints: defaultFrameHints()
   };
 }

--- a/apps/pod-web/src/direct-connect.test.ts
+++ b/apps/pod-web/src/direct-connect.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+
+import { runtimeConfigFromLocation } from "./direct-connect";
+
+describe("direct-connect runtime config", () => {
+  test("builds a websocket config from server query params", () => {
+    const config = runtimeConfigFromLocation({
+      search: "?server=127.0.0.1:7778&player=Scout&debug=1&reconnectMs=2500"
+    } as Location);
+
+    expect(config).not.toBeNull();
+    expect(config?.url).toBe("ws://127.0.0.1:7778");
+    expect(config?.playerName).toBe("Scout");
+    expect(config?.debugTelemetry).toBe(true);
+    expect(config?.reconnectDelayMs).toBe(2500);
+  });
+
+  test("returns null when no direct-connect params are present", () => {
+    const config = runtimeConfigFromLocation({
+      search: "?demo=1"
+    } as Location);
+
+    expect(config).toBeNull();
+  });
+});

--- a/apps/pod-web/src/direct-connect.ts
+++ b/apps/pod-web/src/direct-connect.ts
@@ -1,0 +1,307 @@
+import {
+  applyNetworkStateDelta,
+  buildAuthoritativeWorldFrame,
+  encodeDirectConnectConnectMessage,
+  encodeDirectConnectDebugTelemetryMessage,
+  encodeDirectConnectFullSnapshotRequest,
+  parseDirectConnectServerMessage,
+  type AuthoritativeWorldFrameOptions,
+  type DirectConnectServerMessage,
+  type NetworkWorldSnapshot
+} from "./contracts";
+
+export interface DirectConnectRuntimeConfig {
+  url: string;
+  playerName: string;
+  debugTelemetry: boolean;
+  reconnectDelayMs: number;
+}
+
+export interface DirectConnectStatus {
+  phase:
+    | "idle"
+    | "connecting"
+    | "connected"
+    | "reconnecting"
+    | "rejected"
+    | "disconnected"
+    | "error";
+  detail: string;
+  url: string;
+  tick: number | null;
+  entityCount: number;
+  controlledEntity: number | null;
+  authoritativeDigest: number | null;
+}
+
+interface DirectConnectHandlers {
+  onFrame: (
+    snapshot: NetworkWorldSnapshot,
+    frameOptions: AuthoritativeWorldFrameOptions,
+    status: DirectConnectStatus
+  ) => void;
+  onDebugDocument: (document: string) => void;
+  onStatus: (status: DirectConnectStatus) => void;
+}
+
+const DEFAULT_PLAYER_NAME = "WebPlayer";
+const DEFAULT_RECONNECT_DELAY_MS = 1500;
+
+export function runtimeConfigFromLocation(
+  location: Pick<Location, "search">
+): DirectConnectRuntimeConfig | null {
+  const params = new URLSearchParams(location.search);
+  const explicitUrl = params.get("ws");
+  const server = params.get("server");
+
+  if (!explicitUrl && !server) {
+    return null;
+  }
+
+  const url = explicitUrl ?? normalizeServerToWebSocket(server ?? "");
+  return {
+    url,
+    playerName: params.get("player")?.trim() || DEFAULT_PLAYER_NAME,
+    debugTelemetry: parseBooleanParam(params.get("debug")),
+    reconnectDelayMs: parsePositiveInt(params.get("reconnectMs")) ?? DEFAULT_RECONNECT_DELAY_MS
+  };
+}
+
+export class PodWebDirectConnectClient {
+  private socket: WebSocket | null = null;
+  private reconnectTimer: number | null = null;
+  private reconnectToken: string | null = null;
+  private snapshot: NetworkWorldSnapshot | null = null;
+  private controlledEntity: number | null = null;
+  private authoritativeDigest: number | null = null;
+  private closedExplicitly = false;
+  private debugTelemetryEnabled: boolean;
+  private status: DirectConnectStatus;
+
+  constructor(
+    private readonly config: DirectConnectRuntimeConfig,
+    private readonly handlers: DirectConnectHandlers
+  ) {
+    this.debugTelemetryEnabled = config.debugTelemetry;
+    this.status = {
+      phase: "idle",
+      detail: "Idle",
+      url: config.url,
+      tick: null,
+      entityCount: 0,
+      controlledEntity: null,
+      authoritativeDigest: null
+    };
+  }
+
+  connect(): void {
+    this.closedExplicitly = false;
+    this.clearReconnectTimer();
+    this.updateStatus("connecting", `Connecting to ${this.config.url}`);
+
+    const socket = new WebSocket(this.config.url);
+    this.socket = socket;
+
+    socket.addEventListener("open", () => {
+      socket.send(
+        encodeDirectConnectConnectMessage(this.config.playerName, this.reconnectToken)
+      );
+      if (this.debugTelemetryEnabled) {
+        socket.send(encodeDirectConnectDebugTelemetryMessage(true));
+      }
+    });
+
+    socket.addEventListener("message", (event) => {
+      if (typeof event.data !== "string") {
+        return;
+      }
+
+      try {
+        this.handleServerMessage(parseDirectConnectServerMessage(event.data));
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        this.updateStatus("error", `Invalid server payload: ${message}`);
+      }
+    });
+
+    socket.addEventListener("close", () => {
+      this.socket = null;
+      if (this.closedExplicitly) {
+        this.updateStatus("disconnected", "Disconnected");
+        return;
+      }
+      this.updateStatus("reconnecting", `Connection lost, retrying in ${this.config.reconnectDelayMs}ms`);
+      this.scheduleReconnect();
+    });
+
+    socket.addEventListener("error", () => {
+      this.updateStatus("error", "WebSocket transport error");
+    });
+  }
+
+  disconnect(): void {
+    this.closedExplicitly = true;
+    this.clearReconnectTimer();
+    this.socket?.close();
+    this.socket = null;
+    this.updateStatus("disconnected", "Disconnected");
+  }
+
+  setDebugTelemetry(enabled: boolean): void {
+    this.debugTelemetryEnabled = enabled;
+    if (this.socket?.readyState === WebSocket.OPEN) {
+      this.socket.send(encodeDirectConnectDebugTelemetryMessage(enabled));
+    }
+  }
+
+  currentStatus(): DirectConnectStatus {
+    return { ...this.status };
+  }
+
+  private handleServerMessage(message: DirectConnectServerMessage): void {
+    switch (message.kind) {
+      case "welcome":
+        this.reconnectToken = message.reconnectToken;
+        this.snapshot = message.snapshot;
+        this.controlledEntity = message.controlledEntity;
+        this.authoritativeDigest = message.authoritativeDigest;
+        this.updateWorldStatus("connected", `Connected as ${this.config.playerName}`);
+        this.emitFrame();
+        break;
+      case "stateDelta":
+        try {
+          this.snapshot = applyNetworkStateDelta(
+            this.snapshot,
+            message.delta,
+            message.isFullSnapshot
+          );
+          this.authoritativeDigest = message.authoritativeDigest;
+          this.updateWorldStatus("connected", `Authoritative tick ${message.tick}`);
+          this.emitFrame();
+        } catch {
+          this.socket?.send(
+            encodeDirectConnectFullSnapshotRequest(
+              this.snapshot?.tick ?? null,
+              this.authoritativeDigest
+            )
+          );
+          this.updateStatus("reconnecting", "Requested full snapshot recovery");
+        }
+        break;
+      case "tickTelemetry":
+        this.handlers.onDebugDocument(message.frameJson);
+        break;
+      case "debugDocument":
+        this.handlers.onDebugDocument(message.document);
+        break;
+      case "rejected":
+        this.updateStatus("rejected", message.reason);
+        break;
+      case "pong":
+      case "eventBatch":
+        break;
+    }
+  }
+
+  private emitFrame(): void {
+    if (!this.snapshot) {
+      return;
+    }
+
+    this.handlers.onFrame(
+      this.snapshot,
+      {
+        controlledEntity: this.controlledEntity
+      },
+      this.currentStatus()
+    );
+  }
+
+  private updateWorldStatus(
+    phase: DirectConnectStatus["phase"],
+    detail: string
+  ): void {
+    this.updateStatus(phase, detail, {
+      tick: this.snapshot?.tick ?? null,
+      entityCount: this.snapshot?.entities.length ?? 0,
+      controlledEntity: this.controlledEntity,
+      authoritativeDigest: this.authoritativeDigest
+    });
+  }
+
+  private updateStatus(
+    phase: DirectConnectStatus["phase"],
+    detail: string,
+    overrides: Partial<DirectConnectStatus> = {}
+  ): void {
+    this.status = {
+      ...this.status,
+      phase,
+      detail,
+      ...overrides
+    };
+    this.handlers.onStatus(this.currentStatus());
+  }
+
+  private scheduleReconnect(): void {
+    this.clearReconnectTimer();
+    this.reconnectTimer = window.setTimeout(() => {
+      this.connect();
+    }, this.config.reconnectDelayMs);
+  }
+
+  private clearReconnectTimer(): void {
+    if (this.reconnectTimer != null) {
+      window.clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+}
+
+export function frameFromAuthoritativeSnapshot(
+  snapshot: NetworkWorldSnapshot,
+  options: AuthoritativeWorldFrameOptions = {}
+) {
+  return buildAuthoritativeWorldFrame(snapshot, options);
+}
+
+function normalizeServerToWebSocket(server: string): string {
+  if (server.startsWith("ws://") || server.startsWith("wss://")) {
+    return server;
+  }
+
+  if (server.startsWith("http://")) {
+    return `ws://${server.slice("http://".length)}`;
+  }
+
+  if (server.startsWith("https://")) {
+    return `wss://${server.slice("https://".length)}`;
+  }
+
+  return `ws://${server}`;
+}
+
+function parseBooleanParam(value: string | null): boolean {
+  if (value == null) {
+    return false;
+  }
+
+  switch (value.toLowerCase()) {
+    case "1":
+    case "true":
+    case "yes":
+    case "on":
+      return true;
+    default:
+      return false;
+  }
+}
+
+function parsePositiveInt(value: string | null): number | null {
+  if (value == null) {
+    return null;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}

--- a/apps/pod-web/src/main.ts
+++ b/apps/pod-web/src/main.ts
@@ -1,5 +1,7 @@
 import {
+  buildAuthoritativeWorldFrame,
   parseLiveDebugDocument,
+  type DirectConnectServerMessage,
   parseRenderFrame,
   parseReplayFile,
   parseShardIncidentSummary,
@@ -13,6 +15,11 @@ import {
   type ReplaySummary,
   type ShardIncidentSummary
 } from "./contracts";
+import {
+  PodWebDirectConnectClient,
+  runtimeConfigFromLocation,
+  type DirectConnectStatus
+} from "./direct-connect";
 import { PodThreeWorldRenderer } from "./renderer";
 import { createDemoFrame } from "./sample-frame";
 import {
@@ -50,6 +57,8 @@ declare global {
 const canvas = document.querySelector<HTMLCanvasElement>("#pod-web-canvas");
 const backendLabel = document.querySelector<HTMLElement>("#backend-label");
 const frameSourceLabel = document.querySelector<HTMLElement>("#frame-source");
+const connectionLabel = document.querySelector<HTMLElement>("#connection-label");
+const worldLabel = document.querySelector<HTMLElement>("#world-label");
 const qualityLabel = document.querySelector<HTMLElement>("#quality-label");
 const statsLabel = document.querySelector<HTMLElement>("#stats-label");
 const telemetryToggle = document.querySelector<HTMLButtonElement>("#telemetry-toggle");
@@ -78,6 +87,8 @@ if (
   !canvas ||
   !backendLabel ||
   !frameSourceLabel ||
+  !connectionLabel ||
+  !worldLabel ||
   !qualityLabel ||
   !statsLabel ||
   !telemetryToggle ||
@@ -99,6 +110,8 @@ if (
 }
 
 const telemetryToggleButton = telemetryToggle;
+const connectionNode = connectionLabel;
+const worldNode = worldLabel;
 const telemetrySelectionNode = telemetrySelectionLabel;
 const telemetryTrailNode = telemetryTrailLabel;
 const telemetryActionsNode = telemetryActionsLabel;
@@ -118,9 +131,10 @@ backendLabel.textContent = renderer.backend;
 qualityLabel.textContent = renderer.quality.preset;
 const runtimeStatsLabel = statsLabel;
 const telemetryState = createTelemetryOverlayState(300);
+const runtimeConfig = runtimeConfigFromLocation(window.location);
 
 let liveFrameSource: "demo" | "legacy" | "threejs" = "demo";
-let latestFrameJson: string | null = null;
+let latestFrame: string | ReturnType<typeof buildAuthoritativeWorldFrame> | null = null;
 let lastTelemetryRevision = -1;
 let latestReplaySummary: ReplaySummary | null = null;
 let latestIncidentSummary: ShardIncidentSummary | null = null;
@@ -128,9 +142,46 @@ let latestToolEventSummary: ToolCallEventSummary | null = null;
 let latestRollupSummary: TickRollupSummary | null = null;
 let liveReplayDocuments = 0;
 let liveIncidentDocuments = 0;
+let liveConnectionStatus: DirectConnectStatus | null = runtimeConfig
+  ? {
+      phase: "idle",
+      detail: `Waiting to connect to ${runtimeConfig.url}`,
+      url: runtimeConfig.url,
+      tick: null,
+      entityCount: 0,
+      controlledEntity: null,
+      authoritativeDigest: null
+    }
+  : null;
+
+if (runtimeConfig?.debugTelemetry) {
+  setTelemetryEnabled(telemetryState, true);
+}
+
+const liveClient = runtimeConfig
+  ? new PodWebDirectConnectClient(runtimeConfig, {
+      onFrame(snapshot, frameOptions, status) {
+        latestFrame = buildAuthoritativeWorldFrame(snapshot, {
+          ...frameOptions,
+          viewportWidth: canvas.clientWidth || window.innerWidth,
+          viewportHeight: canvas.clientHeight || window.innerHeight
+        });
+        liveFrameSource = "threejs";
+        frameSourceLabel.textContent = "authoritative websocket";
+        liveConnectionStatus = status;
+      },
+      onDebugDocument(document) {
+        applyLiveDebugDocument(document);
+      },
+      onStatus(status) {
+        liveConnectionStatus = status;
+      }
+    })
+  : null;
 
 telemetryToggleButton.addEventListener("click", () => {
   setTelemetryEnabled(telemetryState, !telemetryState.enabled);
+  liveClient?.setDebugTelemetry(telemetryState.enabled);
 });
 telemetryPrevButton.addEventListener("click", () => {
   cycleTelemetrySelection(telemetryState, -1);
@@ -141,12 +192,12 @@ telemetryNextButton.addEventListener("click", () => {
 
 window.podRender = {
   render(frame: string) {
-    latestFrameJson = frame;
+    latestFrame = frame;
     liveFrameSource = "legacy";
     frameSourceLabel.textContent = "legacy pod-render frame";
   },
   renderThreeJsWebGpuFrame(frame: string) {
-    latestFrameJson = frame;
+    latestFrame = frame;
     liveFrameSource = "threejs";
     frameSourceLabel.textContent = "Three.js WebGPU frame";
   },
@@ -173,7 +224,7 @@ window.podRender = {
     renderer.clearTelemetryTrail();
   },
   resetDemo() {
-    latestFrameJson = null;
+    latestFrame = null;
     liveFrameSource = "demo";
     frameSourceLabel.textContent = "demo frame";
   },
@@ -231,11 +282,15 @@ async function tick(timestamp: number): Promise<void> {
     lastTelemetryRevision = telemetryState.revision;
   }
 
-  if (latestFrameJson) {
+  if (latestFrame) {
     if (liveFrameSource === "threejs") {
-      await renderer.applyFrame(parseThreeJsWebGpuFrame(latestFrameJson));
+      await renderer.applyFrame(
+        typeof latestFrame === "string" ? parseThreeJsWebGpuFrame(latestFrame) : latestFrame
+      );
+    } else if (typeof latestFrame === "string") {
+      await renderer.applyLegacyFrame(parseRenderFrame(latestFrame));
     } else {
-      await renderer.applyLegacyFrame(parseRenderFrame(latestFrameJson));
+      await renderer.applyFrame(latestFrame);
     }
   } else {
     await renderer.applyFrame(createDemoFrame(timestamp / 1000));
@@ -254,6 +309,18 @@ async function tick(timestamp: number): Promise<void> {
 
 function renderTelemetryHud(): void {
   const stats = telemetryStats(telemetryState);
+  connectionNode.textContent = liveConnectionStatus
+    ? `${liveConnectionStatus.phase} · ${liveConnectionStatus.detail}`
+    : "offline demo / bridge mode";
+  worldNode.textContent = liveConnectionStatus
+    ? liveConnectionStatus.tick == null
+      ? `awaiting snapshot · ${liveConnectionStatus.url}`
+      : `tick ${liveConnectionStatus.tick} · ${liveConnectionStatus.entityCount} entities · ${
+          liveConnectionStatus.controlledEntity == null
+            ? "spectator"
+            : `controlled E(${liveConnectionStatus.controlledEntity})`
+        }`
+    : "demo scene";
   telemetryToggleButton.textContent = stats.enabled ? "Disable Telemetry" : "Enable Telemetry";
   telemetryPanelNode.dataset.telemetryEnabled = String(stats.enabled);
   telemetrySelectionNode.textContent = stats.selectedLabel;
@@ -295,4 +362,5 @@ function renderTelemetryHud(): void {
   }
 }
 
+liveClient?.connect();
 void tick(performance.now());


### PR DESCRIPTION
## Summary
- add typed websocket direct-connect parsing and state application in pod-web for authoritative server messages
- render Welcome/StateDelta world snapshots as live Three.js WebGPU frames and feed TOON debug documents into the existing browser telemetry HUD
- add browser runtime config, reconnect/debug telemetry handling, tests, and documentation for live shard inspection

## Validation
- cd apps/pod-web && bun test
- cd apps/pod-web && bun run typecheck
- cd apps/pod-web && bun run build
- live browser smoke via Playwright against cargo run -p pod-server --bin pod-server
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added WebSocket direct-connect capability to link to live authoritative game servers, enabling real-time world snapshot and state delta synchronization.
  * Integrated live connection status indicators in the telemetry HUD showing connection phase and world information.
  * Enabled live debug telemetry support for monitoring server state and entity updates in real-time.

* **Documentation**
  * Added live shard connection guide to README with server URL parameters and debug mode instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->