### PR TITLE
Add authoritative browser event feedback

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -665,5 +665,17 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cd apps/pod-web && bun run build`
   - `git diff --check`
 
-**Last updated**: Iteration 71
-**Current focus**: Iteration 72 richer MMO browser loop completion, starting with surfacing chat/combat outcomes from authoritative events, streamed-world presentation depth, and more direct browser-side interaction feedback on top of the live socket
+### Iteration 72
+- [x] Extended the authoritative direct-connect `GameServer` runtime to broadcast real `EventBatch` gameplay events alongside `StateDelta` and TOON debug documents, instead of leaving browser clients with input but no server-confirmed outcomes.
+- [x] Added typed gameplay-event parsing in `apps/pod-web` for websocket `EventBatch` payloads, including compact summaries and involved entity ids for combat, chat, capture, summon, gather, loot, and lifecycle events.
+- [x] Wired the browser direct-connect client and HUD to authoritative event feedback so the live shard now surfaces recent MMO outcomes and target-relevant status directly in the client instead of only in telemetry/debug overlays.
+- [x] Added deterministic coverage for authoritative event-batch parsing, browser websocket event routing, and direct-connect server event broadcasting.
+- [x] Validated touched targets:
+  - `cargo test -p pod-net --lib`
+  - `cd apps/pod-web && bun test`
+  - `cd apps/pod-web && bun run typecheck`
+  - `cd apps/pod-web && bun run build`
+  - `git diff --check`
+
+**Last updated**: Iteration 72
+**Current focus**: Iteration 73 browser MMO loop completion beyond event feedback, starting with live combat/chat outcome staging, richer world-state presentation, and authoritative UI affordances for creators and players on the flagship shard path

--- a/apps/pod-web/README.md
+++ b/apps/pod-web/README.md
@@ -45,6 +45,7 @@ http://127.0.0.1:5173/?server=127.0.0.1:7778&player=WebPlayer&debug=1
 - `F`: issue a follow command to companion slot `0`
 - `P`: toggle auto-retaliate
 - `Enter`: focus chat input and send a shard message
+- HUD feedback and event feed rows are driven by authoritative `EventBatch` messages from the shard, so combat/chat/loot/capture outcomes come from server events rather than client-side guesses
 
 ## Validate
 

--- a/apps/pod-web/index.html
+++ b/apps/pod-web/index.html
@@ -93,6 +93,11 @@
         margin: 0;
       }
 
+      .hud__multiline {
+        white-space: pre-line;
+        line-height: 1.35;
+      }
+
       .hud__controls {
         display: flex;
         align-items: center;
@@ -166,6 +171,10 @@
           <dd id="world-label">demo scene</dd>
           <dt>Target</dt>
           <dd id="target-label">No target selected</dd>
+          <dt>Feedback</dt>
+          <dd id="feedback-label">Awaiting authoritative outcomes</dd>
+          <dt>Events</dt>
+          <dd class="hud__multiline" id="event-feed-label">No authoritative events yet</dd>
           <dt>Quality</dt>
           <dd id="quality-label">auto</dd>
           <dt>Source</dt>

--- a/apps/pod-web/src/contracts.test.ts
+++ b/apps/pod-web/src/contracts.test.ts
@@ -293,6 +293,49 @@ describe("TOON contract parsing", () => {
     expect(delta.acknowledgedActionTick).toBe(12);
   });
 
+  test("parses authoritative event batches into gameplay summaries", () => {
+    const eventBatch = parseDirectConnectServerMessage(
+      JSON.stringify({
+        EventBatch: {
+          tick: 27,
+          events: [
+            {
+              tick: 27,
+              origin: [18, 22],
+              event: {
+                Damage: {
+                  source: 44,
+                  target: 12,
+                  amount: 7.5
+                }
+              }
+            },
+            {
+              tick: 27,
+              origin: [18, 22],
+              event: {
+                AgentSpoke: {
+                  agent_id: "agent-12345678",
+                  message: "ready",
+                  volume: 200
+                }
+              }
+            }
+          ]
+        }
+      })
+    );
+
+    expect(eventBatch.kind).toBe("eventBatch");
+    if (eventBatch.kind !== "eventBatch") {
+      throw new Error("expected event batch");
+    }
+    expect(eventBatch.events).toHaveLength(2);
+    expect(eventBatch.events[0]?.summary).toBe("E(44) hit E(12) for 7.5");
+    expect(eventBatch.events[0]?.entityIds).toEqual([12, 44]);
+    expect(eventBatch.events[1]?.summary).toBe("agent-12: ready");
+  });
+
   test("applies authoritative state deltas and builds a live world frame", () => {
     const baseline: NetworkWorldSnapshot = {
       tick: 10,

--- a/apps/pod-web/src/contracts.ts
+++ b/apps/pod-web/src/contracts.ts
@@ -385,6 +385,19 @@ export interface NetworkStateDelta {
   destroyed: number[];
 }
 
+export interface NetworkGameEvent {
+  tick: number;
+  origin: Vec2Tuple | null;
+  kind: string;
+  summary: string;
+  entityIds: number[];
+}
+
+export interface NetworkEventBatch {
+  tick: number;
+  events: NetworkGameEvent[];
+}
+
 export type DirectConnectServerMessage =
   | {
       kind: "welcome";
@@ -403,7 +416,7 @@ export type DirectConnectServerMessage =
       isFullSnapshot: boolean;
       delta: NetworkStateDelta;
     }
-  | { kind: "eventBatch"; tick: number; events: unknown[] }
+  | { kind: "eventBatch"; tick: number; events: NetworkGameEvent[] }
   | { kind: "tickTelemetry"; frameJson: string }
   | { kind: "debugDocument"; document: string }
   | { kind: "pong"; clientTimestamp: number; serverTimestamp: number }
@@ -599,6 +612,182 @@ function parseNetworkStateDelta(value: unknown): NetworkStateDelta | null {
     updated,
     destroyed
   };
+}
+
+function entityRef(entityId: number | null | undefined): string {
+  return entityId == null ? "Unknown" : `E(${entityId})`;
+}
+
+function entityIdsFromPayload(payload: JsonRecord): number[] {
+  const ids = new Set<number>();
+  for (const key of [
+    "entity",
+    "target",
+    "source",
+    "killer",
+    "victim",
+    "resource",
+    "trigger",
+    "item"
+  ]) {
+    const entityId = asNumber(payload[key]);
+    if (entityId != null) {
+      ids.add(entityId);
+    }
+  }
+  return Array.from(ids.values()).sort((left, right) => left - right);
+}
+
+function parseNetworkGameEvent(value: unknown): NetworkGameEvent | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const tick = asNumber(value.tick);
+  const origin = vec2Tuple(value.origin);
+  const eventRecord = isRecord(value.event) ? value.event : null;
+  if (tick == null || !eventRecord) {
+    return null;
+  }
+
+  const entries = Object.entries(eventRecord);
+  if (entries.length === 0) {
+    return null;
+  }
+
+  const [kind, rawPayload] = entries[0] ?? [];
+  const payload = isRecord(rawPayload) ? rawPayload : {};
+  const entityIds = entityIdsFromPayload(payload);
+
+  switch (kind) {
+    case "Damage": {
+      const amount = asNumber(payload.amount) ?? 0;
+      const source = asNumber(payload.source);
+      const target = asNumber(payload.target);
+      return {
+        tick,
+        origin,
+        kind,
+        summary: `${entityRef(source)} hit ${entityRef(target)} for ${amount.toFixed(1)}`,
+        entityIds
+      };
+    }
+    case "Kill":
+      return {
+        tick,
+        origin,
+        kind,
+        summary: `${entityRef(asNumber(payload.killer))} defeated ${entityRef(
+          asNumber(payload.victim)
+        )}`,
+        entityIds
+      };
+    case "Heal": {
+      const amount = asNumber(payload.amount) ?? 0;
+      return {
+        tick,
+        origin,
+        kind,
+        summary: `${entityRef(asNumber(payload.source))} healed ${entityRef(
+          asNumber(payload.target)
+        )} for ${amount.toFixed(1)}`,
+        entityIds
+      };
+    }
+    case "AgentSpoke": {
+      const agentId = asString(payload.agent_id)?.slice(0, 8) ?? "agent";
+      const message = asString(payload.message) ?? "";
+      return {
+        tick,
+        origin,
+        kind,
+        summary: `${agentId}: ${message}`,
+        entityIds
+      };
+    }
+    case "CreatureCaptured":
+      return {
+        tick,
+        origin,
+        kind,
+        summary: `Captured ${asString(payload.species_id) ?? "creature"}`,
+        entityIds
+      };
+    case "CompanionSummoned":
+      return {
+        tick,
+        origin,
+        kind,
+        summary: `Summoned ${asString(payload.species_id) ?? "companion"}`,
+        entityIds
+      };
+    case "CompanionCommandIssued":
+      return {
+        tick,
+        origin,
+        kind,
+        summary: `Companion ${asString(payload.command) ?? "command"}${
+          asNumber(payload.target) != null ? ` ${entityRef(asNumber(payload.target))}` : ""
+        }`,
+        entityIds
+      };
+    case "ResourceGathered":
+      return {
+        tick,
+        origin,
+        kind,
+        summary: `${entityRef(asNumber(payload.entity))} gathered ${
+          asNumber(payload.quantity) ?? 0
+        } ${asString(payload.item_id) ?? "resource"}`,
+        entityIds
+      };
+    case "LootClaimed":
+      return {
+        tick,
+        origin,
+        kind,
+        summary: `${entityRef(asNumber(payload.entity))} looted ${
+          asNumber(payload.coins) ?? 0
+        } coins`,
+        entityIds
+      };
+    case "AutoRetaliateSet":
+      return {
+        tick,
+        origin,
+        kind,
+        summary: `${entityRef(asNumber(payload.entity))} auto-retaliate ${
+          payload.enabled === true ? "enabled" : "disabled"
+        }`,
+        entityIds
+      };
+    case "EntitySpawned":
+      return {
+        tick,
+        origin,
+        kind,
+        summary: `${asString(payload.entity_type) ?? "Entity"} ${entityRef(
+          asNumber(payload.entity)
+        )} spawned`,
+        entityIds
+      };
+    case "EntityDestroyed":
+      return {
+        tick,
+        origin,
+        kind,
+        summary: `${entityRef(asNumber(payload.entity))} destroyed`,
+        entityIds
+      };
+    default:
+      return {
+        tick,
+        origin,
+        kind,
+        summary: kind.replace(/([A-Z])/g, " $1").trim(),
+        entityIds
+      };
+  }
 }
 
 function directTickTelemetryFrame(value: unknown): TickTelemetryFrame | null {
@@ -946,6 +1135,8 @@ export function parseDirectConnectServerMessage(
       kind: "eventBatch",
       tick: eventBatch.tick,
       events: eventBatch.events
+        .map((event) => parseNetworkGameEvent(event))
+        .filter((event): event is NetworkGameEvent => event != null)
     };
   }
 

--- a/apps/pod-web/src/direct-connect.test.ts
+++ b/apps/pod-web/src/direct-connect.test.ts
@@ -75,6 +75,7 @@ describe("direct-connect runtime config", () => {
     MockWebSocket.instances = [];
 
     const frames: number[] = [];
+    const eventSummaries: string[] = [];
     const debugDocuments: string[] = [];
 
     try {
@@ -88,6 +89,9 @@ describe("direct-connect runtime config", () => {
         {
           onFrame(snapshot) {
             frames.push(snapshot.tick);
+          },
+          onEventBatch(batch) {
+            eventSummaries.push(...batch.events.map((event) => event.summary));
           },
           onDebugDocument(document) {
             debugDocuments.push(document);
@@ -151,6 +155,29 @@ describe("direct-connect runtime config", () => {
           }
         })
       );
+
+      socket?.emitMessage(
+        JSON.stringify({
+          EventBatch: {
+            tick: 19,
+            events: [
+              {
+                tick: 19,
+                origin: [12, 10],
+                event: {
+                  LootClaimed: {
+                    entity: 12,
+                    source: 14,
+                    coins: 32,
+                    item_count: 2
+                  }
+                }
+              }
+            ]
+          }
+        })
+      );
+      expect(eventSummaries).toEqual(["E(12) looted 32 coins"]);
 
       socket?.emitMessage(
         JSON.stringify({

--- a/apps/pod-web/src/direct-connect.ts
+++ b/apps/pod-web/src/direct-connect.ts
@@ -9,6 +9,7 @@ import {
   type AuthoritativeWorldFrameOptions,
   type BrowserAction,
   type DirectConnectServerMessage,
+  type NetworkEventBatch,
   type NetworkWorldSnapshot
 } from "./contracts";
 
@@ -42,6 +43,7 @@ interface DirectConnectHandlers {
     frameOptions: AuthoritativeWorldFrameOptions,
     status: DirectConnectStatus
   ) => void;
+  onEventBatch: (batch: NetworkEventBatch) => void;
   onDebugDocument: (document: string) => void;
   onStatus: (status: DirectConnectStatus) => void;
 }
@@ -76,6 +78,7 @@ export class PodWebDirectConnectClient {
   private snapshot: NetworkWorldSnapshot | null = null;
   private controlledEntity: number | null = null;
   private authoritativeDigest: number | null = null;
+  private lastEventTick = 0;
   private closedExplicitly = false;
   private debugTelemetryEnabled: boolean;
   private status: DirectConnectStatus;
@@ -214,11 +217,20 @@ export class PodWebDirectConnectClient {
       case "debugDocument":
         this.handlers.onDebugDocument(message.document);
         break;
+      case "eventBatch":
+        if (message.tick < this.lastEventTick) {
+          break;
+        }
+        this.lastEventTick = message.tick;
+        this.handlers.onEventBatch({
+          tick: message.tick,
+          events: message.events
+        });
+        break;
       case "rejected":
         this.updateStatus("rejected", message.reason);
         break;
       case "pong":
-      case "eventBatch":
         break;
     }
   }

--- a/apps/pod-web/src/main.ts
+++ b/apps/pod-web/src/main.ts
@@ -1,6 +1,8 @@
 import {
   type BrowserAction,
   buildAuthoritativeWorldFrame,
+  type NetworkEventBatch,
+  type NetworkGameEvent,
   type NetworkEntitySnapshot,
   type NetworkWorldSnapshot,
   parseLiveDebugDocument,
@@ -62,6 +64,8 @@ const frameSourceLabel = document.querySelector<HTMLElement>("#frame-source");
 const connectionLabel = document.querySelector<HTMLElement>("#connection-label");
 const worldLabel = document.querySelector<HTMLElement>("#world-label");
 const targetLabel = document.querySelector<HTMLElement>("#target-label");
+const feedbackLabel = document.querySelector<HTMLElement>("#feedback-label");
+const eventFeedLabel = document.querySelector<HTMLElement>("#event-feed-label");
 const qualityLabel = document.querySelector<HTMLElement>("#quality-label");
 const statsLabel = document.querySelector<HTMLElement>("#stats-label");
 const chatForm = document.querySelector<HTMLFormElement>("#chat-form");
@@ -95,6 +99,8 @@ if (
   !connectionLabel ||
   !worldLabel ||
   !targetLabel ||
+  !feedbackLabel ||
+  !eventFeedLabel ||
   !qualityLabel ||
   !statsLabel ||
   !chatForm ||
@@ -121,6 +127,8 @@ const telemetryToggleButton = telemetryToggle;
 const connectionNode = connectionLabel;
 const worldNode = worldLabel;
 const targetNode = targetLabel;
+const feedbackNode = feedbackLabel;
+const eventFeedNode = eventFeedLabel;
 const chatFormNode = chatForm;
 const chatInputNode = chatInput;
 const telemetrySelectionNode = telemetrySelectionLabel;
@@ -154,6 +162,8 @@ let latestRollupSummary: TickRollupSummary | null = null;
 let liveReplayDocuments = 0;
 let liveIncidentDocuments = 0;
 let latestSnapshot: NetworkWorldSnapshot | null = null;
+let latestFeedback = "Awaiting authoritative outcomes";
+let recentWorldEvents: NetworkGameEvent[] = [];
 let liveConnectionStatus: DirectConnectStatus | null = runtimeConfig
   ? {
       phase: "idle",
@@ -183,6 +193,9 @@ const liveClient = runtimeConfig
         liveFrameSource = "threejs";
         frameSourceLabel.textContent = "authoritative websocket";
         liveConnectionStatus = status;
+      },
+      onEventBatch(batch) {
+        applyAuthoritativeEventBatch(batch);
       },
       onDebugDocument(document) {
         applyLiveDebugDocument(document);
@@ -254,6 +267,55 @@ function selectedTarget(): NetworkEntitySnapshot | null {
     return null;
   }
   return targetableEntities().find((entity) => entity.id === selectedTargetId) ?? null;
+}
+
+function entityHealthSummary(entity: NetworkEntitySnapshot | null): string {
+  if (
+    entity == null ||
+    entity.health == null ||
+    entity.maxHealth == null ||
+    entity.maxHealth <= 0
+  ) {
+    return "status unknown";
+  }
+
+  return `${entity.health.toFixed(0)}/${entity.maxHealth.toFixed(0)} hp`;
+}
+
+function eventTouchesEntity(event: NetworkGameEvent, entityId: number | null): boolean {
+  return entityId != null && event.entityIds.includes(entityId);
+}
+
+function applyAuthoritativeEventBatch(batch: NetworkEventBatch): void {
+  if (batch.events.length === 0) {
+    return;
+  }
+
+  recentWorldEvents = [...recentWorldEvents, ...batch.events].slice(-6);
+
+  const controlledId = liveConnectionStatus?.controlledEntity ?? null;
+  const highlighted =
+    [...batch.events]
+      .reverse()
+      .find(
+        (event) =>
+          eventTouchesEntity(event, controlledId) ||
+          eventTouchesEntity(event, selectedTargetId)
+      ) ?? batch.events.at(-1);
+
+  if (highlighted) {
+    latestFeedback = `[${highlighted.kind}] ${highlighted.summary}`;
+  }
+}
+
+function formatRecentEventFeed(): string {
+  if (recentWorldEvents.length === 0) {
+    return "No authoritative events yet";
+  }
+
+  return recentWorldEvents
+    .map((event) => `[${event.tick}] ${event.summary}`)
+    .join("\n");
 }
 
 function syncSelectedTarget(): void {
@@ -566,8 +628,10 @@ function renderTelemetryHud(): void {
         }`
     : "demo scene";
   targetNode.textContent = target
