### PR TITLE
Optimize pod-web asset residency and bundling

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -723,5 +723,17 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cd apps/pod-web && bun run build`
   - `git diff --check`
 
-**Last updated**: Iteration 76
-**Current focus**: Iteration 77 browser-first flagship world delivery, continuing with chunk-streamed asset residency, worker/offscreen render execution, and replacing emulated SpacetimeDB client paths with generated typed bindings
+### Iteration 77
+- [x] Added parallel asset prewarming to `PodThreeWorldRenderer` so unique mesh and sprite assets resolve concurrently before the instanced sync path instead of serializing one loader await at a time through the render loop.
+- [x] Added manifest-registry residency metrics (`resident` / `pending` geometry and sprite assets) and surfaced them in the browser HUD stats row for creator-facing runtime inspection.
+- [x] Added deterministic Bun coverage for deduplicated mesh prefetch and residency accounting in the manifest-backed asset registry.
+- [x] Updated `apps/pod-web` Vite config to pre-optimize the dynamic Three.js loader paths and assign stable chunk names for the heavy runtime/vendor modules, reducing main-entry bundle pressure and eliminating the dev-session dependency waterfall after first loader use.
+- [x] Validated touched targets:
+  - `cd apps/pod-web && bun test`
+  - `cd apps/pod-web && bun run typecheck`
+  - `cd apps/pod-web && bun run build`
+  - live browser smoke via Playwright against `bun run dev --host 127.0.0.1 --port 4173`
+  - `git diff --check`
+
+**Last updated**: Iteration 77
+**Current focus**: Iteration 78 browser-first flagship world delivery, continuing with chunk-streamed asset residency beyond the in-memory manifest cache, worker/offscreen render execution, and replacing emulated SpacetimeDB client paths with generated typed bindings

--- a/apps/pod-web/README.md
+++ b/apps/pod-web/README.md
@@ -10,6 +10,7 @@ It consumes the `pod-render` browser frame contract and provides:
 - billboard sprite batches with transparent depth-order preservation
 - CPU-side frustum and distance culling before instance upload
 - adaptive resolution scaling and quality presets for different hardware classes
+- parallel mesh/texture prewarming with live asset residency stats in the HUD
 - ACES tone mapping, tuned shadows, cached materials, and a richer atmospheric scene baseline
 - a 2D overlay scene for the legacy `RenderFrame` contract
 - a demo bridge via `window.podRender.*` so the app is useful before the Rust wasm entrypoint is wired in

--- a/apps/pod-web/src/assets.test.ts
+++ b/apps/pod-web/src/assets.test.ts
@@ -262,4 +262,36 @@ describe("ManifestBackedPodThreeAssetRegistry", () => {
     expect(paths).toEqual(["/assets/textures/selection-ring.svg:none"]);
     expect(resolved.texture.colorSpace).toBe(NoColorSpace);
   });
+
+  test("prefetches unique mesh assets in parallel and reports residency", async () => {
+    const loadedPaths: string[] = [];
+    const registry = new ManifestBackedPodThreeAssetRegistry({
+      manifest,
+      fallbackRegistry: new DefaultPodThreeAssetRegistry(),
+      geometryLoader: {
+        async load(path: string) {
+          loadedPaths.push(path);
+          return new SphereGeometry(1.2, 6, 4);
+        }
+      },
+      textureLoader: {
+        async load() {
+          return new Texture();
+        }
+      }
+    });
+
+    await registry.prefetchMeshes?.([
+      { batch: meshBatch({ mesh: "monster" }), lodLevel: 0 },
+      { batch: meshBatch({ mesh: "rift-beast" }), lodLevel: 0 }
+    ]);
+
+    expect(loadedPaths).toEqual(["/assets/meshes/rift-beast.gltf"]);
+    expect(registry.getResidencyStats?.()).toEqual({
+      residentGeometryAssets: 1,
+      residentSpriteAssets: 0,
+      pendingGeometryAssets: 0,
+      pendingSpriteAssets: 0
+    });
+  });
 });

--- a/apps/pod-web/src/assets.ts
+++ b/apps/pod-web/src/assets.ts
@@ -43,6 +43,20 @@ export interface PodThreeAssetRegistry {
     batch: Pick<ThreeJsSpriteBatch, "texture" | "frame">,
     anisotropy?: number
   ): ResolvedSpriteTexture | Promise<ResolvedSpriteTexture>;
+  prefetchMeshes?(
+    requests: Array<{ batch: ThreeJsMeshBatch; lodLevel: 0 | 1 | 2 }>
+  ): Promise<void>;
+  prefetchSprites?(
+    requests: Array<{ batch: Pick<ThreeJsSpriteBatch, "texture" | "frame">; anisotropy: number }>
+  ): Promise<void>;
+  getResidencyStats?(): PodThreeAssetResidencyStats;
+}
+
+export interface PodThreeAssetResidencyStats {
+  residentGeometryAssets: number;
+  residentSpriteAssets: number;
+  pendingGeometryAssets: number;
+  pendingSpriteAssets: number;
 }
 
 export type PodThreeAssetCategory =
@@ -186,6 +200,8 @@ export class ManifestBackedPodThreeAssetRegistry implements PodThreeAssetRegistr
   private readonly textureCache = new Map<string, Promise<ResolvedSpriteTexture>>();
   private readonly meshDescriptorCache = new Map<string, PodThreeMeshAssetDescriptor | null>();
   private readonly spriteDescriptorCache = new Map<string, PodThreeSpriteAssetDescriptor | null>();
+  private readonly residentGeometryAssets = new Set<string>();
+  private readonly residentSpriteAssets = new Set<string>();
 
   constructor(private readonly options: ManifestBackedPodThreeAssetRegistryOptions) {
     this.fallbackRegistry = options.fallbackRegistry ?? new DefaultPodThreeAssetRegistry();
@@ -209,8 +225,12 @@ export class ManifestBackedPodThreeAssetRegistry implements PodThreeAssetRegistr
 
     const pending = this.options.geometryLoader.load(assetPath).catch(async (error) => {
       this.geometryCache.delete(cacheKey);
+      this.residentGeometryAssets.delete(cacheKey);
       console.warn(`Falling back to procedural mesh asset for ${batch.mesh}`, error);
       return await Promise.resolve(this.fallbackRegistry.resolveGeometry(batch, lodLevel));
+    });
+    void pending.then(() => {
+      this.residentGeometryAssets.add(cacheKey);
     });
     this.geometryCache.set(cacheKey, pending);
     return pending;
@@ -235,11 +255,59 @@ export class ManifestBackedPodThreeAssetRegistry implements PodThreeAssetRegistr
 
     const pending = this.loadSpriteTexture(descriptor, assetPath, anisotropy).catch(async (error) => {
       this.textureCache.delete(cacheKey);
+      this.residentSpriteAssets.delete(cacheKey);
       console.warn(`Falling back to procedural sprite asset for ${batch.texture}`, error);
       return await Promise.resolve(this.fallbackRegistry.resolveSpriteTexture(batch, anisotropy));
     });
+    void pending.then(() => {
+      this.residentSpriteAssets.add(cacheKey);
+    });
     this.textureCache.set(cacheKey, pending);
     return pending;
+  }
+
+  async prefetchMeshes(
+    requests: Array<{ batch: ThreeJsMeshBatch; lodLevel: 0 | 1 | 2 }>
+  ): Promise<void> {
+    const tasks = dedupeBy(
+      requests.map(({ batch, lodLevel }) => ({
+        cacheKey: `${this.meshCachePath(batch.mesh, lodLevel) ?? batch.mesh}|lod:${lodLevel}`,
+        batch,
+        lodLevel
+      })),
+      (entry) => entry.cacheKey
+    ).map(({ batch, lodLevel }) => Promise.resolve(this.resolveGeometry(batch, lodLevel)).then(() => undefined));
+
+    await Promise.all(tasks);
+  }
+
+  async prefetchSprites(
+    requests: Array<{ batch: Pick<ThreeJsSpriteBatch, "texture" | "frame">; anisotropy: number }>
+  ): Promise<void> {
+    const tasks = dedupeBy(
+      requests.map(({ batch, anisotropy }) => ({
+        cacheKey: `${this.spriteCachePath(batch.texture, anisotropy) ?? batch.texture}|anisotropy:${anisotropy}`,
+        batch,
+        anisotropy
+      })),
+      (entry) => entry.cacheKey
+    ).map(({ batch, anisotropy }) =>
+      Promise.resolve(this.resolveSpriteTexture(batch, anisotropy)).then(() => undefined)
+    );
+
+    await Promise.all(tasks);
+  }
+
+  getResidencyStats(): PodThreeAssetResidencyStats {
+    return {
+      residentGeometryAssets: this.residentGeometryAssets.size,
+      residentSpriteAssets: this.residentSpriteAssets.size,
+      pendingGeometryAssets: Math.max(
+        this.geometryCache.size - this.residentGeometryAssets.size,
+        0
+      ),
+      pendingSpriteAssets: Math.max(this.textureCache.size - this.residentSpriteAssets.size, 0)
+    };
   }
 
   private async loadSpriteTexture(
@@ -284,6 +352,21 @@ export class ManifestBackedPodThreeAssetRegistry implements PodThreeAssetRegistr
     const descriptor = resolveManifestSpriteAsset(this.options.manifest, requested);
     this.spriteDescriptorCache.set(cacheKey, descriptor);
     return descriptor;
+  }
+
+  private meshCachePath(requested: string, lodLevel: 0 | 1 | 2): string | null {
+    const descriptor = this.resolveMeshDescriptor(requested);
+    return descriptor ? descriptor.lods?.[lodLevel] ?? descriptor.path : null;
+  }
+
+  private spriteCachePath(requested: string, anisotropy: number): string | null {
+    const descriptor = this.resolveSpriteDescriptor(requested);
+    if (!descriptor) {
+      return null;
+    }
+    return descriptor.ktx2Path && this.options.compressedTextureLoader
+      ? descriptor.ktx2Path
+      : descriptor.path;
   }
 }
 
@@ -756,4 +839,18 @@ function extractPrimaryGeometry(root: { traverse: Mesh["traverse"] }, path: stri
 
 function isRecord(input: unknown): input is Record<string, unknown> {
   return typeof input === "object" && input !== null && !Array.isArray(input);
+}
+
+function dedupeBy<T>(values: T[], keySelector: (value: T) => string): T[] {
+  const seen = new Set<string>();
+  const output: T[] = [];
+  for (const value of values) {
+    const key = keySelector(value);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    output.push(value);
+  }
+  return output;
 }

--- a/apps/pod-web/src/main.ts
+++ b/apps/pod-web/src/main.ts
@@ -646,7 +646,9 @@ async function tick(timestamp: number): Promise<void> {
   const stats = renderer.getStats();
   runtimeStatsLabel.textContent = `${stats.drawCalls} calls · ${stats.triangles} tris · ${stats.pixelRatio.toFixed(
     2
-  )}x DPR · ${stats.frameMs.toFixed(1)}ms`;
+  )}x DPR · ${stats.frameMs.toFixed(1)}ms · assets ${
+    stats.residentGeometryAssets + stats.residentSpriteAssets
+  } resident / ${stats.pendingGeometryAssets + stats.pendingSpriteAssets} pending`;
   renderTelemetryHud();
 
   requestAnimationFrame((nextTimestamp) => {

--- a/apps/pod-web/src/renderer.ts
+++ b/apps/pod-web/src/renderer.ts
@@ -62,6 +62,10 @@ export interface PodThreeRendererStats {
   triangles: number;
   textures: number;
   frameMs: number;
+  residentGeometryAssets: number;
+  residentSpriteAssets: number;
+  pendingGeometryAssets: number;
+  pendingSpriteAssets: number;
 }
 
 export interface PodThreeWorldRendererOptions {
@@ -167,6 +171,7 @@ export class PodThreeWorldRenderer {
       ...planningOptionsFromQuality(this.quality)
     });
     this.applyCamera(planned.camera, frame.camera);
+    await this.prewarmPlannedAssets(planned);
     await this.syncMeshBatches(planned.meshBatches);
     await this.syncSpriteBatches(planned.spriteBatches);
     await this.syncOverlay(frame.overlayCommands);
@@ -503,6 +508,13 @@ export class PodThreeWorldRenderer {
   }
 
   getStats(): PodThreeRendererStats {
+    const residency = this.assetRegistry.getResidencyStats?.() ?? {
+      residentGeometryAssets: 0,
+      residentSpriteAssets: 0,
+      pendingGeometryAssets: 0,
+      pendingSpriteAssets: 0
+    };
+
     return {
       backend: this.backend,
       qualityPreset: this.quality.preset,
@@ -510,8 +522,35 @@ export class PodThreeWorldRenderer {
       drawCalls: this.renderer.info.render.calls,
       triangles: this.renderer.info.render.triangles,
       textures: this.renderer.info.memory.textures,
-      frameMs: Number(this.smoothedFrameMs.toFixed(2))
+      frameMs: Number(this.smoothedFrameMs.toFixed(2)),
+      residentGeometryAssets: residency.residentGeometryAssets,
+      residentSpriteAssets: residency.residentSpriteAssets,
+      pendingGeometryAssets: residency.pendingGeometryAssets,
+      pendingSpriteAssets: residency.pendingSpriteAssets
     };
+  }
+
+  private async prewarmPlannedAssets(
+    planned: ReturnType<typeof buildFramePlan>
+  ): Promise<void> {
+    await Promise.all([
+      this.assetRegistry.prefetchMeshes?.(
+        planned.meshBatches
+          .filter((batch) => batch.visibleCount > 0)
+          .map((batch) => ({ batch: batch.batch, lodLevel: batch.lodLevel }))
+      ),
+      this.assetRegistry.prefetchSprites?.(
+        planned.spriteBatches
+          .filter((batch) => batch.visibleCount > 0)
+          .map((batch) => ({
+            batch: {
+              texture: batch.batch.texture,
+              frame: batch.batch.frame
+            },
+            anisotropy: this.quality.anisotropy
+          }))
+      )
+    ]);
   }
 
   private getOrCreateMeshMaterial(planned: PlannedMeshBatch): THREE.Material {

--- a/apps/pod-web/vite.config.ts
+++ b/apps/pod-web/vite.config.ts
@@ -1,6 +1,37 @@
 import { defineConfig } from "vite";
 
 export default defineConfig({
+  optimizeDeps: {
+    include: [
+      "three/examples/jsm/loaders/GLTFLoader.js",
+      "three/examples/jsm/loaders/KTX2Loader.js",
+      "three/examples/jsm/libs/meshopt_decoder.module.js"
+    ]
+  },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes("three/examples/jsm/loaders/GLTFLoader")) {
+            return "three-gltf-loader";
+          }
+          if (id.includes("three/examples/jsm/loaders/KTX2Loader")) {
+            return "three-ktx2-loader";
+          }
+          if (id.includes("three/examples/jsm/libs/meshopt_decoder")) {
+            return "three-meshopt";
+          }
+          if (id.includes("@toon-format/toon")) {
+            return "toon-format";
+          }
+          if (id.includes("three_webgpu") || id.includes("three/build/three.webgpu")) {
+            return "three-webgpu";
+          }
+          return undefined;
+        }
+      }
+    }
+  },
   server: {
     host: "0.0.0.0",
     port: 4173


### PR DESCRIPTION
## Summary\n- parallelize pod-web asset warming and expose residency stats in the browser HUD\n- add deterministic asset prefetch/residency coverage in the manifest-backed registry\n- pre-optimize dynamic Three.js loader deps and stabilize chunk naming in Vite\n\n## Validation\n- cd apps/pod-web && bun test\n- cd apps/pod-web && bun run typecheck\n- cd apps/pod-web && bun run build\n- live browser smoke via Playwright against bun run dev --host 127.0.0.1 --port 4173\n- git diff --check