### PR TITLE
Add authoritative browser action staging

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -677,5 +677,15 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cd apps/pod-web && bun run build`
   - `git diff --check`
 
-**Last updated**: Iteration 72
-**Current focus**: Iteration 73 browser MMO loop completion beyond event feedback, starting with live combat/chat outcome staging, richer world-state presentation, and authoritative UI affordances for creators and players on the flagship shard path
+### Iteration 73
+- [x] Extended the browser direct-connect runtime with authoritative action staging so submitted `ActionBatch` payloads now track pending, acknowledged, and rejected states instead of disappearing into the websocket transport.
+- [x] Reclassified post-connect `Rejected` messages as action outcomes for the live shard path, keeping the browser session connected while surfacing the authoritative rejection reason to the player/creator HUD.
+- [x] Added a gameplay HUD action-status row in `apps/pod-web` driven by `acknowledged_action_tick` and rejection responses, alongside deterministic websocket coverage for pending -> acknowledged -> rejected transitions.
+- [x] Validated touched targets:
+  - `cd apps/pod-web && bun test`
+  - `cd apps/pod-web && bun run typecheck`
+  - `cd apps/pod-web && bun run build`
+  - `git diff --check`
+
+**Last updated**: Iteration 73
+**Current focus**: Iteration 74 browser MMO loop completion beyond action staging, starting with richer live world-state affordances, direct shard-side player/chat outcome surfaces, and tighter creator inspection UX on the flagship browser path

--- a/apps/pod-web/README.md
+++ b/apps/pod-web/README.md
@@ -46,6 +46,7 @@ http://127.0.0.1:5173/?server=127.0.0.1:7778&player=WebPlayer&debug=1
 - `P`: toggle auto-retaliate
 - `Enter`: focus chat input and send a shard message
 - HUD feedback and event feed rows are driven by authoritative `EventBatch` messages from the shard, so combat/chat/loot/capture outcomes come from server events rather than client-side guesses
+- The action status row is driven by authoritative `acknowledged_action_tick` and `Rejected` responses, so creators can see pending, acknowledged, and rejected browser input on the live shard path
 
 ## Validate
 

--- a/apps/pod-web/index.html
+++ b/apps/pod-web/index.html
@@ -171,6 +171,8 @@
           <dd id="world-label">demo scene</dd>
           <dt>Target</dt>
           <dd id="target-label">No target selected</dd>
+          <dt>Action</dt>
+          <dd id="action-status-label">idle</dd>
           <dt>Feedback</dt>
           <dd id="feedback-label">Awaiting authoritative outcomes</dd>
           <dt>Events</dt>

--- a/apps/pod-web/src/direct-connect.test.ts
+++ b/apps/pod-web/src/direct-connect.test.ts
@@ -77,6 +77,14 @@ describe("direct-connect runtime config", () => {
     const frames: number[] = [];
     const eventSummaries: string[] = [];
     const debugDocuments: string[] = [];
+    const actionStates: Array<{
+      pendingCount: number;
+      lastSubmittedTick: number | null;
+      lastAcknowledgedTick: number | null;
+      lastRejectedTick: number | null;
+      lastRejectedReason: string | null;
+      lastActionSummary: string | null;
+    }> = [];
 
     try {
       const client = new PodWebDirectConnectClient(
@@ -95,6 +103,9 @@ describe("direct-connect runtime config", () => {
           },
           onDebugDocument(document) {
             debugDocuments.push(document);
+          },
+          onActionState(state) {
+            actionStates.push(state);
           },
           onStatus() {}
         }
@@ -155,6 +166,63 @@ describe("direct-connect runtime config", () => {
           }
         })
       );
+      expect(actionStates.at(-1)).toEqual({
+        pendingCount: 1,
+        lastSubmittedTick: 19,
+        lastAcknowledgedTick: null,
+        lastRejectedTick: null,
+        lastRejectedReason: null,
+        lastActionSummary: "move"
+      });
+
+      socket?.emitMessage(
+        JSON.stringify({
+          StateDelta: {
+            tick: 19,
+            acknowledged_action_tick: 19,
+            authoritative_digest: 1001,
+            is_full_snapshot: false,
+            delta: {
+              tick: 19,
+              updated: [
+                {
+                  id: 12,
+                  position: [11, 10],
+                  velocity: [1, 0],
+                  rotation: 0,
+                  label: "Hero"
+                }
+              ],
+              destroyed: []
+            }
+          }
+        })
+      );
+      expect(actionStates.at(-1)).toEqual({
+        pendingCount: 0,
+        lastSubmittedTick: 19,
+        lastAcknowledgedTick: 19,
+        lastRejectedTick: null,
+        lastRejectedReason: null,
+        lastActionSummary: "move"
+      });
+
+      client.submitActions([{ kind: "speak", message: "hello", volume: "Normal" }]);
+      socket?.emitMessage(
+        JSON.stringify({
+          Rejected: {
+            reason: "speak cooldown"
+          }
+        })
+      );
+      expect(actionStates.at(-1)).toEqual({
+        pendingCount: 0,
+        lastSubmittedTick: 20,
+        lastAcknowledgedTick: 19,
+        lastRejectedTick: 20,
+        lastRejectedReason: "speak cooldown",
+        lastActionSummary: "speak"
+      });
 
       socket?.emitMessage(
         JSON.stringify({

--- a/apps/pod-web/src/direct-connect.ts
+++ b/apps/pod-web/src/direct-connect.ts
@@ -37,6 +37,15 @@ export interface DirectConnectStatus {
   authoritativeDigest: number | null;
 }
 
+export interface DirectConnectActionState {
+  pendingCount: number;
+  lastSubmittedTick: number | null;
+  lastAcknowledgedTick: number | null;
+  lastRejectedTick: number | null;
+  lastRejectedReason: string | null;
+  lastActionSummary: string | null;
+}
+
 interface DirectConnectHandlers {
   onFrame: (
     snapshot: NetworkWorldSnapshot,
@@ -45,11 +54,17 @@ interface DirectConnectHandlers {
   ) => void;
   onEventBatch: (batch: NetworkEventBatch) => void;
   onDebugDocument: (document: string) => void;
+  onActionState: (state: DirectConnectActionState) => void;
   onStatus: (status: DirectConnectStatus) => void;
 }
 
 const DEFAULT_PLAYER_NAME = "WebPlayer";
 const DEFAULT_RECONNECT_DELAY_MS = 1500;
+
+interface PendingActionBatch {
+  tick: number;
+  summary: string;
+}
 
 export function runtimeConfigFromLocation(
   location: Pick<Location, "search">
@@ -79,9 +94,11 @@ export class PodWebDirectConnectClient {
   private controlledEntity: number | null = null;
   private authoritativeDigest: number | null = null;
   private lastEventTick = 0;
+  private pendingActionBatches: PendingActionBatch[] = [];
   private closedExplicitly = false;
   private debugTelemetryEnabled: boolean;
   private status: DirectConnectStatus;
+  private actionState: DirectConnectActionState;
 
   constructor(
     private readonly config: DirectConnectRuntimeConfig,
@@ -96,6 +113,14 @@ export class PodWebDirectConnectClient {
       entityCount: 0,
       controlledEntity: null,
       authoritativeDigest: null
+    };
+    this.actionState = {
+      pendingCount: 0,
+      lastSubmittedTick: null,
+      lastAcknowledgedTick: null,
+      lastRejectedTick: null,
+      lastRejectedReason: null,
+      lastActionSummary: null
     };
   }
 
@@ -163,6 +188,10 @@ export class PodWebDirectConnectClient {
     return { ...this.status };
   }
 
+  currentActionState(): DirectConnectActionState {
+    return { ...this.actionState };
+  }
+
   snapshotState(): NetworkWorldSnapshot | null {
     return this.snapshot;
   }
@@ -177,6 +206,18 @@ export class PodWebDirectConnectClient {
     }
 
     const nextTick = (this.snapshot?.tick ?? this.status.tick ?? 0) + 1;
+    const summary = summarizeActions(actions);
+    this.pendingActionBatches.push({
+      tick: nextTick,
+      summary
+    });
+    this.actionState = {
+      ...this.actionState,
+      pendingCount: this.pendingActionBatches.length,
+      lastSubmittedTick: nextTick,
+      lastActionSummary: summary
+    };
+    this.handlers.onActionState(this.currentActionState());
     this.socket.send(encodeDirectConnectActionBatch(nextTick, actions));
     return true;
   }
@@ -199,6 +240,7 @@ export class PodWebDirectConnectClient {
             message.isFullSnapshot
           );
           this.authoritativeDigest = message.authoritativeDigest;
+          this.reconcileAcknowledgedActions(message.acknowledgedActionTick);
           this.updateWorldStatus("connected", `Authoritative tick ${message.tick}`);
           this.emitFrame();
         } catch {
@@ -228,7 +270,12 @@ export class PodWebDirectConnectClient {
         });
         break;
       case "rejected":
-        this.updateStatus("rejected", message.reason);
+        this.rejectLatestPendingAction(message.reason);
+        if (this.status.phase === "connected") {
+          this.updateWorldStatus("connected", `Rejected action: ${message.reason}`);
+        } else {
+          this.updateStatus("rejected", message.reason);
+        }
         break;
       case "pong":
         break;
@@ -288,6 +335,38 @@ export class PodWebDirectConnectClient {
       this.reconnectTimer = null;
     }
   }
+
+  private reconcileAcknowledgedActions(acknowledgedTick: number | null): void {
+    if (acknowledgedTick == null) {
+      return;
+    }
+
+    const acknowledged = this.pendingActionBatches
+      .filter((batch) => batch.tick <= acknowledgedTick)
+      .at(-1);
+    this.pendingActionBatches = this.pendingActionBatches.filter(
+      (batch) => batch.tick > acknowledgedTick
+    );
+    this.actionState = {
+      ...this.actionState,
+      pendingCount: this.pendingActionBatches.length,
+      lastAcknowledgedTick: acknowledgedTick,
+      lastActionSummary: acknowledged?.summary ?? this.actionState.lastActionSummary
+    };
+    this.handlers.onActionState(this.currentActionState());
+  }
+
+  private rejectLatestPendingAction(reason: string): void {
+    const rejected = this.pendingActionBatches.pop() ?? null;
+    this.actionState = {
+      ...this.actionState,
+      pendingCount: this.pendingActionBatches.length,
+      lastRejectedTick: rejected?.tick ?? this.actionState.lastRejectedTick,
+      lastRejectedReason: reason,
+      lastActionSummary: rejected?.summary ?? this.actionState.lastActionSummary
+    };
+    this.handlers.onActionState(this.currentActionState());
+  }
 }
 
 export function frameFromAuthoritativeSnapshot(
@@ -336,4 +415,10 @@ function parsePositiveInt(value: string | null): number | null {
 
   const parsed = Number.parseInt(value, 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function summarizeActions(actions: BrowserAction[]): string {
+  return actions
+    .map((action) => action.kind.replace(/([A-Z])/g, " $1").toLowerCase())
+    .join(" + ");
 }

--- a/apps/pod-web/src/main.ts
+++ b/apps/pod-web/src/main.ts
@@ -21,6 +21,7 @@ import {
 } from "./contracts";
 import {
   PodWebDirectConnectClient,
+  type DirectConnectActionState,
   runtimeConfigFromLocation,
   type DirectConnectStatus
 } from "./direct-connect";
@@ -64,6 +65,7 @@ const frameSourceLabel = document.querySelector<HTMLElement>("#frame-source");
 const connectionLabel = document.querySelector<HTMLElement>("#connection-label");
 const worldLabel = document.querySelector<HTMLElement>("#world-label");
 const targetLabel = document.querySelector<HTMLElement>("#target-label");
+const actionStatusLabel = document.querySelector<HTMLElement>("#action-status-label");
 const feedbackLabel = document.querySelector<HTMLElement>("#feedback-label");
 const eventFeedLabel = document.querySelector<HTMLElement>("#event-feed-label");
 const qualityLabel = document.querySelector<HTMLElement>("#quality-label");
@@ -99,6 +101,7 @@ if (
   !connectionLabel ||
   !worldLabel ||
   !targetLabel ||
+  !actionStatusLabel ||
   !feedbackLabel ||
   !eventFeedLabel ||
   !qualityLabel ||
@@ -127,6 +130,7 @@ const telemetryToggleButton = telemetryToggle;
 const connectionNode = connectionLabel;
 const worldNode = worldLabel;
 const targetNode = targetLabel;
+const actionStatusNode = actionStatusLabel;
 const feedbackNode = feedbackLabel;
 const eventFeedNode = eventFeedLabel;
 const chatFormNode = chatForm;
@@ -162,6 +166,14 @@ let latestRollupSummary: TickRollupSummary | null = null;
 let liveReplayDocuments = 0;
 let liveIncidentDocuments = 0;
 let latestSnapshot: NetworkWorldSnapshot | null = null;
+let latestActionStatus: DirectConnectActionState = {
+  pendingCount: 0,
+  lastSubmittedTick: null,
+  lastAcknowledgedTick: null,
+  lastRejectedTick: null,
+  lastRejectedReason: null,
+  lastActionSummary: null
+};
 let latestFeedback = "Awaiting authoritative outcomes";
 let recentWorldEvents: NetworkGameEvent[] = [];
 let liveConnectionStatus: DirectConnectStatus | null = runtimeConfig
@@ -199,6 +211,9 @@ const liveClient = runtimeConfig
       },
       onDebugDocument(document) {
         applyLiveDebugDocument(document);
+      },
+      onActionState(state) {
+        latestActionStatus = state;
       },
       onStatus(status) {
         liveConnectionStatus = status;
@@ -316,6 +331,28 @@ function formatRecentEventFeed(): string {
   return recentWorldEvents
     .map((event) => `[${event.tick}] ${event.summary}`)
     .join("\n");
+}
+
+function formatActionStatus(): string {
+  if (latestActionStatus.lastRejectedReason) {
+    return `rejected @ ${
+      latestActionStatus.lastRejectedTick ?? "?"
+    } · ${latestActionStatus.lastRejectedReason}`;
+  }
+
+  if (latestActionStatus.pendingCount > 0) {
+    return `pending ${latestActionStatus.pendingCount} · ${
+      latestActionStatus.lastActionSummary ?? "action"
+    }`;
+  }
+
+  if (latestActionStatus.lastAcknowledgedTick != null) {
+    return `acknowledged @ ${latestActionStatus.lastAcknowledgedTick} · ${
+      latestActionStatus.lastActionSummary ?? "action"
+    }`;
+  }
+
+  return "idle";
 }
 
 function syncSelectedTarget(): void {
@@ -630,6 +667,7 @@ function renderTelemetryHud(): void {
   targetNode.textContent = target
     ? `${target.label ?? "Target"} · E(${target.id}) · ${entityHealthSummary(target)}`
     : "No target selected";
+  actionStatusNode.textContent = formatActionStatus();
   feedbackNode.textContent = latestFeedback;
   eventFeedNode.textContent = formatRecentEventFeed();
   telemetryToggleButton.textContent = stats.enabled ? "Disable Telemetry" : "Enable Telemetry";


### PR DESCRIPTION
## Summary
- track pending, acknowledged, and rejected browser action batches in the direct-connect runtime
- surface authoritative action status directly in the pod-web HUD
- keep websocket sessions connected when post-connect rejections are action-level failures

## Validation
- cd apps/pod-web && bun test
- cd apps/pod-web && bun run typecheck
- cd apps/pod-web && bun run build
- git diff --check