### PR TITLE
Add pod-web browser action controls

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -653,5 +653,17 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - live browser smoke via Playwright against `cargo run -p pod-server --bin pod-server`
   - `git diff --check`
 
-**Last updated**: Iteration 70
-**Current focus**: Iteration 71 MMO world/runtime completion beyond snapshot visualization, starting with browser-side action submission, chat/combat loop interaction, and richer streamed world presentation on top of the live authoritative socket
+### Iteration 71
+- [x] Extended `apps/pod-web` with browser-side action encoding for the shared `pod-core::Action` contract so human browser input emits the same Rust enum-tagged `ActionBatch` payloads the authoritative server already validates for AI agents.
+- [x] Extended the direct-connect browser websocket client with action submission on top of authoritative tick state, keeping reconnect-token recovery and debug-telemetry behavior intact while enabling browser-side human interaction.
+- [x] Added a minimal MMO control surface to `pod-web`: keyboard movement, target cycling, combat/interact/gather/loot/capture triggers, companion summon/follow commands, auto-retaliate toggle, and shard chat submission.
+- [x] Surfaced target selection and browser action controls directly in the browser HUD so creators can inspect and drive the live authoritative shard without dropping back to a native client or debug console.
+- [x] Added deterministic Bun coverage proving the browser websocket client sends a real Rust-shaped `ActionBatch` after `Welcome`, alongside the existing contract tests for direct-connect message parsing and world-frame generation.
+- [x] Validated touched targets:
+  - `cd apps/pod-web && bun test`
+  - `cd apps/pod-web && bun run typecheck`
+  - `cd apps/pod-web && bun run build`
+  - `git diff --check`
+
+**Last updated**: Iteration 71
+**Current focus**: Iteration 72 richer MMO browser loop completion, starting with surfacing chat/combat outcomes from authoritative events, streamed-world presentation depth, and more direct browser-side interaction feedback on top of the live socket

--- a/apps/pod-web/README.md
+++ b/apps/pod-web/README.md
@@ -32,6 +32,20 @@ http://127.0.0.1:5173/?server=127.0.0.1:7778&player=WebPlayer&debug=1
 
 `server` may be `host:port`, `ws://host:port`, or `wss://host:port`.
 
