### PR TITLE
Add authoritative browser world metadata

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -697,5 +697,18 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cd apps/pod-web && bun run build`
   - `git diff --check`
 
-**Last updated**: Iteration 74
-**Current focus**: Iteration 75 broader flagship MMO loop completion, starting with richer shard-side world metadata for browser clients, stronger creator inspection affordances, and continued convergence on the browser-first live world path
+### Iteration 75
+- [x] Expanded authoritative `pod-net` snapshots with gameplay metadata (`EntityKind`, interaction hints, team/combat/species/resource/encounter fields) so browser and creator tooling can consume shard-side meaning instead of guessing from labels.
+- [x] Fixed a deeper snapshot coverage gap by capturing all transformed entities, including non-moving resource nodes, loot containers, and static world props that previously fell out of direct-connect snapshots.
+- [x] Upgraded `apps/pod-web` target summaries, affordances, target filtering, and render profile selection to use authoritative metadata first while preserving legacy label fallbacks for older payloads.
+- [x] Added deterministic Rust and Bun coverage for static-entity snapshot capture, metadata parsing, and metadata-driven browser affordances/render planning.
+- [x] Validated touched targets:
+  - `cargo test -p pod-net --lib`
+  - `cd apps/pod-web && bun test`
+  - `cd apps/pod-web && bun run typecheck`
+  - `cd apps/pod-web && bun run build`
+  - `cargo fmt --all`
+  - `git diff --check`
+
+**Last updated**: Iteration 75
+**Current focus**: Iteration 76 browser-first flagship world delivery, starting with asset-backed WebGPU rendering (`GLTFLoader` + `KTX2Loader` + `Meshopt`), worker-ready/offscreen render preparation, and a plan to replace emulated SpacetimeDB client paths with generated typed bindings

--- a/apps/pod-web/src/affordances.test.ts
+++ b/apps/pod-web/src/affordances.test.ts
@@ -1,6 +1,33 @@
 import { describe, expect, test } from "bun:test";
 
 import { describeTargetAffordances, formatTargetSummary } from "./affordances";
+import type { NetworkEntityMetadataSnapshot } from "./contracts";
+
+function metadata(
+  overrides: Partial<NetworkEntityMetadataSnapshot> = {}
+): NetworkEntityMetadataSnapshot {
+  return {
+    kind: "Unknown",
+    teamId: null,
+    combatStyle: null,
+    speciesId: null,
+    speciesName: null,
+    resourceSkill: null,
+    resourceTier: null,
+    encounterKind: null,
+    interaction: {
+      canInspect: false,
+      canInteract: false,
+      canAttack: false,
+      canGather: false,
+      canLoot: false,
+      canCapture: false,
+      canCommandCompanion: false,
+      canChat: false
+    },
+    ...overrides
+  };
+}
 
 describe("target affordances", () => {
   test("formats target summaries with health and distance", () => {
@@ -13,17 +40,43 @@ describe("target affordances", () => {
           rotation: 0,
           health: 28,
           maxHealth: 40,
-          label: "Monster-Wolf"
+          label: "Monster-Wolf",
+          metadata: metadata({
+            kind: "WildCreature",
+            interaction: {
+              canInspect: true,
+              canInteract: false,
+              canAttack: true,
+              canGather: false,
+              canLoot: false,
+              canCapture: true,
+              canCommandCompanion: false,
+              canChat: false
+            }
+          })
         },
         {
           id: 12,
           position: [10, 10],
           velocity: [0, 0],
           rotation: 0,
-          label: "Player"
+          label: "Player",
+          metadata: metadata({
+            kind: "Player",
+            interaction: {
+              canInspect: true,
+              canInteract: true,
+              canAttack: true,
+              canGather: false,
+              canLoot: false,
+              canCapture: false,
+              canCommandCompanion: false,
+              canChat: true
+            }
+          })
         }
       )
-    ).toBe("Monster-Wolf · E(9) · 28/40 hp · 36u away");
+    ).toBe("Monster-Wolf · E(9) · wild creature · 28/40 hp · 36u away");
   });
 
   test("describes capture and combat affordances for wild creatures", () => {
@@ -33,7 +86,20 @@ describe("target affordances", () => {
         position: [0, 0],
         velocity: [0, 0],
         rotation: 0,
-        label: "Wild Creature"
+        label: "Wild Creature",
+        metadata: metadata({
+          kind: "WildCreature",
+          interaction: {
+            canInspect: true,
+            canInteract: false,
+            canAttack: true,
+            canGather: false,
+            canLoot: false,
+            canCapture: true,
+            canCommandCompanion: false,
+            canChat: false
+          }
+        })
       })
     ).toBe("Space attack · C capture · E inspect");
   });
@@ -45,8 +111,46 @@ describe("target affordances", () => {
         position: [0, 0],
         velocity: [0, 0],
         rotation: 0,
-        label: "Loot Cache"
+        label: "Loot Cache",
+        metadata: metadata({
+          kind: "LootContainer",
+          interaction: {
+            canInspect: true,
+            canInteract: false,
+            canAttack: false,
+            canGather: false,
+            canLoot: true,
+            canCapture: false,
+            canCommandCompanion: false,
+            canChat: false
+          }
+        })
       })
     ).toBe("R loot · E inspect");
+  });
+
+  test("describes static scenery from authoritative metadata", () => {
+    expect(
+      describeTargetAffordances({
+        id: 21,
+        position: [0, 0],
+        velocity: [0, 0],
+        rotation: 0,
+        label: "Shard Anchor",
+        metadata: metadata({
+          kind: "Scenery",
+          interaction: {
+            canInspect: true,
+            canInteract: false,
+            canAttack: false,
+            canGather: false,
+            canLoot: false,
+            canCapture: false,
+            canCommandCompanion: false,
+            canChat: false
+          }
+        })
+      })
+    ).toBe("Static scenery");
   });
 });

--- a/apps/pod-web/src/affordances.ts
+++ b/apps/pod-web/src/affordances.ts
@@ -8,7 +8,14 @@ export function formatTargetSummary(
     return "No target selected";
   }
 
-  const parts = [`${target.label ?? "Target"} · E(${target.id})`];
+  const parts = [`${displayName(target)} · E(${target.id})`];
+  const descriptor = describeTargetKind(target);
+  if (descriptor) {
+    parts.push(descriptor);
+  }
+  if (target.metadata.teamId != null) {
+    parts.push(`team ${target.metadata.teamId}`);
+  }
   const health = healthSummary(target);
   if (health) {
     parts.push(health);
@@ -30,6 +37,11 @@ export function describeTargetAffordances(
 ): string {
   if (!target) {
     return "Tab to cycle targets";
+  }
+
+  const actions = authoritativeAffordances(target);
+  if (actions.length > 0) {
+    return actions.join(" · ");
   }
 
   const label = target.label?.toLowerCase() ?? "";
@@ -85,4 +97,93 @@ function healthSummary(target: NetworkEntitySnapshot): string | null {
   }
 
   return `${target.health.toFixed(0)}/${target.maxHealth.toFixed(0)} hp`;
+}
+
+function displayName(target: NetworkEntitySnapshot): string {
+  return (
+    target.metadata.speciesName ??
+    target.label ??
+    fallbackKindLabel(target.metadata.kind) ??
+    "Target"
+  );
+}
+
+function describeTargetKind(target: NetworkEntitySnapshot): string | null {
+  switch (target.metadata.kind) {
+    case "WildCreature":
+      return "wild creature";
+    case "Companion":
+      return "companion";
+    case "ResourceNode":
+      return target.metadata.resourceSkill
+        ? `${target.metadata.resourceSkill.toLowerCase()} node`
+        : "resource node";
+    case "LootContainer":
+      return "loot cache";
+    case "Npc":
+      return target.metadata.combatStyle
+        ? `${target.metadata.combatStyle.toLowerCase()} npc`
+        : "npc";
+    case "Player":
+      return "player";
+    case "Scenery":
+      return "scenery";
+    default:
+      return null;
+  }
+}
+
+function authoritativeAffordances(target: NetworkEntitySnapshot): string[] {
+  const actions: string[] = [];
+  const hints = target.metadata.interaction;
+
+  if (target.metadata.kind === "Scenery") {
+    return ["Static scenery"];
+  }
+  if (hints.canAttack) {
+    actions.push("Space attack");
+  }
+  if (hints.canCapture) {
+    actions.push("C capture");
+  }
+  if (hints.canGather) {
+    actions.push("G gather");
+  }
+  if (hints.canLoot) {
+    actions.push("R loot");
+  }
+  if (hints.canCommandCompanion) {
+    actions.push("F command companion");
+  }
+  if (hints.canInteract) {
+    actions.push("E interact");
+  } else if (hints.canInspect) {
+    actions.push("E inspect");
+  }
+  if (hints.canChat) {
+    actions.push("Enter chat");
+  }
+
+  return actions;
+}
+
+function fallbackKindLabel(kind: NetworkEntitySnapshot["metadata"]["kind"]): string | null {
+  switch (kind) {
+    case "WildCreature":
+      return "Wild Creature";
+    case "Companion":
+      return "Companion";
+    case "ResourceNode":
+      return "Resource Node";
+    case "LootContainer":
+      return "Loot Cache";
+    case "Npc":
+      return "NPC";
+    case "Player":
+      return "Player";
+    case "Scenery":
+      return "Scenery";
+    default:
+      return null;
+  }
 }

--- a/apps/pod-web/src/contracts.test.ts
+++ b/apps/pod-web/src/contracts.test.ts
@@ -21,6 +21,30 @@ import {
   summarizeReplayFile
 } from "./contracts";
 
+function entityMetadata(kind: string, overrides: Record<string, unknown> = {}) {
+  return {
+    kind,
+    team_id: null,
+    combat_style: null,
+    species_id: null,
+    species_name: null,
+    resource_skill: null,
+    resource_tier: null,
+    encounter_kind: null,
+    interaction: {
+      can_inspect: true,
+      can_interact: false,
+      can_attack: false,
+      can_gather: false,
+      can_loot: false,
+      can_capture: false,
+      can_command_companion: false,
+      can_chat: false
+    },
+    ...overrides
+  };
+}
+
 describe("TOON contract parsing", () => {
   test("accepts versioned tick telemetry TOON documents", () => {
     const document = encode({
@@ -247,7 +271,19 @@ describe("TOON contract parsing", () => {
                 position: [12, 18],
                 velocity: [1, 0],
                 rotation: 0.4,
-                label: "Hero"
+                label: "Hero",
+                metadata: entityMetadata("Player", {
+                  interaction: {
+                    can_inspect: true,
+                    can_interact: true,
+                    can_attack: true,
+                    can_gather: false,
+                    can_loot: false,
+                    can_capture: false,
+                    can_command_companion: false,
+                    can_chat: true
+                  }
+                })
               }
             ]
           }
@@ -260,6 +296,7 @@ describe("TOON contract parsing", () => {
       throw new Error("expected welcome");
     }
     expect(welcome.snapshot.entities[0]?.position).toEqual([12, 18]);
+    expect(welcome.snapshot.entities[0]?.metadata.kind).toBe("Player");
 
     const delta = parseDirectConnectServerMessage(
       JSON.stringify({
@@ -276,7 +313,20 @@ describe("TOON contract parsing", () => {
                 position: { x: 14, y: 19 },
                 velocity: [2, 0],
                 rotation: 0.55,
-                label: "Hero"
+                label: "Hero",
+                metadata: entityMetadata("Player", {
+                  team_id: 2,
+                  interaction: {
+                    can_inspect: true,
+                    can_interact: true,
+                    can_attack: true,
+                    can_gather: false,
+                    can_loot: false,
+                    can_capture: false,
+                    can_command_companion: false,
+                    can_chat: true
+                  }
+                })
               }
             ],
             destroyed: [99]
@@ -291,6 +341,7 @@ describe("TOON contract parsing", () => {
     }
     expect(delta.delta.updated[0]?.position).toEqual([14, 19]);
     expect(delta.acknowledgedActionTick).toBe(12);
+    expect(delta.delta.updated[0]?.metadata.teamId).toBe(2);
   });
 
   test("parses authoritative event batches into gameplay summaries", () => {
@@ -345,14 +396,54 @@ describe("TOON contract parsing", () => {
           position: [10, 10],
           velocity: [0, 0],
           rotation: 0,
-          label: "Hero"
+          label: "Hero",
+          metadata: {
+            kind: "Player",
+            teamId: 1,
+            combatStyle: "Melee",
+            speciesId: null,
+            speciesName: null,
+            resourceSkill: null,
+            resourceTier: null,
+            encounterKind: null,
+            interaction: {
+              canInspect: true,
+              canInteract: true,
+              canAttack: true,
+              canGather: false,
+              canLoot: false,
+              canCapture: false,
+              canCommandCompanion: false,
+              canChat: true
+            }
+          }
         },
         {
           id: 2,
           position: [20, 12],
           velocity: [0, 0],
           rotation: 0,
-          label: "Wall-East"
+          label: "Wall-East",
+          metadata: {
+            kind: "Scenery",
+            teamId: null,
+            combatStyle: null,
+            speciesId: null,
+            speciesName: null,
+            resourceSkill: null,
+            resourceTier: null,
+            encounterKind: null,
+            interaction: {
+              canInspect: true,
+              canInteract: false,
+              canAttack: false,
+              canGather: false,
+              canLoot: false,
+              canCapture: false,
+              canCommandCompanion: false,
+              canChat: false
+            }
+          }
         }
       ]
     };
@@ -367,14 +458,54 @@ describe("TOON contract parsing", () => {
             position: [14, 12],
             velocity: [4, 0],
             rotation: 0.3,
-            label: "Hero"
+            label: "Hero",
+            metadata: {
+              kind: "Player",
+              teamId: 1,
+              combatStyle: "Melee",
+              speciesId: null,
+              speciesName: null,
+              resourceSkill: null,
+              resourceTier: null,
+              encounterKind: null,
+              interaction: {
+                canInspect: true,
+                canInteract: true,
+                canAttack: true,
+                canGather: false,
+                canLoot: false,
+                canCapture: false,
+                canCommandCompanion: false,
+                canChat: true
+              }
+            }
           },
           {
             id: 3,
             position: [18, 20],
             velocity: [0, 0],
             rotation: 0,
-            label: "Monster-Wolf"
+            label: "Monster-Wolf",
+            metadata: {
+              kind: "WildCreature",
+              teamId: null,
+              combatStyle: "Melee",
+              speciesId: "embercub",
+              speciesName: "Wild Embercub",
+              resourceSkill: null,
+              resourceTier: null,
+              encounterKind: "WildCreature",
+              interaction: {
+                canInspect: true,
+                canInteract: false,
+                canAttack: true,
+                canGather: false,
+                canLoot: false,
+                canCapture: true,
+                canCommandCompanion: false,
+                canChat: false
+              }
+            }
           }
         ],
         destroyed: [2]

--- a/apps/pod-web/src/contracts.ts
+++ b/apps/pod-web/src/contracts.ts
@@ -363,6 +363,65 @@ export type LiveDebugDocument =
   | { kind: "replay"; documentType: string; payload: ReplayFileDocument }
   | { kind: "incident"; documentType: string; payload: ShardIncidentSummary };
 
+export type NetworkEntityKind =
+  | "Unknown"
+  | "Player"
+  | "Npc"
+  | "WildCreature"
+  | "Companion"
+  | "ResourceNode"
+  | "LootContainer"
+  | "Scenery";
+
+export type NetworkCombatStyle = "Melee" | "Ranged" | "Magic" | "Summoning";
+
+export type NetworkSkillKind =
+  | "Attack"
+  | "Strength"
+  | "Defence"
+  | "Ranged"
+  | "Magic"
+  | "Constitution"
+  | "Mining"
+  | "Woodcutting"
+  | "Fishing"
+  | "Cooking"
+  | "Smithing"
+  | "Crafting"
+  | "Slayer"
+  | "Taming"
+  | "Bonding";
+
+export type NetworkEncounterKind =
+  | "OpenWorld"
+  | "Duel"
+  | "WildCreature"
+  | "Boss"
+  | "Raid";
+
+export interface NetworkEntityInteractionHints {
+  canInspect: boolean;
+  canInteract: boolean;
+  canAttack: boolean;
+  canGather: boolean;
+  canLoot: boolean;
+  canCapture: boolean;
+  canCommandCompanion: boolean;
+  canChat: boolean;
+}
+
+export interface NetworkEntityMetadataSnapshot {
+  kind: NetworkEntityKind;
+  teamId: number | null;
+  combatStyle: NetworkCombatStyle | null;
+  speciesId: string | null;
+  speciesName: string | null;
+  resourceSkill: NetworkSkillKind | null;
+  resourceTier: number | null;
+  encounterKind: NetworkEncounterKind | null;
+  interaction: NetworkEntityInteractionHints;
+}
+
 export interface NetworkEntitySnapshot {
   id: number;
   position: Vec2Tuple;
@@ -372,6 +431,7 @@ export interface NetworkEntitySnapshot {
   maxHealth?: number | null;
   movementSpeed?: number | null;
   label?: string | null;
+  metadata: NetworkEntityMetadataSnapshot;
 }
 
 export interface NetworkWorldSnapshot {
@@ -569,8 +629,130 @@ function parseNetworkEntitySnapshot(value: unknown): NetworkEntitySnapshot | nul
     health: optionalNumber(value.health),
     maxHealth: optionalNumber(value.max_health ?? value.maxHealth),
     movementSpeed: optionalNumber(value.movement_speed ?? value.movementSpeed),
-    label: optionalString(value.label) ?? null
+    label: optionalString(value.label) ?? null,
+    metadata: parseNetworkEntityMetadata(value.metadata)
   };
+}
+
+function parseNetworkEntityMetadata(value: unknown): NetworkEntityMetadataSnapshot {
+  if (!isRecord(value)) {
+    return defaultNetworkEntityMetadata();
+  }
+
+  const combatStyle = value.combat_style ?? value.combatStyle;
+  const resourceSkill = value.resource_skill ?? value.resourceSkill;
+  const encounterKind = value.encounter_kind ?? value.encounterKind;
+
+  return {
+    kind: isEntityKind(value.kind) ? value.kind : "Unknown",
+    teamId: optionalNumber(value.team_id ?? value.teamId) ?? null,
+    combatStyle: isCombatStyle(combatStyle) ? combatStyle : null,
+    speciesId: optionalString(value.species_id ?? value.speciesId) ?? null,
+    speciesName: optionalString(value.species_name ?? value.speciesName) ?? null,
+    resourceSkill: isSkillKind(resourceSkill) ? resourceSkill : null,
+    resourceTier: optionalNumber(value.resource_tier ?? value.resourceTier) ?? null,
+    encounterKind: isEncounterKind(encounterKind) ? encounterKind : null,
+    interaction: parseInteractionHints(value.interaction)
+  };
+}
+
+function parseInteractionHints(value: unknown): NetworkEntityInteractionHints {
+  if (!isRecord(value)) {
+    return defaultInteractionHints();
+  }
+
+  return {
+    canInspect: Boolean(value.can_inspect ?? value.canInspect),
+    canInteract: Boolean(value.can_interact ?? value.canInteract),
+    canAttack: Boolean(value.can_attack ?? value.canAttack),
+    canGather: Boolean(value.can_gather ?? value.canGather),
+    canLoot: Boolean(value.can_loot ?? value.canLoot),
+    canCapture: Boolean(value.can_capture ?? value.canCapture),
+    canCommandCompanion: Boolean(
+      value.can_command_companion ?? value.canCommandCompanion
+    ),
+    canChat: Boolean(value.can_chat ?? value.canChat)
+  };
+}
+
+function defaultInteractionHints(): NetworkEntityInteractionHints {
+  return {
+    canInspect: false,
+    canInteract: false,
+    canAttack: false,
+    canGather: false,
+    canLoot: false,
+    canCapture: false,
+    canCommandCompanion: false,
+    canChat: false
+  };
+}
+
+function defaultNetworkEntityMetadata(): NetworkEntityMetadataSnapshot {
+  return {
+    kind: "Unknown",
+    teamId: null,
+    combatStyle: null,
+    speciesId: null,
+    speciesName: null,
+    resourceSkill: null,
+    resourceTier: null,
+    encounterKind: null,
+    interaction: defaultInteractionHints()
+  };
+}
+
+function isEntityKind(value: unknown): value is NetworkEntityKind {
+  return (
+    typeof value === "string" &&
+    [
+      "Unknown",
+      "Player",
+      "Npc",
+      "WildCreature",
+      "Companion",
+      "ResourceNode",
+      "LootContainer",
+      "Scenery"
+    ].includes(value)
+  );
+}
+
+function isCombatStyle(value: unknown): value is NetworkCombatStyle {
+  return (
+    typeof value === "string" &&
+    ["Melee", "Ranged", "Magic", "Summoning"].includes(value)
+  );
+}
+
+function isSkillKind(value: unknown): value is NetworkSkillKind {
+  return (
+    typeof value === "string" &&
+    [
+      "Attack",
+      "Strength",
+      "Defence",
+      "Ranged",
+      "Magic",
+      "Constitution",
+      "Mining",
+      "Woodcutting",
+      "Fishing",
+      "Cooking",
+      "Smithing",
+      "Crafting",
+      "Slayer",
+      "Taming",
+      "Bonding"
+    ].includes(value)
+  );
+}
+
+function isEncounterKind(value: unknown): value is NetworkEncounterKind {
+  return (
+    typeof value === "string" &&
+    ["OpenWorld", "Duel", "WildCreature", "Boss", "Raid"].includes(value)
+  );
 }
 
 function parseNetworkWorldSnapshot(value: unknown): NetworkWorldSnapshot | null {
@@ -1388,12 +1570,119 @@ function healthBand(entity: NetworkEntitySnapshot): "healthy" | "wounded" | "cri
   return "healthy";
 }
 
+function entityKind(entity: NetworkEntitySnapshot): NetworkEntityKind {
+  return entity.metadata.kind;
+}
+
+function fallbackLabel(entity: NetworkEntitySnapshot): string {
+  return entity.label?.toLowerCase() ?? "";
+}
+
+function teamTint(teamId: number | null, controlled: boolean): RgbaTuple {
+  if (controlled) {
+    return [0.92, 0.84, 0.58, 1];
+  }
+
+  if (teamId == null) {
+    return [0.36, 0.66, 0.88, 1];
+  }
+
+  const palette: RgbaTuple[] = [
+    [0.78, 0.52, 0.34, 1],
+    [0.38, 0.72, 0.94, 1],
+    [0.54, 0.84, 0.48, 1],
+    [0.88, 0.46, 0.46, 1]
+  ];
+  return palette[teamId % palette.length] ?? palette[0];
+}
+
 function entityRenderProfile(
   entity: NetworkEntitySnapshot,
   controlledEntity: number | null
 ): EntityRenderProfile {
-  const label = entity.label?.toLowerCase() ?? "";
+  const kind = entityKind(entity);
+  const label = fallbackLabel(entity);
   const band = healthBand(entity);
+  const isControlled = controlledEntity != null && entity.id === controlledEntity;
+
+  if (kind === "ResourceNode") {
+    const isWood = entity.metadata.resourceSkill === "Woodcutting";
+    return {
+      mesh: isWood ? "canopy-tree" : "weathered-boulder",
+      material: isWood ? "forest-resource" : "ore-vein",
+      tint: isWood ? [0.28, 0.62, 0.34, 1] : [0.74, 0.54, 0.28, 1],
+      emissive: isWood ? [0.02, 0.05, 0.02] : [0.08, 0.04, 0.01],
+      scale: isWood ? [2.4, 4.8, 2.4] : [2.4, 1.7, 2.2],
+      layer: 1,
+      renderOrder: 1,
+      roughness: isWood ? 0.9 : 0.86,
+      metallic: isWood ? 0.04 : 0.1
+    };
+  }
+
+  if (kind === "LootContainer") {
+    return {
+      mesh: "supply-crate",
+      material: "bronze-cache",
+      tint: [0.78, 0.58, 0.34, 1],
+      emissive: [0.03, 0.02, 0.01],
+      scale: [1.6, 1.1, 1.2],
+      layer: 2,
+      renderOrder: 2,
+      roughness: 0.8,
+      metallic: 0.12
+    };
+  }
+
+  if (kind === "WildCreature") {
+    return {
+      mesh: "rift-beast",
+      material: `rift-hide:${band}:${entity.metadata.speciesId ?? "wild"}`,
+      tint:
+        band === "critical"
+          ? [0.86, 0.34, 0.28, 1]
+          : band === "wounded"
+            ? [0.82, 0.56, 0.34, 1]
+            : [0.72, 0.52, 0.4, 1],
+      emissive: band === "critical" ? [0.12, 0.03, 0.02] : [0.04, 0.02, 0.01],
+      scale: [1.6, 1.9, 1.6],
+      layer: 3,
+      renderOrder: 3,
+      roughness: 0.82,
+      metallic: 0.08
+    };
+  }
+
+  if (kind === "Companion") {
+    return {
+      mesh: "spirit-companion",
+      material: `summon-shell:${band}:${entity.metadata.speciesId ?? "companion"}`,
+      tint: [0.42, 0.88, 0.74, 1],
+      emissive: [0.06, 0.16, 0.12],
+      scale: [1.0, 1.35, 1.0],
+      layer: 4,
+      renderOrder: 4,
+      roughness: 0.42,
+      metallic: 0.12
+    };
+  }
+
+  if (kind === "Npc") {
+    return {
+      mesh: "adventurer-avatar",
+      material: `npc-cloth:${band}:${entity.metadata.combatStyle ?? "Melee"}`,
+      tint:
+        band === "critical"
+          ? [0.82, 0.38, 0.34, 1]
+          : teamTint(entity.metadata.teamId, false),
+      emissive: [0.02, 0.03, 0.05],
+      scale: [1.1, 1.9, 1.1],
+      layer: 5,
+      renderOrder: 5,
+      roughness: 0.66,
+      metallic: 0.08
+    };
+  }
 
   if (label.includes("wall")) {
     return {
@@ -1424,14 +1713,15 @@ function entityRenderProfile(
   }
 
   if (
-    label.includes("monster") ||
-    label.includes("creature") ||
-    label.includes("beast") ||
-    label.includes("npc")
+    kind === "Unknown" &&
+    (label.includes("monster") ||
+      label.includes("creature") ||
+      label.includes("beast") ||
+      label.includes("npc"))
   ) {
     return {
-      mesh: "rift-beast",
-      material: `rift-hide:${band}`,
+      mesh: label.includes("npc") ? "adventurer-avatar" : "rift-beast",
+      material: label.includes("npc") ? `npc-cloth:${band}:legacy` : `rift-hide:${band}:legacy`,
       tint:
         band === "critical"
           ? [0.86, 0.34, 0.28, 1]
@@ -1439,48 +1729,46 @@ function entityRenderProfile(
             ? [0.82, 0.56, 0.34, 1]
             : [0.72, 0.52, 0.4, 1],
       emissive: band === "critical" ? [0.12, 0.03, 0.02] : [0.04, 0.02, 0.01],
-      scale: [1.6, 1.9, 1.6],
-      layer: 2,
-      renderOrder: 2,
+      scale: label.includes("npc") ? [1.1, 1.9, 1.1] : [1.6, 1.9, 1.6],
+      layer: label.includes("npc") ? 5 : 3,
+      renderOrder: label.includes("npc") ? 5 : 3,
       roughness: 0.82,
       metallic: 0.08
     };
   }
 
   if (
-    label.includes("companion") ||
-    label.includes("pet") ||
-    label.includes("summon") ||
-    label.includes("spirit")
+    kind === "Unknown" &&
+    (label.includes("companion") ||
+      label.includes("pet") ||
+      label.includes("summon") ||
+      label.includes("spirit"))
   ) {
     return {
       mesh: "spirit-companion",
-      material: `summon-shell:${band}`,
+      material: `summon-shell:${band}:legacy`,
       tint: [0.42, 0.88, 0.74, 1],
       emissive: [0.06, 0.16, 0.12],
       scale: [1.0, 1.35, 1.0],
-      layer: 3,
-      renderOrder: 3,
+      layer: 4,
+      renderOrder: 4,
       roughness: 0.42,
       metallic: 0.12
     };
   }
-
-  const isControlled = controlledEntity != null && entity.id === controlledEntity;
   return {
     mesh: isControlled ? "adventurer-hero" : "adventurer-avatar",
-    material: `traveler-cloth:${band}:${isControlled ? "hero" : "party"}`,
-    tint: isControlled
-      ? [0.92, 0.84, 0.58, 1]
-      : band === "critical"
+    material: `traveler-cloth:${band}:${isControlled ? "hero" : kind.toLowerCase()}`,
+    tint:
+      band === "critical"
         ? [0.82, 0.38, 0.34, 1]
         : band === "wounded"
           ? [0.44, 0.76, 0.92, 1]
-          : [0.36, 0.66, 0.88, 1],
+          : teamTint(entity.metadata.teamId, isControlled),
     emissive: isControlled ? [0.08, 0.06, 0.02] : [0.02, 0.03, 0.05],
     scale: isControlled ? [1.2, 2.0, 1.2] : [1.05, 1.85, 1.05],
-    layer: 4,
-    renderOrder: 4,
+    layer: 6,
+    renderOrder: 6,
     roughness: 0.64,
     metallic: 0.08
   };

--- a/apps/pod-web/src/main.ts
+++ b/apps/pod-web/src/main.ts
@@ -261,6 +261,12 @@ function targetableEntities(): NetworkEntitySnapshot[] {
   return latestSnapshot.entities
     .filter((entity) => entity.id !== selfId)
     .filter((entity) => {
+      if (entity.metadata.kind === "Scenery") {
+        return false;
+      }
+      if (entity.metadata.kind !== "Unknown") {
+        return true;
+      }
       const label = entity.label?.toLowerCase() ?? "";
       return !label.includes("wall") && !label.includes("obstacle");
     })

--- a/crates/pod-net/src/client_native.rs
+++ b/crates/pod-net/src/client_native.rs
@@ -885,6 +885,7 @@ mod tests {
                 max_health: None,
                 movement_speed: Some(120.0),
                 label: Some("player".into()),
+                metadata: crate::snapshot::EntityMetadataSnapshot::default(),
             }],
         };
         let predicted = WorldSnapshot {
@@ -898,6 +899,7 @@ mod tests {
                 max_health: None,
                 movement_speed: Some(120.0),
                 label: Some("player".into()),
+                metadata: crate::snapshot::EntityMetadataSnapshot::default(),
             }],
         };
         let mut render_buffer = SnapshotInterpolationBuffer::default();

--- a/crates/pod-net/src/client_stdb.rs
+++ b/crates/pod-net/src/client_stdb.rs
@@ -60,8 +60,9 @@ use pod_stdb::types::{
 use crate::protocol::{ClientId, ReconnectToken, ServerMessage};
 use crate::snapshot::{
     build_catch_up_diagnostics, build_rollback_preview, compose_presentation_snapshot,
-    CatchUpDiagnostics, EntitySnapshot, InterpolatedSnapshot, RecoveryRequestState, RenderClock,
-    RollbackPreview, SnapshotInterpolationBuffer, StateDelta, WorldSnapshot,
+    CatchUpDiagnostics, EntityMetadataSnapshot, EntitySnapshot, InterpolatedSnapshot,
+    RecoveryRequestState, RenderClock, RollbackPreview, SnapshotInterpolationBuffer, StateDelta,
+    WorldSnapshot,
 };
 
 // ============================================================
@@ -1013,6 +1014,10 @@ fn entity_to_snapshot(cached: &CachedEntity) -> EntitySnapshot {
         max_health: cached.max_health,
         movement_speed: cached.max_speed,
         label: cached.name.clone(),
+        metadata: EntityMetadataSnapshot {
+            team_id: cached.team_id,
+            ..EntityMetadataSnapshot::default()
+        },
     }
 }
 
@@ -1526,6 +1531,7 @@ mod tests {
                 max_health: Some(100.0),
                 movement_speed: Some(120.0),
                 label: Some("player".into()),
+                metadata: EntityMetadataSnapshot::default(),
             }],
         });
         client.ingest_local_snapshot();
@@ -1551,6 +1557,7 @@ mod tests {
                 max_health: None,
                 movement_speed: Some(90.0),
                 label: Some("npc".into()),
+                metadata: EntityMetadataSnapshot::default(),
             }],
         });
         client.ingest_local_snapshot();

--- a/crates/pod-net/src/lib.rs
+++ b/crates/pod-net/src/lib.rs
@@ -68,10 +68,11 @@ pub use protocol::{
 };
 pub use snapshot::{
     apply_authoritative_update, build_catch_up_diagnostics, build_rollback_preview,
-    compose_presentation_snapshot, CatchUpDiagnostics, EntityDrift, EntitySnapshot,
-    InterpolatedSnapshot, InterpolationConfig, PredictedActionBatch, ReconciliationReport,
-    RecoveryRequestState, RenderClock, RollbackPreview, SnapshotInterpolationBuffer,
-    SnapshotSampleMode, SnapshotUpdateError, StateDelta, WorldSnapshot,
+    compose_presentation_snapshot, CatchUpDiagnostics, EntityDrift, EntityInteractionHints,
+    EntityKind, EntityMetadataSnapshot, EntitySnapshot, InterpolatedSnapshot, InterpolationConfig,
+    PredictedActionBatch, ReconciliationReport, RecoveryRequestState, RenderClock, RollbackPreview,
+    SnapshotInterpolationBuffer, SnapshotSampleMode, SnapshotUpdateError, StateDelta,
+    WorldSnapshot,
 };
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/pod-net/src/snapshot.rs
+++ b/crates/pod-net/src/snapshot.rs
@@ -5,9 +5,12 @@
 
 use glam::Vec2;
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 
-use pod_core::{Action, Health, Label, Movement, Transform, Velocity};
+use pod_core::{
+    Action, CombatLoadout, CombatStyle, CreatureIdentity, EncounterKind, EncounterState, Health,
+    Label, LootContainer, Movement, ResourceNode, SkillKind, Team, Transform, Velocity,
+};
 
 const FIXED_TICK_DURATION_SECS: f32 = 1.0 / 60.0;
 const DEFAULT_PREDICTION_MOVE_SPEED: f32 = 200.0;
@@ -45,6 +48,49 @@ pub struct EntitySnapshot {
     pub movement_speed: Option<f32>,
     /// Entity label/name
     pub label: Option<String>,
+    /// Authoritative gameplay metadata used by browser/editor consumers.
+    pub metadata: EntityMetadataSnapshot,
+}
+
+/// Coarse authoritative classification for world entities.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum EntityKind {
+    #[default]
+    Unknown,
+    Player,
+    Npc,
+    WildCreature,
+    Companion,
+    ResourceNode,
+    LootContainer,
+    Scenery,
+}
+
+/// Action affordances exposed to creator/browser tooling from authoritative state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct EntityInteractionHints {
+    pub can_inspect: bool,
+    pub can_interact: bool,
+    pub can_attack: bool,
+    pub can_gather: bool,
+    pub can_loot: bool,
+    pub can_capture: bool,
+    pub can_command_companion: bool,
+    pub can_chat: bool,
+}
+
+/// Rich per-entity metadata for browser/editor presentation and creator tooling.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct EntityMetadataSnapshot {
+    pub kind: EntityKind,
+    pub team_id: Option<u8>,
+    pub combat_style: Option<CombatStyle>,
+    pub species_id: Option<String>,
+    pub species_name: Option<String>,
+    pub resource_skill: Option<SkillKind>,
+    pub resource_tier: Option<u8>,
+    pub encounter_kind: Option<EncounterKind>,
+    pub interaction: EntityInteractionHints,
 }
 
 /// Efficient delta — only changed entities
@@ -424,26 +470,74 @@ impl WorldSnapshot {
     /// Capture current world state into a snapshot
     pub fn capture(world: &pod_core::World) -> Self {
         let mut entities = Vec::new();
+        let controlled_entities = world
+            .agents
+            .iter()
+            .filter_map(|slot| slot.entity_id.map(|entity| entity.id() as u64))
+            .collect::<HashSet<_>>();
 
-        for (entity, (transform, velocity)) in world.ecs.query::<(&Transform, &Velocity)>().iter() {
+        for (entity, (transform,)) in world.ecs.query::<(&Transform,)>().iter() {
             let id = entity.id();
+            let velocity = world
+                .ecs
+                .get::<&Velocity>(entity)
+                .map(|velocity| velocity.linear)
+                .unwrap_or(Vec2::ZERO);
             let health_opt = world.ecs.get::<&Health>(entity).ok();
             let label_opt = world.ecs.get::<&Label>(entity).ok();
+            let combat_loadout = world.ecs.get::<&CombatLoadout>(entity).ok();
+            let creature = world.ecs.get::<&CreatureIdentity>(entity).ok();
+            let resource = world.ecs.get::<&ResourceNode>(entity).ok();
+            let loot = world.ecs.get::<&LootContainer>(entity).ok();
+            let encounter = world.ecs.get::<&EncounterState>(entity).ok();
 
             let health = health_opt.as_ref().map(|h| h.current);
             let max_health = health_opt.as_ref().map(|h| h.max);
             let movement_speed = world.ecs.get::<&Movement>(entity).ok().map(|m| m.max_speed);
-            let label = label_opt.map(|l| l.name.clone());
+            let label = label_opt.as_ref().map(|label| label.name.clone());
+            let team_id = label_opt.as_ref().and_then(|label| team_to_id(label.team));
+            let kind = classify_entity_kind(
+                id as u64,
+                &controlled_entities,
+                resource.is_some(),
+                loot.is_some(),
+                creature.as_deref(),
+                combat_loadout.as_deref(),
+                health_opt.as_deref(),
+            );
+            let interaction = interaction_hints_for_entity(
+                kind,
+                resource.as_deref(),
+                loot.as_deref(),
+                creature.as_deref(),
+                combat_loadout.as_deref(),
+                health_opt.as_deref(),
+            );
 
             entities.push(EntitySnapshot {
                 id: id as u64,
                 position: transform.position,
-                velocity: velocity.linear,
+                velocity,
                 rotation: transform.rotation,
                 health,
                 max_health,
                 movement_speed,
                 label,
+                metadata: EntityMetadataSnapshot {
+                    kind,
+                    team_id,
+                    combat_style: combat_loadout.as_ref().map(|loadout| loadout.style),
+                    species_id: creature
+                        .as_ref()
+                        .map(|creature| creature.species_id.clone()),
+                    species_name: creature
+                        .as_ref()
+                        .map(|creature| creature.species_name.clone()),
+                    resource_skill: resource.as_ref().map(|resource| resource.skill),
+                    resource_tier: resource.as_ref().map(|resource| resource.tier),
+                    encounter_kind: encounter.as_ref().map(|encounter| encounter.kind),
+                    interaction,
+                },
             });
         }
 
@@ -488,6 +582,7 @@ impl WorldSnapshot {
             hash_option_f32(&mut hash, entity.max_health);
             hash_option_f32(&mut hash, entity.movement_speed);
             hash_option_str(&mut hash, entity.label.as_deref());
+            hash_entity_metadata(&mut hash, &entity.metadata);
         }
 
         hash
@@ -608,6 +703,7 @@ fn entity_changed(old: &EntitySnapshot, new: &EntitySnapshot) -> bool {
         || old.max_health != new.max_health
         || old.movement_speed != new.movement_speed
         || old.label != new.label
+        || old.metadata != new.metadata
 }
 
 /// Applies an authoritative state update and validates its digest.
@@ -801,6 +897,11 @@ fn interpolate_entity(
         } else {
             upper.label.clone()
         },
+        metadata: if factor < 1.0 && lower.metadata == upper.metadata {
+            lower.metadata.clone()
+        } else {
+            upper.metadata.clone()
+        },
     }
 }
 
@@ -927,15 +1028,238 @@ fn hash_option_str(hash: &mut u64, value: Option<&str>) {
     }
 }
 
+fn hash_bool(hash: &mut u64, value: bool) {
+    hash_u64(hash, value as u64);
+}
+
+fn hash_option_u8(hash: &mut u64, value: Option<u8>) {
+    match value {
+        Some(value) => {
+            hash_u64(hash, 1);
+            hash_u64(hash, value as u64);
+        }
+        None => hash_u64(hash, 0),
+    }
+}
+
+fn hash_entity_metadata(hash: &mut u64, metadata: &EntityMetadataSnapshot) {
+    hash_option_str(hash, Some(entity_kind_name(metadata.kind)));
+    hash_option_u8(hash, metadata.team_id);
+    hash_option_str(hash, metadata.combat_style.map(combat_style_name));
+    hash_option_str(hash, metadata.species_id.as_deref());
+    hash_option_str(hash, metadata.species_name.as_deref());
+    hash_option_str(hash, metadata.resource_skill.map(skill_kind_name));
+    hash_option_u8(hash, metadata.resource_tier);
+    hash_option_str(hash, metadata.encounter_kind.map(encounter_kind_name));
+    hash_bool(hash, metadata.interaction.can_inspect);
+    hash_bool(hash, metadata.interaction.can_interact);
+    hash_bool(hash, metadata.interaction.can_attack);
+    hash_bool(hash, metadata.interaction.can_gather);
+    hash_bool(hash, metadata.interaction.can_loot);
+    hash_bool(hash, metadata.interaction.can_capture);
+    hash_bool(hash, metadata.interaction.can_command_companion);
+    hash_bool(hash, metadata.interaction.can_chat);
+}
+
+fn team_to_id(team: Team) -> Option<u8> {
+    match team {
+        Team::None => None,
+        Team::Team(id) => Some(id),
+    }
+}
+
+fn classify_entity_kind(
+    entity_id: u64,
+    controlled_entities: &HashSet<u64>,
+    has_resource: bool,
+    has_loot: bool,
+    creature: Option<&CreatureIdentity>,
+    combat_loadout: Option<&CombatLoadout>,
+    health: Option<&Health>,
+) -> EntityKind {
+    if has_resource {
+        EntityKind::ResourceNode
+    } else if has_loot {
+        EntityKind::LootContainer
+    } else if let Some(creature) = creature {
+        if creature.is_wild {
+            EntityKind::WildCreature
+        } else {
+            EntityKind::Companion
+        }
+    } else if controlled_entities.contains(&entity_id) {
+        EntityKind::Player
+    } else if combat_loadout.is_some() || health.is_some() {
+        EntityKind::Npc
+    } else {
+        EntityKind::Scenery
+    }
+}
+
+fn interaction_hints_for_entity(
+    kind: EntityKind,
+    resource: Option<&ResourceNode>,
+    loot: Option<&LootContainer>,
+    creature: Option<&CreatureIdentity>,
+    combat_loadout: Option<&CombatLoadout>,
+    health: Option<&Health>,
+) -> EntityInteractionHints {
+    let has_health = health.map(|health| health.current > 0.0).unwrap_or(false);
+    let can_attack = matches!(
+        kind,
+        EntityKind::Player | EntityKind::Npc | EntityKind::WildCreature | EntityKind::Companion
+    ) && (combat_loadout.is_some() || has_health);
+
+    EntityInteractionHints {
+        can_inspect: !matches!(kind, EntityKind::Unknown),
+        can_interact: matches!(kind, EntityKind::Player | EntityKind::Npc),
+        can_attack,
+        can_gather: resource
+            .map(|resource| resource.remaining_uses > 0)
+            .unwrap_or(false),
+        can_loot: loot
+            .map(|loot| !loot.claimed && (loot.coins > 0 || !loot.items.is_empty()))
+            .unwrap_or(false),
+        can_capture: creature.map(|creature| creature.is_wild).unwrap_or(false),
+        can_command_companion: matches!(kind, EntityKind::Companion),
+        can_chat: matches!(kind, EntityKind::Player | EntityKind::Npc),
+    }
+}
+
+fn entity_kind_name(kind: EntityKind) -> &'static str {
+    match kind {
+        EntityKind::Unknown => "unknown",
+        EntityKind::Player => "player",
+        EntityKind::Npc => "npc",
+        EntityKind::WildCreature => "wild_creature",
+        EntityKind::Companion => "companion",
+        EntityKind::ResourceNode => "resource_node",
+        EntityKind::LootContainer => "loot_container",
+        EntityKind::Scenery => "scenery",
+    }
+}
+
+fn combat_style_name(style: CombatStyle) -> &'static str {
+    match style {
+        CombatStyle::Melee => "melee",
+        CombatStyle::Ranged => "ranged",
+        CombatStyle::Magic => "magic",
+        CombatStyle::Summoning => "summoning",
+    }
+}
+
+fn skill_kind_name(skill: SkillKind) -> &'static str {
+    match skill {
+        SkillKind::Attack => "attack",
+        SkillKind::Strength => "strength",
+        SkillKind::Defence => "defence",
+        SkillKind::Ranged => "ranged",
+        SkillKind::Magic => "magic",
+        SkillKind::Constitution => "constitution",
+        SkillKind::Mining => "mining",
+        SkillKind::Woodcutting => "woodcutting",
+        SkillKind::Fishing => "fishing",
+        SkillKind::Cooking => "cooking",
+        SkillKind::Smithing => "smithing",
+        SkillKind::Crafting => "crafting",
+        SkillKind::Slayer => "slayer",
+        SkillKind::Taming => "taming",
+        SkillKind::Bonding => "bonding",
+    }
+}
+
+fn encounter_kind_name(kind: EncounterKind) -> &'static str {
+    match kind {
+        EncounterKind::OpenWorld => "open_world",
+        EncounterKind::Duel => "duel",
+        EncounterKind::WildCreature => "wild_creature",
+        EncounterKind::Boss => "boss",
+        EncounterKind::Raid => "raid",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pod_core::{CombatLoadout, CreatureIdentity, IdleAgent, LootContainer, ResourceNode};
 
     #[test]
     fn test_snapshot_default() {
         let snap = WorldSnapshot::default();
         assert_eq!(snap.tick, 0);
         assert_eq!(snap.entity_count(), 0);
+    }
+
+    #[test]
+    fn test_capture_includes_static_entities_and_authoritative_metadata() {
+        let mut world = pod_core::World::new(7);
+        let _ = world.add_agent(Box::new(IdleAgent::new()));
+        world
+            .spawn_at(32.0, 12.0)
+            .with_label("Copper Vein", Team::None)
+            .with_resource_node(ResourceNode::default())
+            .build();
+        world
+            .spawn_at(36.0, 16.0)
+            .with_label("Bronze Chest", Team::None)
+            .with_loot_container(LootContainer {
+                coins: 24,
+                ..LootContainer::default()
+            })
+            .build();
+        world
+            .spawn_at(40.0, 20.0)
+            .with_label("Wild Embercub", Team::None)
+            .with_health(24.0)
+            .with_combat_loadout(CombatLoadout::default())
+            .with_creature_identity(CreatureIdentity {
+                species_id: "embercub".into(),
+                species_name: "Wild Embercub".into(),
+                is_wild: true,
+                ..CreatureIdentity::default()
+            })
+            .build();
+
+        let snapshot = WorldSnapshot::capture(&world);
+
+        assert_eq!(snapshot.entities.len(), 4);
+
+        let player = snapshot
+            .entities
+            .iter()
+            .find(|entity| entity.metadata.kind == EntityKind::Player)
+            .expect("player entity present");
+        assert!(player.metadata.interaction.can_chat);
+        assert!(player.metadata.interaction.can_attack);
+
+        let resource = snapshot
+            .entities
+            .iter()
+            .find(|entity| entity.label.as_deref() == Some("Copper Vein"))
+            .expect("resource present");
+        assert_eq!(resource.metadata.kind, EntityKind::ResourceNode);
+        assert_eq!(resource.metadata.resource_skill, Some(SkillKind::Mining));
+        assert!(resource.metadata.interaction.can_gather);
+
+        let loot = snapshot
+            .entities
+            .iter()
+            .find(|entity| entity.label.as_deref() == Some("Bronze Chest"))
+            .expect("loot present");
+        assert_eq!(loot.metadata.kind, EntityKind::LootContainer);
+        assert!(loot.metadata.interaction.can_loot);
+
+        let creature = snapshot
+            .entities
+            .iter()
+            .find(|entity| entity.metadata.kind == EntityKind::WildCreature)
+            .expect("wild creature present");
+        assert_eq!(creature.metadata.species_id.as_deref(), Some("embercub"));
+        assert_eq!(
+            creature.metadata.species_name.as_deref(),
+            Some("Wild Embercub")
+        );
+        assert!(creature.metadata.interaction.can_capture);
     }
 
     #[test]
@@ -950,6 +1274,7 @@ mod tests {
             max_health: Some(100.0),
             movement_speed: Some(200.0),
             label: Some("Player".into()),
+            metadata: EntityMetadataSnapshot::default(),
         });
 
         let mut snap2 = WorldSnapshot::default();
@@ -962,6 +1287,7 @@ mod tests {
             max_health: Some(100.0),
             movement_speed: Some(200.0),
             label: Some("Player".into()),
+            metadata: EntityMetadataSnapshot::default(),
         });
 
         let delta = StateDelta::diff(&snap1, &snap2);
@@ -981,6 +1307,7 @@ mod tests {
             max_health: None,
             movement_speed: None,
             label: None,
+            metadata: EntityMetadataSnapshot::default(),
         });
 
         let delta = StateDelta {
@@ -994,6 +1321,7 @@ mod tests {
                 max_health: None,
                 movement_speed: None,
                 label: None,
+                metadata: EntityMetadataSnapshot::default(),
             }],
             destroyed: vec![],
         };
@@ -1014,6 +1342,7 @@ mod tests {
             max_health: None,
             movement_speed: Some(200.0),
             label: Some("sprite2d".into()),
+            metadata: EntityMetadataSnapshot::default(),
         });
 
         let mut snap2 = WorldSnapshot::default();
@@ -1026,6 +1355,7 @@ mod tests {
             max_health: None,
             movement_speed: Some(200.0),
             label: Some("sprite2d".into()),
+            metadata: EntityMetadataSnapshot::default(),
         });
 
         let delta = StateDelta::diff(&snap1, &snap2);
@@ -1045,6 +1375,7 @@ mod tests {
             max_health: Some(100.0),
             movement_speed: Some(200.0),
             label: Some("sprite2d".into()),
+            metadata: EntityMetadataSnapshot::default(),
         });
 
         let mut next = WorldSnapshot::default();
@@ -1057,6 +1388,7 @@ mod tests {
             max_health: Some(100.0),
             movement_speed: Some(200.0),
             label: Some("sprite3d".into()),
+            metadata: EntityMetadataSnapshot::default(),
         });
 
         let delta = StateDelta::diff(&base, &next);
@@ -1088,6 +1420,7 @@ mod tests {
             max_health: Some(100.0),
             movement_speed: None,
             label: Some("keep".into()),
+            metadata: EntityMetadataSnapshot::default(),
         });
         base.entities.push(EntitySnapshot {
             id: 11,
@@ -1098,6 +1431,7 @@ mod tests {
             max_health: Some(50.0),
             movement_speed: None,
             label: Some("to_remove".into()),
+            metadata: EntityMetadataSnapshot::default(),
         });
 
         let delta = StateDelta {
@@ -1111,6 +1445,7 @@ mod tests {
                 max_health: Some(100.0),
                 movement_speed: None,
                 label: Some("updated".into()),
+                metadata: EntityMetadataSnapshot::default(),
             }],
             destroyed: vec![11, 99_999],
         };
@@ -1142,6 +1477,7 @@ mod tests {
             max_health: Some(20.0),
             movement_speed: Some(200.0),
             label: Some("a".into()),
+            metadata: EntityMetadataSnapshot::default(),
         };
         let entity_b = EntitySnapshot {
             id: 2,
@@ -1152,6 +1488,7 @@ mod tests {
             max_health: None,
             movement_speed: None,
             label: Some("b".into()),
+            metadata: EntityMetadataSnapshot::default(),
         };
 
         let snapshot_a = WorldSnapshot {
@@ -1179,6 +1516,7 @@ mod tests {
                 max_health: None,
                 movement_speed: Some(120.0),
                 label: Some("player".into()),
+                metadata: EntityMetadataSnapshot::default(),
             }],
         };
 
@@ -1217,6 +1555,7 @@ mod tests {
                 max_health: None,
                 movement_speed: None,
                 label: Some("old".into()),
+                metadata: EntityMetadataSnapshot::default(),
             }],
         });
         buffer.push(WorldSnapshot {
@@ -1230,6 +1569,7 @@ mod tests {
                 max_health: None,
                 movement_speed: None,
                 label: Some("new".into()),
+                metadata: EntityMetadataSnapshot::default(),
             }],
         });
 
@@ -1254,6 +1594,7 @@ mod tests {
                 max_health: Some(100.0),
                 movement_speed: Some(120.0),
                 label: Some("player".into()),
+                metadata: EntityMetadataSnapshot::default(),
             }],
         });
         buffer.push(WorldSnapshot {
@@ -1267,6 +1608,7 @@ mod tests {
                 max_health: Some(100.0),
                 movement_speed: Some(160.0),
                 label: Some("player".into()),
+                metadata: EntityMetadataSnapshot::default(),
             }],
         });
 
@@ -1295,6 +1637,7 @@ mod tests {
                 max_health: None,
                 movement_speed: Some(60.0),
                 label: Some("npc".into()),
+                metadata: EntityMetadataSnapshot::default(),
             }],
         });
 
@@ -1323,6 +1666,7 @@ mod tests {
                 max_health: None,
                 movement_speed: None,
                 label: None,
+                metadata: EntityMetadataSnapshot::default(),
             }],
         });
 
@@ -1381,6 +1725,7 @@ mod tests {
                 max_health: None,
                 movement_speed: Some(120.0),
                 label: Some("player".into()),
+                metadata: EntityMetadataSnapshot::default(),
             }],
         });
         buffer.push(WorldSnapshot {
@@ -1394,6 +1739,7 @@ mod tests {
                 max_health: None,
                 movement_speed: Some(120.0),
                 label: Some("player".into()),
+                metadata: EntityMetadataSnapshot::default(),
             }],
         });
 
@@ -1455,6 +1801,7 @@ mod tests {
                 max_health: Some(10.0),
                 movement_speed: Some(120.0),
                 label: Some("player".into()),
+                metadata: EntityMetadataSnapshot::default(),
             }],
         };
         let predicted = WorldSnapshot {
@@ -1468,6 +1815,7 @@ mod tests {
                 max_health: Some(10.0),
                 movement_speed: Some(120.0),
                 label: Some("player".into()),
+                metadata: EntityMetadataSnapshot::default(),
             }],
         };
         let mut buffer = SnapshotInterpolationBuffer::default();
@@ -1555,6 +1903,7 @@ mod tests {
                         max_health: None,
                         movement_speed: Some(120.0),
                         label: Some("player".into()),
+                        metadata: EntityMetadataSnapshot::default(),
                     },
                     EntitySnapshot {
                         id: 2,
@@ -1565,6 +1914,7 @@ mod tests {
                         max_health: None,
                         movement_speed: None,
                         label: Some("npc".into()),
+                        metadata: EntityMetadataSnapshot::default(),
                     },
                 ],
             },
@@ -1580,6 +1930,7 @@ mod tests {
                 max_health: None,
                 movement_speed: Some(120.0),
                 label: Some("player".into()),
+                metadata: EntityMetadataSnapshot::default(),
             }],
         };
 
@@ -1621,6 +1972,7 @@ mod tests {
                 max_health: Some(10.0),
                 movement_speed: Some(200.0),
                 label: Some("player".into()),
+                metadata: EntityMetadataSnapshot::default(),
             }],
             destroyed: vec![],
         };


### PR DESCRIPTION
## Summary
- add authoritative entity metadata to pod-net snapshots and include static world entities in capture
- teach pod-web targeting, summaries, and render planning to consume metadata first instead of guessing from labels
- add deterministic Rust and Bun coverage for metadata capture, parsing, and affordances

## Validation
- cargo test -p pod-net --lib
- cd apps/pod-web && bun test
- cd apps/pod-web && bun run typecheck
- cd apps/pod-web && bun run build
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Entity metadata system provides authoritative type information and interaction hints, improving entity descriptions, rendering accuracy, and targeting logic.

* **Documentation**
  * Updated implementation plan to reflect Iteration 75 completion and outline Iteration 76 browser-first rendering strategy.

* **Tests**
  * Enhanced test coverage for metadata-driven entity descriptions, affordances, interactions, and entity categorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->