### PR TITLE
Add pod-web target affordances

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -687,5 +687,15 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cd apps/pod-web && bun run build`
   - `git diff --check`
 
-**Last updated**: Iteration 73
-**Current focus**: Iteration 74 browser MMO loop completion beyond action staging, starting with richer live world-state affordances, direct shard-side player/chat outcome surfaces, and tighter creator inspection UX on the flagship browser path
+### Iteration 74
+- [x] Added pure, testable browser target-affordance helpers so the selected target now exposes compact summary and suggested-action hints grounded in live shard state.
+- [x] Surfaced selected-target affordances and better local feedback in the gameplay HUD, including immediate client-side guidance for missing targets, empty chat submits, and unavailable direct-connect submission paths.
+- [x] Added deterministic Bun coverage for target summary formatting and interaction-hint classification across creature and loot targets.
+- [x] Validated touched targets:
+  - `cd apps/pod-web && bun test`
+  - `cd apps/pod-web && bun run typecheck`
+  - `cd apps/pod-web && bun run build`
+  - `git diff --check`
+
+**Last updated**: Iteration 74
+**Current focus**: Iteration 75 broader flagship MMO loop completion, starting with richer shard-side world metadata for browser clients, stronger creator inspection affordances, and continued convergence on the browser-first live world path

--- a/apps/pod-web/README.md
+++ b/apps/pod-web/README.md
@@ -47,6 +47,7 @@ http://127.0.0.1:5173/?server=127.0.0.1:7778&player=WebPlayer&debug=1
 - `Enter`: focus chat input and send a shard message
 - HUD feedback and event feed rows are driven by authoritative `EventBatch` messages from the shard, so combat/chat/loot/capture outcomes come from server events rather than client-side guesses
 - The action status row is driven by authoritative `acknowledged_action_tick` and `Rejected` responses, so creators can see pending, acknowledged, and rejected browser input on the live shard path
+- The selected-target summary and suggested-actions row give browser players and creators an immediate interaction hint from the live shard state instead of relying on memorized keybinds alone
 
 ## Validate
 

--- a/apps/pod-web/index.html
+++ b/apps/pod-web/index.html
@@ -171,6 +171,8 @@
           <dd id="world-label">demo scene</dd>
           <dt>Target</dt>
           <dd id="target-label">No target selected</dd>
+          <dt>Suggested</dt>
+          <dd id="affordance-label">Tab to cycle targets</dd>
           <dt>Action</dt>
           <dd id="action-status-label">idle</dd>
           <dt>Feedback</dt>

--- a/apps/pod-web/src/affordances.test.ts
+++ b/apps/pod-web/src/affordances.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+
+import { describeTargetAffordances, formatTargetSummary } from "./affordances";
+
+describe("target affordances", () => {
+  test("formats target summaries with health and distance", () => {
+    expect(
+      formatTargetSummary(
+        {
+          id: 9,
+          position: [30, 40],
+          velocity: [0, 0],
+          rotation: 0,
+          health: 28,
+          maxHealth: 40,
+          label: "Monster-Wolf"
+        },
+        {
+          id: 12,
+          position: [10, 10],
+          velocity: [0, 0],
+          rotation: 0,
+          label: "Player"
+        }
+      )
+    ).toBe("Monster-Wolf · E(9) · 28/40 hp · 36u away");
+  });
+
+  test("describes capture and combat affordances for wild creatures", () => {
+    expect(
+      describeTargetAffordances({
+        id: 9,
+        position: [0, 0],
+        velocity: [0, 0],
+        rotation: 0,
+        label: "Wild Creature"
+      })
+    ).toBe("Space attack · C capture · E inspect");
+  });
+
+  test("describes loot affordances for containers", () => {
+    expect(
+      describeTargetAffordances({
+        id: 14,
+        position: [0, 0],
+        velocity: [0, 0],
+        rotation: 0,
+        label: "Loot Cache"
+      })
+    ).toBe("R loot · E inspect");
+  });
+});

--- a/apps/pod-web/src/affordances.ts
+++ b/apps/pod-web/src/affordances.ts
@@ -1,0 +1,88 @@
+import type { NetworkEntitySnapshot } from "./contracts";
+
+export function formatTargetSummary(
+  target: NetworkEntitySnapshot | null,
+  controlled: NetworkEntitySnapshot | null
+): string {
+  if (!target) {
+    return "No target selected";
+  }
+
+  const parts = [`${target.label ?? "Target"} · E(${target.id})`];
+  const health = healthSummary(target);
+  if (health) {
+    parts.push(health);
+  }
+
+  if (controlled) {
+    const distance = Math.hypot(
+      target.position[0] - controlled.position[0],
+      target.position[1] - controlled.position[1]
+    );
+    parts.push(`${distance.toFixed(0)}u away`);
+  }
+
+  return parts.join(" · ");
+}
+
+export function describeTargetAffordances(
+  target: NetworkEntitySnapshot | null
+): string {
+  if (!target) {
+    return "Tab to cycle targets";
+  }
+
+  const label = target.label?.toLowerCase() ?? "";
+  if (label.includes("wall") || label.includes("obstacle")) {
+    return "Static scenery";
+  }
+  if (
+    label.includes("resource") ||
+    label.includes("ore") ||
+    label.includes("tree") ||
+    label.includes("node")
+  ) {
+    return "G gather · E inspect";
+  }
+  if (
+    label.includes("loot") ||
+    label.includes("chest") ||
+    label.includes("cache") ||
+    label.includes("corpse")
+  ) {
+    return "R loot · E inspect";
+  }
+  if (
+    label.includes("monster") ||
+    label.includes("creature") ||
+    label.includes("beast") ||
+    label.includes("wild")
+  ) {
+    return "Space attack · C capture · E inspect";
+  }
+  if (
+    label.includes("companion") ||
+    label.includes("pet") ||
+    label.includes("summon") ||
+    label.includes("spirit")
+  ) {
+    return "F command companion · E inspect";
+  }
+  if (label.includes("player") || label.includes("npc")) {
+    return "Space attack · E interact · Enter chat";
+  }
+
+  return "E interact";
+}
+
+function healthSummary(target: NetworkEntitySnapshot): string | null {
+  if (
+    target.health == null ||
+    target.maxHealth == null ||
+    target.maxHealth <= 0
+  ) {
+    return null;
+  }
+
+  return `${target.health.toFixed(0)}/${target.maxHealth.toFixed(0)} hp`;
+}

--- a/apps/pod-web/src/main.ts
+++ b/apps/pod-web/src/main.ts
@@ -20,6 +20,10 @@ import {
   type ShardIncidentSummary
 } from "./contracts";
 import {
+  describeTargetAffordances,
+  formatTargetSummary
+} from "./affordances";
+import {
   PodWebDirectConnectClient,
   type DirectConnectActionState,
   runtimeConfigFromLocation,
@@ -65,6 +69,7 @@ const frameSourceLabel = document.querySelector<HTMLElement>("#frame-source");
 const connectionLabel = document.querySelector<HTMLElement>("#connection-label");
 const worldLabel = document.querySelector<HTMLElement>("#world-label");
 const targetLabel = document.querySelector<HTMLElement>("#target-label");
+const affordanceLabel = document.querySelector<HTMLElement>("#affordance-label");
 const actionStatusLabel = document.querySelector<HTMLElement>("#action-status-label");
 const feedbackLabel = document.querySelector<HTMLElement>("#feedback-label");
 const eventFeedLabel = document.querySelector<HTMLElement>("#event-feed-label");
@@ -101,6 +106,7 @@ if (
   !connectionLabel ||
   !worldLabel ||
   !targetLabel ||
+  !affordanceLabel ||
   !actionStatusLabel ||
   !feedbackLabel ||
   !eventFeedLabel ||
@@ -130,6 +136,7 @@ const telemetryToggleButton = telemetryToggle;
 const connectionNode = connectionLabel;
 const worldNode = worldLabel;
 const targetNode = targetLabel;
+const affordanceNode = affordanceLabel;
 const actionStatusNode = actionStatusLabel;
 const feedbackNode = feedbackLabel;
 const eventFeedNode = eventFeedLabel;
@@ -284,19 +291,6 @@ function selectedTarget(): NetworkEntitySnapshot | null {
   return targetableEntities().find((entity) => entity.id === selectedTargetId) ?? null;
 }
 
-function entityHealthSummary(entity: NetworkEntitySnapshot | null): string {
-  if (
-    entity == null ||
-    entity.health == null ||
-    entity.maxHealth == null ||
-    entity.maxHealth <= 0
-  ) {
-    return "status unknown";
-  }
-
-  return `${entity.health.toFixed(0)}/${entity.maxHealth.toFixed(0)} hp`;
-}
-
 function eventTouchesEntity(event: NetworkGameEvent, entityId: number | null): boolean {
   return entityId != null && event.entityIds.includes(entityId);
 }
@@ -384,9 +378,12 @@ function cycleTargetSelection(delta: number): void {
 
 function submitActions(actions: BrowserAction[]): void {
   if (!liveClient) {
+    latestFeedback = "Direct-connect is not active";
     return;
   }
-  liveClient.submitActions(actions);
+  if (!liveClient.submitActions(actions)) {
+    latestFeedback = "Action could not be submitted";
+  }
 }
 
 function movementDirection(): [number, number] | null {
@@ -433,6 +430,7 @@ function submitTargetedAction(
 ): void {
   const target = selectedTarget();
   if (!target) {
+    latestFeedback = "Select a target first";
     return;
   }
   submitActions([actionBuilder(target)]);
@@ -506,6 +504,7 @@ chatFormNode.addEventListener("submit", (event) => {
   event.preventDefault();
   const message = chatInputNode.value.trim();
   if (message.length === 0) {
+    latestFeedback = "Type a message first";
     return;
   }
 
@@ -652,6 +651,7 @@ async function tick(timestamp: number): Promise<void> {
 function renderTelemetryHud(): void {
   const stats = telemetryStats(telemetryState);
   const target = selectedTarget();
+  const controlled = controlledEntity();
   connectionNode.textContent = liveConnectionStatus
     ? `${liveConnectionStatus.phase} · ${liveConnectionStatus.detail}`
     : "offline demo / bridge mode";
@@ -664,9 +664,8 @@ function renderTelemetryHud(): void {
             : `controlled E(${liveConnectionStatus.controlledEntity})`
         }`
     : "demo scene";
-  targetNode.textContent = target
-    ? `${target.label ?? "Target"} · E(${target.id}) · ${entityHealthSummary(target)}`
-    : "No target selected";
+  targetNode.textContent = formatTargetSummary(target, controlled);
+  affordanceNode.textContent = describeTargetAffordances(target);
   actionStatusNode.textContent = formatActionStatus();
   feedbackNode.textContent = latestFeedback;
   eventFeedNode.textContent = formatRecentEventFeed();


### PR DESCRIPTION
## Summary
- add pure target-summary and affordance helpers for the browser MMO HUD
- surface suggested actions and tighter local feedback for selected targets and invalid input paths
- cover the new affordance logic with deterministic Bun tests

## Validation
- cd apps/pod-web && bun test
- cd apps/pod-web && bun run typecheck
- cd apps/pod-web && bun run build
- git diff --check