+### Browser controls
+
+- `WASD` or arrow keys: move
+- `Tab`: cycle nearby targets
+- `Space`: attack current target
+- `E`: interact with current target
+- `G`: gather from current target
+- `R`: loot current target
+- `C`: capture current target
+- `1`: summon companion slot `0`
+- `F`: issue a follow command to companion slot `0`
+- `P`: toggle auto-retaliate
+- `Enter`: focus chat input and send a shard message
+
 ## Validate
 
 ```bash

--- a/apps/pod-web/index.html
+++ b/apps/pod-web/index.html
@@ -125,6 +125,23 @@
         color: var(--panel-accent);
       }
 
+      .hud__chat {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: 8px;
+        margin-top: 14px;
+      }
+
+      .hud__chat input {
+        width: 100%;
+        border: 1px solid rgba(138, 245, 207, 0.18);
+        border-radius: 999px;
+        background: rgba(5, 9, 15, 0.72);
+        color: var(--copy);
+        padding: 9px 12px;
+        font: inherit;
+      }
+
       #telemetry-panel[data-telemetry-enabled="false"] .telemetry-debug-only {
         opacity: 0.56;
       }
@@ -147,15 +164,23 @@
           <dd id="connection-label">offline demo / bridge mode</dd>
           <dt>World</dt>
           <dd id="world-label">demo scene</dd>
+          <dt>Target</dt>
+          <dd id="target-label">No target selected</dd>
           <dt>Quality</dt>
           <dd id="quality-label">auto</dd>
           <dt>Source</dt>
           <dd id="frame-source">demo frame</dd>
           <dt>Stats</dt>
           <dd id="stats-label">warming up…</dd>
+          <dt>Controls</dt>
+          <dd><code>WASD</code> move · <code>Tab</code> target · <code>Space</code> attack · <code>E</code> interact · <code>Enter</code> chat</dd>
           <dt>Bridge</dt>
           <dd><code>window.podRender.renderThreeJsWebGpuFrame(...)</code> or <code>?server=127.0.0.1:7778&amp;debug=1</code></dd>
         </dl>
+        <form class="hud__chat" id="chat-form">
+          <input id="chat-input" type="text" maxlength="120" placeholder="Say something to the shard…" />
+          <button type="submit">Send</button>
+        </form>
       </section>
       <section class="hud hud--telemetry" id="telemetry-panel" data-telemetry-enabled="false">
         <h1>Debug Telemetry</h1>

--- a/apps/pod-web/src/contracts.test.ts
+++ b/apps/pod-web/src/contracts.test.ts
@@ -4,6 +4,7 @@ import { encode } from "@toon-format/toon";
 import {
   applyNetworkStateDelta,
   buildAuthoritativeWorldFrame,
+  encodeDirectConnectActionBatch,
   encodeDirectConnectConnectMessage,
   encodeDirectConnectDebugTelemetryMessage,
   encodeDirectConnectFullSnapshotRequest,
@@ -371,6 +372,25 @@ describe("TOON contract parsing", () => {
       RequestFullSnapshot: {
         last_known_tick: 42,
         last_known_digest: 99
+      }
+    });
+
+    expect(
+      JSON.parse(
+        encodeDirectConnectActionBatch(77, [
+          { kind: "move", direction: [1, 0] },
+          { kind: "attackTarget", target: 9 },
+          { kind: "speak", message: "hello", volume: "Normal" }
+        ])
+      )
+    ).toEqual({
+      ActionBatch: {
+        tick: 77,
+        actions: [
+          { Move: { direction: [1, 0] } },
+          { AttackTarget: { target: 9 } },
+          { Speak: { message: "hello", volume: "Normal" } }
+        ]
       }
     });
   });

--- a/apps/pod-web/src/contracts.ts
+++ b/apps/pod-web/src/contracts.ts
@@ -416,6 +416,36 @@ export interface AuthoritativeWorldFrameOptions {
   backgroundColor?: RgbaTuple;
 }
 
+export type BrowserSpeakVolume = "Whisper" | "Normal" | "Shout";
+export type BrowserCompanionCommand = "Attack" | "Follow" | "Guard" | "Recall";
+
+export type BrowserAction =
+  | { kind: "move"; direction: Vec2Tuple }
+  | { kind: "stop" }
+  | { kind: "rotate"; angle: number }
+  | { kind: "lookAt"; target: Vec2Tuple }
+  | { kind: "attack" }
+  | { kind: "attackTarget"; target: number }
+  | { kind: "interact" }
+  | { kind: "interactWith"; target: number }
+  | { kind: "gatherResource"; target: number; skill: string }
+  | { kind: "loot"; target: number }
+  | { kind: "captureCreature"; target: number; toolSlot?: number | null }
+  | { kind: "summonCompanion"; slot: number }
+  | {
+      kind: "commandCompanion";
+      slot: number;
+      command: BrowserCompanionCommand;
+      target?: number | null;
+    }
+  | {
+      kind: "speak";
+      message: string;
+      volume: BrowserSpeakVolume;
+    }
+  | { kind: "setAutoRetaliate"; enabled: boolean }
+  | { kind: "idle" };
+
 interface ToonDocumentEnvelope<T = unknown> {
   document_type: string;
   payload: T;
@@ -991,6 +1021,18 @@ export function encodeDirectConnectFullSnapshotRequest(
   });
 }
 
+export function encodeDirectConnectActionBatch(
+  tick: number,
+  actions: BrowserAction[]
+): string {
+  return JSON.stringify({
+    ActionBatch: {
+      tick,
+      actions: actions.map((action) => encodeBrowserAction(action))
+    }
+  });
+}
+
 export function applyNetworkStateDelta(
   currentSnapshot: NetworkWorldSnapshot | null,
   delta: NetworkStateDelta,
@@ -1076,6 +1118,68 @@ function defaultFrameHints(): ThreeJsWebGpuHints {
     transparentDepthWrite: false,
     maxPixelRatio: 2
   };
+}
+
+function encodeBrowserAction(action: BrowserAction): unknown {
+  switch (action.kind) {
+    case "move":
+      return { Move: { direction: action.direction } };
+    case "stop":
+      return { Stop: null };
+    case "rotate":
+      return { Rotate: { angle: action.angle } };
+    case "lookAt":
+      return { LookAt: { target: action.target } };
+    case "attack":
+      return { Attack: null };
+    case "attackTarget":
+      return { AttackTarget: { target: action.target } };
+    case "interact":
+      return { Interact: null };
+    case "interactWith":
+      return { InteractWith: { target: action.target } };
+    case "gatherResource":
+      return {
+        GatherResource: {
+          target: action.target,
+          skill: action.skill
+        }
+      };
+    case "loot":
+      return { Loot: { target: action.target } };
+    case "captureCreature":
+      return {
+        CaptureCreature: {
+          target: action.target,
+          tool_slot: action.toolSlot ?? null
+        }
+      };
+    case "summonCompanion":
+      return { SummonCompanion: { slot: action.slot } };
+    case "commandCompanion":
+      return {
+        CommandCompanion: {
+          slot: action.slot,
+          command: action.command,
+          target: action.target ?? null
+        }
+      };
+    case "speak":
+      return {
+        Speak: {
+          message: action.message,
+          volume: action.volume
+        }
+      };
+    case "setAutoRetaliate":
+      return {
+        SetAutoRetaliate: {
+          enabled: action.enabled
+        }
+      };
+    case "idle":
+      return { Idle: null };
+  }
 }
 
 function healthBand(entity: NetworkEntitySnapshot): "healthy" | "wounded" | "critical" | "neutral" {

--- a/apps/pod-web/src/direct-connect.test.ts
+++ b/apps/pod-web/src/direct-connect.test.ts
@@ -1,6 +1,52 @@
 import { describe, expect, test } from "bun:test";
 
-import { runtimeConfigFromLocation } from "./direct-connect";
+import { PodWebDirectConnectClient, runtimeConfigFromLocation } from "./direct-connect";
+
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  static instances: MockWebSocket[] = [];
+
+  readonly sent: string[] = [];
+  readyState = MockWebSocket.CONNECTING;
+  private readonly listeners = new Map<string, Array<(event: unknown) => void>>();
+
+  constructor(readonly url: string) {
+    MockWebSocket.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: (event: unknown) => void): void {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  send(payload: string): void {
+    this.sent.push(payload);
+  }
+
+  close(): void {
+    this.readyState = MockWebSocket.CLOSED;
+    this.emit("close", {});
+  }
+
+  open(): void {
+    this.readyState = MockWebSocket.OPEN;
+    this.emit("open", {});
+  }
+
+  emitMessage(payload: string): void {
+    this.emit("message", { data: payload });
+  }
+
+  private emit(type: string, event: unknown): void {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+}
 
 describe("direct-connect runtime config", () => {
   test("builds a websocket config from server query params", () => {
@@ -21,5 +67,101 @@ describe("direct-connect runtime config", () => {
     } as Location);
 
     expect(config).toBeNull();
+  });
+
+  test("submits websocket action batches after an authoritative welcome", () => {
+    const originalWebSocket = globalThis.WebSocket;
+    globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+    MockWebSocket.instances = [];
+
+    const frames: number[] = [];
+    const debugDocuments: string[] = [];
+
+    try {
+      const client = new PodWebDirectConnectClient(
+        {
+          url: "ws://127.0.0.1:7778",
+          playerName: "BrowserPilot",
+          debugTelemetry: true,
+          reconnectDelayMs: 1000
+        },
+        {
+          onFrame(snapshot) {
+            frames.push(snapshot.tick);
+          },
+          onDebugDocument(document) {
+            debugDocuments.push(document);
+          },
+          onStatus() {}
+        }
+      );
+
+      client.connect();
+      const socket = MockWebSocket.instances[0];
+      expect(socket).toBeDefined();
+      socket?.open();
+
+      expect(socket?.sent.slice(0, 2)).toEqual([
+        JSON.stringify({
+          Connect: {
+            player_name: "BrowserPilot",
+            reconnect_token: null
+          }
+        }),
+        JSON.stringify({
+          SetDebugTelemetry: {
+            enabled: true
+          }
+        })
+      ]);
+
+      socket?.emitMessage(
+        JSON.stringify({
+          Welcome: {
+            client_id: "client-1",
+            reconnect_token: "resume-1",
+            tick: 18,
+            controlled_entity: 12,
+            authoritative_digest: 999,
+            snapshot: {
+              tick: 18,
+              entities: [
+                {
+                  id: 12,
+                  position: [10, 10],
+                  velocity: [0, 0],
+                  rotation: 0,
+                  label: "Hero"
+                }
+              ]
+            }
+          }
+        })
+      );
+
+      expect(frames).toEqual([18]);
+
+      const sent = client.submitActions([{ kind: "move", direction: [1, 0] }]);
+      expect(sent).toBe(true);
+      expect(socket?.sent.at(-1)).toEqual(
+        JSON.stringify({
+          ActionBatch: {
+            tick: 19,
+            actions: [{ Move: { direction: [1, 0] } }]
+          }
+        })
+      );
+
+      socket?.emitMessage(
+        JSON.stringify({
+          DebugDocument: {
+            document: "debug-doc"
+          }
+        })
+      );
+      expect(debugDocuments).toEqual(["debug-doc"]);
+    } finally {
+      globalThis.WebSocket = originalWebSocket;
+    }
   });
 });

--- a/apps/pod-web/src/direct-connect.ts
+++ b/apps/pod-web/src/direct-connect.ts
@@ -1,11 +1,13 @@
 import {
   applyNetworkStateDelta,
   buildAuthoritativeWorldFrame,
+  encodeDirectConnectActionBatch,
   encodeDirectConnectConnectMessage,
   encodeDirectConnectDebugTelemetryMessage,
   encodeDirectConnectFullSnapshotRequest,
   parseDirectConnectServerMessage,
   type AuthoritativeWorldFrameOptions,
+  type BrowserAction,
   type DirectConnectServerMessage,
   type NetworkWorldSnapshot
 } from "./contracts";
@@ -156,6 +158,24 @@ export class PodWebDirectConnectClient {
 
   currentStatus(): DirectConnectStatus {
     return { ...this.status };
+  }
+
+  snapshotState(): NetworkWorldSnapshot | null {
+    return this.snapshot;
+  }
+
+  controlledEntityId(): number | null {
+    return this.controlledEntity;
+  }
+
+  submitActions(actions: BrowserAction[]): boolean {
+    if (actions.length === 0 || this.socket?.readyState !== WebSocket.OPEN) {
+      return false;
+    }
+
+    const nextTick = (this.snapshot?.tick ?? this.status.tick ?? 0) + 1;
+    this.socket.send(encodeDirectConnectActionBatch(nextTick, actions));
+    return true;
   }
 
   private handleServerMessage(message: DirectConnectServerMessage): void {

--- a/apps/pod-web/src/main.ts
+++ b/apps/pod-web/src/main.ts
@@ -1,7 +1,9 @@
 import {
+  type BrowserAction,
   buildAuthoritativeWorldFrame,
+  type NetworkEntitySnapshot,
+  type NetworkWorldSnapshot,
   parseLiveDebugDocument,
-  type DirectConnectServerMessage,
   parseRenderFrame,
   parseReplayFile,
   parseShardIncidentSummary,
@@ -59,8 +61,11 @@ const backendLabel = document.querySelector<HTMLElement>("#backend-label");
 const frameSourceLabel = document.querySelector<HTMLElement>("#frame-source");
 const connectionLabel = document.querySelector<HTMLElement>("#connection-label");
 const worldLabel = document.querySelector<HTMLElement>("#world-label");
+const targetLabel = document.querySelector<HTMLElement>("#target-label");
 const qualityLabel = document.querySelector<HTMLElement>("#quality-label");
 const statsLabel = document.querySelector<HTMLElement>("#stats-label");
+const chatForm = document.querySelector<HTMLFormElement>("#chat-form");
+const chatInput = document.querySelector<HTMLInputElement>("#chat-input");
 const telemetryToggle = document.querySelector<HTMLButtonElement>("#telemetry-toggle");
 const telemetrySelectionLabel =
   document.querySelector<HTMLElement>("#telemetry-selection");
@@ -89,8 +94,11 @@ if (
   !frameSourceLabel ||
   !connectionLabel ||
   !worldLabel ||
+  !targetLabel ||
   !qualityLabel ||
   !statsLabel ||
+  !chatForm ||
+  !chatInput ||
   !telemetryToggle ||
   !telemetrySelectionLabel ||
   !telemetryTrailLabel ||
@@ -112,6 +120,9 @@ if (
 const telemetryToggleButton = telemetryToggle;
 const connectionNode = connectionLabel;
 const worldNode = worldLabel;
+const targetNode = targetLabel;
+const chatFormNode = chatForm;
+const chatInputNode = chatInput;
 const telemetrySelectionNode = telemetrySelectionLabel;
 const telemetryTrailNode = telemetryTrailLabel;
 const telemetryActionsNode = telemetryActionsLabel;
@@ -142,6 +153,7 @@ let latestToolEventSummary: ToolCallEventSummary | null = null;
 let latestRollupSummary: TickRollupSummary | null = null;
 let liveReplayDocuments = 0;
 let liveIncidentDocuments = 0;
+let latestSnapshot: NetworkWorldSnapshot | null = null;
 let liveConnectionStatus: DirectConnectStatus | null = runtimeConfig
   ? {
       phase: "idle",
@@ -161,6 +173,8 @@ if (runtimeConfig?.debugTelemetry) {
 const liveClient = runtimeConfig
   ? new PodWebDirectConnectClient(runtimeConfig, {
       onFrame(snapshot, frameOptions, status) {
+        latestSnapshot = snapshot;
+        syncSelectedTarget();
         latestFrame = buildAuthoritativeWorldFrame(snapshot, {
           ...frameOptions,
           viewportWidth: canvas.clientWidth || window.innerWidth,
@@ -178,6 +192,233 @@ const liveClient = runtimeConfig
       }
     })
   : null;
+const pressedKeys = new Set<string>();
+let selectedTargetId: number | null = null;
+let autoRetaliateEnabled = true;
+let lastMovementSignature = "stop";
+let lastMovementSubmitAtMs = 0;
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  return (
+    target instanceof HTMLInputElement ||
+    target instanceof HTMLTextAreaElement ||
+    (target instanceof HTMLElement && target.isContentEditable)
+  );
+}
+
+function controlledEntity(): NetworkEntitySnapshot | null {
+  const controlledId = liveConnectionStatus?.controlledEntity ?? null;
+  if (latestSnapshot == null || controlledId == null) {
+    return null;
+  }
+
+  return latestSnapshot.entities.find((entity) => entity.id === controlledId) ?? null;
+}
+
+function targetableEntities(): NetworkEntitySnapshot[] {
+  if (!latestSnapshot) {
+    return [];
+  }
+
+  const selfId = liveConnectionStatus?.controlledEntity ?? null;
+  const selfEntity = controlledEntity();
+
+  return latestSnapshot.entities
+    .filter((entity) => entity.id !== selfId)
+    .filter((entity) => {
+      const label = entity.label?.toLowerCase() ?? "";
+      return !label.includes("wall") && !label.includes("obstacle");
+    })
+    .sort((left, right) => {
+      if (!selfEntity) {
+        return left.id - right.id;
+      }
+      const leftDistance = Math.hypot(
+        left.position[0] - selfEntity.position[0],
+        left.position[1] - selfEntity.position[1]
+      );
+      const rightDistance = Math.hypot(
+        right.position[0] - selfEntity.position[0],
+        right.position[1] - selfEntity.position[1]
+      );
+      if (leftDistance !== rightDistance) {
+        return leftDistance - rightDistance;
+      }
+      return left.id - right.id;
+    });
+}
+
+function selectedTarget(): NetworkEntitySnapshot | null {
+  syncSelectedTarget();
+  if (selectedTargetId == null) {
+    return null;
+  }
+  return targetableEntities().find((entity) => entity.id === selectedTargetId) ?? null;
+}
+
+function syncSelectedTarget(): void {
+  const candidates = targetableEntities();
+  if (candidates.length === 0) {
+    selectedTargetId = null;
+    return;
+  }
+
+  if (selectedTargetId == null || !candidates.some((entity) => entity.id === selectedTargetId)) {
+    selectedTargetId = candidates[0]?.id ?? null;
+  }
+}
+
+function cycleTargetSelection(delta: number): void {
+  const candidates = targetableEntities();
+  if (candidates.length === 0) {
+    selectedTargetId = null;
+    return;
+  }
+
+  const currentIndex = candidates.findIndex((entity) => entity.id === selectedTargetId);
+  const nextIndex =
+    currentIndex === -1
+      ? 0
+      : (currentIndex + delta + candidates.length) % candidates.length;
+  selectedTargetId = candidates[nextIndex]?.id ?? null;
+}
+
+function submitActions(actions: BrowserAction[]): void {
+  if (!liveClient) {
+    return;
+  }
+  liveClient.submitActions(actions);
+}
+
+function movementDirection(): [number, number] | null {
+  const horizontal =
+    (pressedKeys.has("KeyD") || pressedKeys.has("ArrowRight") ? 1 : 0) -
+    (pressedKeys.has("KeyA") || pressedKeys.has("ArrowLeft") ? 1 : 0);
+  const vertical =
+    (pressedKeys.has("KeyS") || pressedKeys.has("ArrowDown") ? 1 : 0) -
+    (pressedKeys.has("KeyW") || pressedKeys.has("ArrowUp") ? 1 : 0);
+
+  if (horizontal === 0 && vertical === 0) {
+    return null;
+  }
+
+  const length = Math.hypot(horizontal, vertical);
+  return [horizontal / length, vertical / length];
+}
+
+function maybeSubmitMovement(timestamp: number): void {
+  const direction = movementDirection();
+  const signature = direction
+    ? `${direction[0].toFixed(3)}:${direction[1].toFixed(3)}`
+    : "stop";
+  const resendDue = timestamp - lastMovementSubmitAtMs >= 90;
+
+  if (direction) {
+    if (signature !== lastMovementSignature || resendDue) {
+      submitActions([{ kind: "move", direction }]);
+      lastMovementSignature = signature;
+      lastMovementSubmitAtMs = timestamp;
+    }
+    return;
+  }
+
+  if (lastMovementSignature !== "stop") {
+    submitActions([{ kind: "stop" }]);
+    lastMovementSignature = "stop";
+    lastMovementSubmitAtMs = timestamp;
+  }
+}
+
+function submitTargetedAction(
+  actionBuilder: (target: NetworkEntitySnapshot) => BrowserAction
+): void {
+  const target = selectedTarget();
+  if (!target) {
+    return;
+  }
+  submitActions([actionBuilder(target)]);
+}
+
+window.addEventListener("keydown", (event) => {
+  if (isEditableTarget(event.target)) {
+    return;
+  }
+
+  switch (event.code) {
+    case "Tab":
+      event.preventDefault();
+      cycleTargetSelection(event.shiftKey ? -1 : 1);
+      return;
+    case "Space":
+      event.preventDefault();
+      submitTargetedAction((target) => ({ kind: "attackTarget", target: target.id }));
+      return;
+    case "KeyE":
+      submitTargetedAction((target) => ({ kind: "interactWith", target: target.id }));
+      return;
+    case "KeyG":
+      submitTargetedAction((target) => ({
+        kind: "gatherResource",
+        target: target.id,
+        skill: "Mining"
+      }));
+      return;
+    case "KeyR":
+      submitTargetedAction((target) => ({ kind: "loot", target: target.id }));
+      return;
+    case "KeyC":
+      submitTargetedAction((target) => ({ kind: "captureCreature", target: target.id }));
+      return;
+    case "Digit1":
+      submitActions([{ kind: "summonCompanion", slot: 0 }]);
+      return;
+    case "KeyF":
+      submitActions([
+        {
+          kind: "commandCompanion",
+          slot: 0,
+          command: "Follow",
+          target: selectedTarget()?.id ?? null
+        }
+      ]);
+      return;
+    case "KeyP":
+      autoRetaliateEnabled = !autoRetaliateEnabled;
+      submitActions([{ kind: "setAutoRetaliate", enabled: autoRetaliateEnabled }]);
+      return;
+    case "Enter":
+      event.preventDefault();
+      chatInputNode.focus();
+      return;
+    default:
+      break;
+  }
+
+  if (event.code.startsWith("Key") || event.code.startsWith("Arrow")) {
+    pressedKeys.add(event.code);
+  }
+});
+
+window.addEventListener("keyup", (event) => {
+  pressedKeys.delete(event.code);
+});
+
+chatFormNode.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const message = chatInputNode.value.trim();
+  if (message.length === 0) {
+    return;
+  }
+
+  submitActions([
+    {
+      kind: "speak",
+      message,
+      volume: "Normal"
+    }
+  ]);
+  chatInputNode.value = "";
+});
 
 telemetryToggleButton.addEventListener("click", () => {
   setTelemetryEnabled(telemetryState, !telemetryState.enabled);
@@ -270,6 +511,8 @@ function applyLiveDebugDocument(document: string): void {
 }
 
 async function tick(timestamp: number): Promise<void> {
+  maybeSubmitMovement(timestamp);
+
   if (lastTelemetryRevision !== telemetryState.revision) {
     const samples = telemetryState.enabled
       ? selectedTrajectorySamples(telemetryState)
@@ -309,6 +552,7 @@ async function tick(timestamp: number): Promise<void> {
 
 function renderTelemetryHud(): void {
   const stats = telemetryStats(telemetryState);
+  const target = selectedTarget();
   connectionNode.textContent = liveConnectionStatus
     ? `${liveConnectionStatus.phase} · ${liveConnectionStatus.detail}`
     : "offline demo / bridge mode";
@@ -321,6 +565,9 @@ function renderTelemetryHud(): void {
             : `controlled E(${liveConnectionStatus.controlledEntity})`
         }`
     : "demo scene";
+  targetNode.textContent = target
+    ? `${target.label ?? "Target"} · E(${target.id})`
+    : "No target selected";
   telemetryToggleButton.textContent = stats.enabled ? "Disable Telemetry" : "Enable Telemetry";
   telemetryPanelNode.dataset.telemetryEnabled = String(stats.enabled);
   telemetrySelectionNode.textContent = stats.selectedLabel;


### PR DESCRIPTION
## Summary
- add browser-side action encoding and websocket submission for shared POD actions
- add target selection, chat, and MMO interaction controls in the pod-web HUD
- add deterministic mocked websocket coverage for action-batch submission

## Validation
- cd apps/pod-web && bun test
- cd apps/pod-web && bun run typecheck
- cd apps/pod-web && bun run build
- git diff --check