-    ? `${target.label ?? "Target"} · E(${target.id})`
+    ? `${target.label ?? "Target"} · E(${target.id}) · ${entityHealthSummary(target)}`
     : "No target selected";
+  feedbackNode.textContent = latestFeedback;
+  eventFeedNode.textContent = formatRecentEventFeed();
   telemetryToggleButton.textContent = stats.enabled ? "Disable Telemetry" : "Enable Telemetry";
   telemetryPanelNode.dataset.telemetryEnabled = String(stats.enabled);
   telemetrySelectionNode.textContent = stats.selectedLabel;

--- a/crates/pod-net/src/server.rs
+++ b/crates/pod-net/src/server.rs
@@ -18,7 +18,7 @@ use tokio_tungstenite::{accept_async, tungstenite::Message};
 
 use pod_core::{
     Action, AgentTickRollup, AgentToolCallEvent, IdleAgent, TelemetryArchive, TelemetryConfig,
-    VersionedTickTelemetry, World,
+    VersionedTickTelemetry, World, GameEvent,
 };
 
 use crate::protocol::{
@@ -101,6 +101,8 @@ pub struct GameServer {
     last_snapshot: Option<WorldSnapshot>,
     /// Latest authoritative telemetry payload for debug/editor clients.
     last_tick_telemetry_json: Option<String>,
+    /// Game events emitted during the current authoritative tick.
+    pending_events: Vec<GameEvent>,
     /// Recent authoritative telemetry retained for live debug rollups.
     debug_archive: TelemetryArchive,
     /// TOON debug documents collected during the current authoritative tick.
@@ -124,6 +126,7 @@ impl GameServer {
             last_snapshot_tick: 0,
             last_snapshot: None,
             last_tick_telemetry_json: None,
+            pending_events: Vec::new(),
             debug_archive: TelemetryArchive::with_capacity(
                 TelemetryConfig::default().core_archive_ticks,
             ),
@@ -249,6 +252,7 @@ impl GameServer {
         self.debug_archive
             .record_tick(tick_result.telemetry.clone());
         self.pending_debug_documents.clear();
+        self.pending_events = tick_result.events.clone();
 
         let telemetry_document =
             VersionedTickTelemetry::new(tick_result.telemetry.clone()).to_toon_document();
@@ -686,12 +690,14 @@ impl GameServer {
         };
 
         let has_state_update = should_snapshot || delta.change_count() > 0;
+        let has_event_update = !self.pending_events.is_empty();
         let clients = self.clients.read().await;
         let has_debug_subscribers = clients
             .values()
             .any(|session| session.debug_telemetry_enabled);
 
-        if !has_state_update && !has_debug_subscribers {
+        if !has_state_update && !has_debug_subscribers && !has_event_update {
+            self.pending_events.clear();
             self.pending_debug_documents.clear();
             return Ok(());
         }
@@ -708,6 +714,18 @@ impl GameServer {
                 if let Some(tx) = self.client_tx.read().await.get(client_id) {
                     if let Err(e) = tx.send(msg).await {
                         error!("Failed to send update to client {}: {}", client_id.0, e);
+                    }
+                }
+            }
+
+            if has_event_update {
+                let msg = ServerMessage::EventBatch {
+                    tick: self.tick,
+                    events: self.pending_events.clone(),
+                };
+                if let Some(tx) = self.client_tx.read().await.get(client_id) {
+                    if let Err(e) = tx.send(msg).await {
+                        error!("Failed to send event batch to client {}: {}", client_id.0, e);
                     }
                 }
             }
@@ -738,6 +756,7 @@ impl GameServer {
         if has_state_update {
             self.last_snapshot = Some(current_snapshot);
         }
+        self.pending_events.clear();
         self.pending_debug_documents.clear();
 
         Ok(())
@@ -998,10 +1017,11 @@ impl std::fmt::Display for ServerError {
 impl std::error::Error for ServerError {}
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use pod_core::decode_toon_value;
-    use tokio_tungstenite::{connect_async, tungstenite::Message};
+    mod tests {
+        use super::*;
+        use pod_core::decode_toon_value;
+        use tokio_tungstenite::{connect_async, tungstenite::Message};
+        use pod_core::action::SpeakVolume;
 
     fn next_available_port() -> u16 {
         std::net::TcpListener::bind("127.0.0.1:0")
@@ -1098,6 +1118,109 @@ mod tests {
         }
 
         assert!(saw_tick_telemetry);
+    }
+
+    #[tokio::test]
+    async fn test_broadcast_updates_emits_authoritative_event_batches() {
+        let config = ProtoServerConfig::default();
+        let world = World::new(42);
+        let mut server = GameServer::new(config, world);
+        let client_id = ClientId::new();
+        let (tx, mut rx) = mpsc::channel(8);
+        server.client_tx.write().await.insert(client_id, tx);
+        server.clients.write().await.insert(
+            client_id,
+            ClientSession {
+                player_name: Some("player".into()),
+                agent_id: None,
+                pending_actions: Vec::new(),
+                reconnect_token: ReconnectToken::new(),
+                last_action_tick: None,
+                last_processed_action_tick: None,
+                debug_telemetry_enabled: false,
+            },
+        );
+        server.tick = 12;
+        server.pending_events = vec![pod_core::GameEvent {
+            tick: 12,
+            origin: glam::Vec2::new(32.0, 48.0),
+            event: pod_core::Event::AgentSpoke {
+                agent_id: pod_core::AgentId::new(),
+                message: "hello shard".into(),
+                volume: 200.0,
+            },
+        }];
+
+        server.broadcast_updates().await.unwrap();
+
+        let mut saw_event_batch = false;
+        while let Ok(message) = rx.try_recv() {
+            if let ServerMessage::EventBatch { tick, events } = message {
+                saw_event_batch = true;
+                assert_eq!(tick, 12);
+                assert_eq!(events.len(), 1);
+                assert!(matches!(
+                    events[0].event,
+                    pod_core::Event::AgentSpoke { .. }
+                ));
+            }
+        }
+
+        assert!(saw_event_batch);
+        assert!(server.pending_events.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_step_tick_promotes_speak_action_into_event_batch() {
+        let config = ProtoServerConfig::default();
+        let mut server = GameServer::new(config, World::new(42));
+        let client_id = ClientId::new();
+        let (tx, mut rx) = mpsc::channel(8);
+        let (slot_index, _) = server.world.add_agent(Box::new(IdleAgent::new()));
+        let agent_id = server.world.agents[slot_index].agent.id();
+
+        server.client_tx.write().await.insert(client_id, tx);
+        server.clients.write().await.insert(
+            client_id,
+            ClientSession {
+                player_name: Some("speaker".into()),
+                agent_id: Some(agent_id),
+                pending_actions: Vec::new(),
+                reconnect_token: ReconnectToken::new(),
+                last_action_tick: None,
+                last_processed_action_tick: None,
+                debug_telemetry_enabled: false,
+            },
+        );
+        server
+            .world
+            .submit_external_action(
+                agent_id,
+                Action::Speak {
+                    message: "authoritative hello".into(),
+                    volume: SpeakVolume::Normal,
+                },
+            );
+
+        server.step_tick().await.unwrap();
+        assert!(server.pending_events.iter().any(|event| matches!(
+            event.event,
+            pod_core::Event::AgentSpoke { .. }
+        )));
+
+        server.broadcast_updates().await.unwrap();
+
+        let mut saw_spoken_event = false;
+        while let Ok(message) = rx.try_recv() {
+            if let ServerMessage::EventBatch { events, .. } = message {
+                saw_spoken_event = events.iter().any(|event| matches!(
+                    event.event,
+                    pod_core::Event::AgentSpoke { .. }
+                ));
+            }
+        }
+
+        assert!(saw_spoken_event);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- broadcast real authoritative EventBatch gameplay events from the direct-connect server runtime
- parse and route typed MMO event summaries through the browser websocket client
- surface outcome feedback and recent authoritative events directly in the pod-web HUD

## Validation
- cargo test -p pod-net --lib
- cd apps/pod-web && bun test
- cd apps/pod-web && bun run typecheck
- cd apps/pod-web && bun run build
- git diff --check