### PR TITLE
Add pod-web render worker runtime

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -735,5 +735,17 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - live browser smoke via Playwright against `bun run dev --host 127.0.0.1 --port 4173`
   - `git diff --check`
 
-**Last updated**: Iteration 77
-**Current focus**: Iteration 78 browser-first flagship world delivery, continuing with chunk-streamed asset residency beyond the in-memory manifest cache, worker/offscreen render execution, and replacing emulated SpacetimeDB client paths with generated typed bindings
+### Iteration 78
+- [x] Added a real `OffscreenCanvas` render-worker runtime in `apps/pod-web`, with a dedicated worker module that owns `PodThreeWorldRenderer` off the main thread while keeping the HUD, input, and authoritative socket flow on the main thread.
+- [x] Added a creator-facing render-thread preference (`?renderThread=worker` / `?renderThread=main`) and a safe default of main-thread rendering until broader worker compatibility hardening is complete.
+- [x] Added worker-side render-command coalescing plus live worker stats propagation so the HUD can report `main` vs `worker` thread execution without blocking the gameplay/bootstrap path.
+- [x] Added deterministic Bun coverage for render-thread preference parsing and worker-capability gating.
+- [x] Validated touched targets:
+  - `cd apps/pod-web && bun test`
+  - `cd apps/pod-web && bun run typecheck`
+  - `cd apps/pod-web && bun run build`
+  - live browser smoke via Playwright against `bun run dev --host 127.0.0.1 --port 4173?renderThread=worker`
+  - `git diff --check`
+
+**Last updated**: Iteration 78
+**Current focus**: Iteration 79 browser-first flagship world delivery, continuing with chunk-streamed asset residency beyond the in-memory manifest cache and replacing emulated SpacetimeDB client paths with generated typed bindings

--- a/apps/pod-web/README.md
+++ b/apps/pod-web/README.md
@@ -11,6 +11,7 @@ It consumes the `pod-render` browser frame contract and provides:
 - CPU-side frustum and distance culling before instance upload
 - adaptive resolution scaling and quality presets for different hardware classes
 - parallel mesh/texture prewarming with live asset residency stats in the HUD
+- optional `OffscreenCanvas` render-worker path for creator benchmarking and future main-thread relief
 - ACES tone mapping, tuned shadows, cached materials, and a richer atmospheric scene baseline
 - a 2D overlay scene for the legacy `RenderFrame` contract
 - a demo bridge via `window.podRender.*` so the app is useful before the Rust wasm entrypoint is wired in
@@ -34,6 +35,12 @@ http://127.0.0.1:5173/?server=127.0.0.1:7778&player=WebPlayer&debug=1
 ```
 
 `server` may be `host:port`, `ws://host:port`, or `wss://host:port`.
+
+### Render thread selection
+
+- default: main-thread rendering
+- `?renderThread=worker`: transfers the canvas to a dedicated render worker via `OffscreenCanvas`
+- `?renderThread=main`: forces the existing main-thread path
 
 ### Browser controls
 

--- a/apps/pod-web/src/assets.test.ts
+++ b/apps/pod-web/src/assets.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { BoxGeometry, NoColorSpace, SphereGeometry, Texture } from "three";
 
 import {
+  createProceduralSpriteTexture,
   createMeshMaterial,
   DefaultPodThreeAssetRegistry,
   ManifestBackedPodThreeAssetRegistry,
@@ -61,6 +62,19 @@ describe("createMeshMaterial", () => {
       QUALITY
     );
     expect(material.type).toBe("MeshStandardMaterial");
+  });
+});
+
+describe("createProceduralSpriteTexture", () => {
+  test("creates a worker-safe ring texture for SVG overlay assets", () => {
+    const texture = createProceduralSpriteTexture("/assets/textures/selection-ring.svg");
+    const image = texture.image as { data: Uint8Array; width: number; height: number };
+    const centerIndex = ((Math.floor(image.height / 2) * image.width) + Math.floor(image.width / 2)) * 4 + 3;
+    const ringIndex = ((Math.floor(image.height / 2) * image.width) + Math.floor(image.width * 0.88)) * 4 + 3;
+
+    expect(texture.name).toContain("selection-ring");
+    expect(image.data[centerIndex]).toBeLessThan(32);
+    expect(image.data[ringIndex]).toBeGreaterThan(image.data[centerIndex]);
   });
 });
 
@@ -261,6 +275,48 @@ describe("ManifestBackedPodThreeAssetRegistry", () => {
 
     expect(paths).toEqual(["/assets/textures/selection-ring.svg:none"]);
     expect(resolved.texture.colorSpace).toBe(NoColorSpace);
+  });
+
+  test("keeps a fallback sprite resident after a load failure instead of retrying every frame", async () => {
+    let attempts = 0;
+    const warnings: unknown[][] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args);
+    };
+
+    const registry = new ManifestBackedPodThreeAssetRegistry({
+      manifest,
+      fallbackRegistry: new DefaultPodThreeAssetRegistry(),
+      geometryLoader: {
+        async load() {
+          return new BoxGeometry(1, 1, 1);
+        }
+      },
+      textureLoader: {
+        async load() {
+          attempts += 1;
+          throw new Error("worker image decode failed");
+        }
+      }
+    });
+
+    try {
+      const first = await registry.resolveSpriteTexture({ texture: "selection-ring", frame: 0 }, 2);
+      const second = await registry.resolveSpriteTexture({ texture: "selection-ring", frame: 0 }, 2);
+
+      expect(first.texture).toBe(second.texture);
+      expect(attempts).toBe(1);
+      expect(warnings).toHaveLength(1);
+      expect(registry.getResidencyStats?.()).toEqual({
+        residentGeometryAssets: 0,
+        residentSpriteAssets: 1,
+        pendingGeometryAssets: 0,
+        pendingSpriteAssets: 0
+      });
+    } finally {
+      console.warn = originalWarn;
+    }
   });
 
   test("prefetches unique mesh assets in parallel and reports residency", async () => {

--- a/apps/pod-web/src/assets.ts
+++ b/apps/pod-web/src/assets.ts
@@ -202,6 +202,8 @@ export class ManifestBackedPodThreeAssetRegistry implements PodThreeAssetRegistr
   private readonly spriteDescriptorCache = new Map<string, PodThreeSpriteAssetDescriptor | null>();
   private readonly residentGeometryAssets = new Set<string>();
   private readonly residentSpriteAssets = new Set<string>();
+  private readonly warnedGeometryFallbacks = new Set<string>();
+  private readonly warnedSpriteFallbacks = new Set<string>();
 
   constructor(private readonly options: ManifestBackedPodThreeAssetRegistryOptions) {
     this.fallbackRegistry = options.fallbackRegistry ?? new DefaultPodThreeAssetRegistry();
@@ -224,9 +226,10 @@ export class ManifestBackedPodThreeAssetRegistry implements PodThreeAssetRegistr
     }
 
     const pending = this.options.geometryLoader.load(assetPath).catch(async (error) => {
-      this.geometryCache.delete(cacheKey);
-      this.residentGeometryAssets.delete(cacheKey);
-      console.warn(`Falling back to procedural mesh asset for ${batch.mesh}`, error);
+      if (!this.warnedGeometryFallbacks.has(cacheKey)) {
+        this.warnedGeometryFallbacks.add(cacheKey);
+        console.warn(`Falling back to procedural mesh asset for ${batch.mesh}`, error);
+      }
       return await Promise.resolve(this.fallbackRegistry.resolveGeometry(batch, lodLevel));
     });
     void pending.then(() => {
@@ -254,9 +257,10 @@ export class ManifestBackedPodThreeAssetRegistry implements PodThreeAssetRegistr
     }
 
     const pending = this.loadSpriteTexture(descriptor, assetPath, anisotropy).catch(async (error) => {
-      this.textureCache.delete(cacheKey);
-      this.residentSpriteAssets.delete(cacheKey);
-      console.warn(`Falling back to procedural sprite asset for ${batch.texture}`, error);
+      if (!this.warnedSpriteFallbacks.has(cacheKey)) {
+        this.warnedSpriteFallbacks.add(cacheKey);
+        console.warn(`Falling back to procedural sprite asset for ${batch.texture}`, error);
+      }
       return await Promise.resolve(this.fallbackRegistry.resolveSpriteTexture(batch, anisotropy));
     });
     void pending.then(() => {
@@ -514,7 +518,16 @@ export function createSpriteMaterial(
 export const OVERLAY_PLANE_GEOMETRY = new PlaneGeometry(1, 1);
 export const SPRITE_PLANE_GEOMETRY = new PlaneGeometry(1, 1);
 
-function createRadialTexture(color: [number, number, number]): Texture {
+export function createProceduralSpriteTexture(assetPath: string): Texture {
+  const normalized = normalizeAssetKey(assetPath);
+  const color = spritePalette(assetPath);
+  if (normalized.includes("ring")) {
+    return createRingTexture(color, assetPath);
+  }
+  return createRadialTexture(color, assetPath);
+}
+
+function createRadialTexture(color: [number, number, number], assetPath?: string): Texture {
   const size = 32;
   const pixels = new Uint8Array(size * size * 4);
 
@@ -538,7 +551,40 @@ function createRadialTexture(color: [number, number, number]): Texture {
   texture.colorSpace = SRGBColorSpace;
   texture.wrapS = RepeatWrapping;
   texture.wrapT = RepeatWrapping;
-  texture.name = "pod-fallback-sprite";
+  texture.name = assetPath
+    ? `pod-procedural-sprite:${normalizeAssetKey(assetPath)}`
+    : "pod-fallback-sprite";
+  return texture;
+}
+
+function createRingTexture(color: [number, number, number], assetPath: string): Texture {
+  const size = 64;
+  const pixels = new Uint8Array(size * size * 4);
+
+  for (let y = 0; y < size; y += 1) {
+    for (let x = 0; x < size; x += 1) {
+      const index = (y * size + x) * 4;
+      const dx = (x / (size - 1)) * 2 - 1;
+      const dy = (y / (size - 1)) * 2 - 1;
+      const distance = Math.sqrt(dx * dx + dy * dy);
+      const outerFade = clamp01((0.9 - distance) / 0.08);
+      const innerFade = clamp01((distance - 0.52) / 0.08);
+      const glow = clamp01((0.72 - Math.abs(distance - 0.72)) / 0.18);
+      const alpha = clamp01(Math.min(outerFade, innerFade) * 0.85 + glow * 0.25);
+
+      pixels[index] = color[0];
+      pixels[index + 1] = color[1];
+      pixels[index + 2] = color[2];
+      pixels[index + 3] = Math.round(alpha * 255);
+    }
+  }
+
+  const texture = new DataTexture(pixels, size, size);
+  texture.needsUpdate = true;
+  texture.colorSpace = SRGBColorSpace;
+  texture.wrapS = RepeatWrapping;
+  texture.wrapT = RepeatWrapping;
+  texture.name = `pod-procedural-sprite:${normalizeAssetKey(assetPath)}`;
   return texture;
 }
 
@@ -593,6 +639,20 @@ function shouldUseToonShading(batch: ThreeJsMeshBatch): boolean {
       token
     )
   );
+}
+
+function spritePalette(assetPath: string): [number, number, number] {
+  const normalized = normalizeAssetKey(assetPath);
+  if (normalized.includes("danger")) {
+    return [246, 92, 92];
+  }
+  if (normalized.includes("mist")) {
+    return [132, 208, 255];
+  }
+  if (normalized.includes("selection") || normalized.includes("target") || normalized.includes("focus")) {
+    return [255, 212, 94];
+  }
+  return hashColor(assetPath);
 }
 
 function parseAssetRecord<T>(
@@ -794,7 +854,12 @@ async function createRuntimeAssetLoaders(options: {
         path: string,
         loaderOptions: { anisotropy: number; colorSpace: "srgb" | "none" }
       ): Promise<Texture> {
-        const texture = await textureLoader.loadAsync(path);
+        const texture =
+          typeof document === "object"
+            ? await textureLoader.loadAsync(path)
+            : path.endsWith(".svg")
+              ? createProceduralSpriteTexture(path)
+              : await loadWorkerSafeTexture(path);
         texture.colorSpace =
           loaderOptions.colorSpace === "none" ? NoColorSpace : SRGBColorSpace;
         texture.anisotropy = loaderOptions.anisotropy;
@@ -837,6 +902,22 @@ function extractPrimaryGeometry(root: { traverse: Mesh["traverse"] }, path: stri
   return primaryGeometry;
 }
 
+async function loadWorkerSafeTexture(path: string): Promise<Texture> {
+  if (typeof fetch !== "function" || typeof createImageBitmap !== "function") {
+    throw new Error(`Worker texture loading is unavailable for ${path}`);
+  }
+
+  const response = await fetch(path);
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} while loading ${path}`);
+  }
+
+  const image = await createImageBitmap(await response.blob());
+  const texture = new Texture(image);
+  texture.needsUpdate = true;
+  return texture;
+}
+
 function isRecord(input: unknown): input is Record<string, unknown> {
   return typeof input === "object" && input !== null && !Array.isArray(input);
 }
@@ -853,4 +934,8 @@ function dedupeBy<T>(values: T[], keySelector: (value: T) => string): T[] {
     output.push(value);
   }
   return output;
+}
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value));
 }

--- a/apps/pod-web/src/main.ts
+++ b/apps/pod-web/src/main.ts
@@ -29,8 +29,8 @@ import {
   runtimeConfigFromLocation,
   type DirectConnectStatus
 } from "./direct-connect";
-import { PodThreeWorldRenderer } from "./renderer";
 import { createDemoFrame } from "./sample-frame";
+import { createPodRenderRuntime, type PodThreeRenderRuntime } from "./render-runtime";
 import {
   applyTickTelemetry,
   createTelemetryOverlayState,
@@ -55,7 +55,7 @@ declare global {
       resetTelemetry: () => void;
       resetDemo: () => void;
       getBackend: () => string;
-      getStats: () => ReturnType<PodThreeWorldRenderer["getStats"]>;
+      getStats: () => ReturnType<PodThreeRenderRuntime["getStats"]>;
       getTelemetryStats: () => ReturnType<typeof telemetryStats>;
       getReplaySummary: () => ReplaySummary | null;
       getIncidentSummary: () => ShardIncidentSummary | null;
@@ -156,9 +156,9 @@ const telemetryPanelNode = telemetryPanel;
 const telemetryPrevButton = telemetryPrev;
 const telemetryNextButton = telemetryNext;
 
-const renderer = await PodThreeWorldRenderer.create(canvas);
+const renderer = await createPodRenderRuntime(canvas);
 backendLabel.textContent = renderer.backend;
-qualityLabel.textContent = renderer.quality.preset;
+qualityLabel.textContent = renderer.qualityPreset;
 const runtimeStatsLabel = statsLabel;
 const telemetryState = createTelemetryOverlayState(300);
 const runtimeConfig = runtimeConfigFromLocation(window.location);
@@ -206,8 +206,8 @@ const liveClient = runtimeConfig
         syncSelectedTarget();
         latestFrame = buildAuthoritativeWorldFrame(snapshot, {
           ...frameOptions,
-          viewportWidth: canvas.clientWidth || window.innerWidth,
-          viewportHeight: canvas.clientHeight || window.innerHeight
+      viewportWidth: canvas.clientWidth || window.innerWidth,
+      viewportHeight: canvas.clientHeight || window.innerHeight
         });
         liveFrameSource = "threejs";
         frameSourceLabel.textContent = "authoritative websocket";
@@ -564,7 +564,7 @@ window.podRender = {
   streamShardIncidentSummary(document: string) {
     applyLiveDebugDocument(document);
   },
-  resetTelemetry() {
+    resetTelemetry() {
     resetTelemetry(telemetryState);
     renderer.clearTelemetryTrail();
   },
@@ -646,7 +646,7 @@ async function tick(timestamp: number): Promise<void> {
   const stats = renderer.getStats();
   runtimeStatsLabel.textContent = `${stats.drawCalls} calls · ${stats.triangles} tris · ${stats.pixelRatio.toFixed(
     2
-  )}x DPR · ${stats.frameMs.toFixed(1)}ms · assets ${
+  )}x DPR · ${stats.frameMs.toFixed(1)}ms · ${stats.renderThread} thread · assets ${
     stats.residentGeometryAssets + stats.residentSpriteAssets
   } resident / ${stats.pendingGeometryAssets + stats.pendingSpriteAssets} pending`;
   renderTelemetryHud();

--- a/apps/pod-web/src/render-runtime.test.ts
+++ b/apps/pod-web/src/render-runtime.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  detectRenderWorkerCapabilities,
+  resolveRenderThreadPreference,
+  shouldUseRenderWorker
+} from "./render-runtime";
+
+describe("render worker runtime", () => {
+  test("parses render thread preferences from the query string", () => {
+    expect(resolveRenderThreadPreference("")).toBe("auto");
+    expect(resolveRenderThreadPreference("?renderThread=main")).toBe("main");
+    expect(resolveRenderThreadPreference("?renderThread=worker")).toBe("worker");
+    expect(resolveRenderThreadPreference("?renderThread=unknown")).toBe("auto");
+  });
+
+  test("only enables the render worker when explicitly requested and supported", () => {
+    const supported = {
+      hasWorkerConstructor: true,
+      hasOffscreenCanvas: true,
+      hasCanvasTransferControl: true
+    };
+
+    expect(shouldUseRenderWorker("auto", supported)).toBe(false);
+    expect(shouldUseRenderWorker("main", supported)).toBe(false);
+    expect(shouldUseRenderWorker("worker", supported)).toBe(true);
+    expect(
+      shouldUseRenderWorker("worker", {
+        ...supported,
+        hasCanvasTransferControl: false
+      })
+    ).toBe(false);
+  });
+
+  test("detects transfer support from the canvas surface", () => {
+    expect(
+      detectRenderWorkerCapabilities({
+        transferControlToOffscreen() {
+          return {} as OffscreenCanvas;
+        }
+      })
+    ).toEqual({
+      hasWorkerConstructor: typeof Worker === "function",
+      hasOffscreenCanvas: typeof OffscreenCanvas === "function",
+      hasCanvasTransferControl: true
+    });
+  });
+});

--- a/apps/pod-web/src/render-runtime.ts
+++ b/apps/pod-web/src/render-runtime.ts
@@ -1,0 +1,285 @@
+import type {
+  RenderFrame,
+  TelemetryTrajectorySample,
+  ThreeJsWebGpuFrame
+} from "./contracts";
+import {
+  PodThreeWorldRenderer,
+  type PodThreeRendererStats,
+  type PodThreeWorldRendererOptions
+} from "./renderer";
+
+export type PodRenderThread = "main" | "worker";
+export type PodRenderThreadPreference = "auto" | PodRenderThread;
+
+export interface PodRenderWorkerCapabilities {
+  hasWorkerConstructor: boolean;
+  hasOffscreenCanvas: boolean;
+  hasCanvasTransferControl: boolean;
+}
+
+export interface PodThreeRenderRuntime {
+  readonly backend: PodThreeRendererStats["backend"];
+  readonly qualityPreset: PodThreeRendererStats["qualityPreset"];
+  readonly renderThread: PodRenderThread;
+  applyFrame(frame: ThreeJsWebGpuFrame): Promise<void>;
+  applyLegacyFrame(frame: RenderFrame): Promise<void>;
+  setTelemetryTrail(samples: TelemetryTrajectorySample[]): void | Promise<void>;
+  clearTelemetryTrail(): void | Promise<void>;
+  getStats(): PodThreeRendererStats;
+  dispose(): void;
+}
+
+interface RenderWorkerReadyMessage {
+  type: "ready";
+  backend: PodThreeRendererStats["backend"];
+  qualityPreset: PodThreeRendererStats["qualityPreset"];
+  stats: PodThreeRendererStats;
+}
+
+interface RenderWorkerStatsMessage {
+  type: "stats";
+  stats: PodThreeRendererStats;
+}
+
+interface RenderWorkerErrorMessage {
+  type: "error";
+  message: string;
+}
+
+type RenderWorkerResponse =
+  | RenderWorkerReadyMessage
+  | RenderWorkerStatsMessage
+  | RenderWorkerErrorMessage;
+
+export type RenderWorkerRequest =
+  | {
+      type: "init";
+      canvas: OffscreenCanvas;
+      options: PodThreeWorldRendererOptions;
+    }
+  | {
+      type: "applyFrame";
+      frame: ThreeJsWebGpuFrame;
+    }
+  | {
+      type: "applyLegacyFrame";
+      frame: RenderFrame;
+    }
+  | {
+      type: "setTelemetryTrail";
+      samples: TelemetryTrajectorySample[];
+    }
+  | {
+      type: "clearTelemetryTrail";
+    }
+  | {
+      type: "dispose";
+    };
+
+export async function createPodRenderRuntime(
+  canvas: HTMLCanvasElement,
+  options: PodThreeWorldRendererOptions = {},
+  search =
+    typeof window === "object" ? window.location.search : "",
+  workerFactory: ((url: URL, options: WorkerOptions) => Worker) | null = defaultWorkerFactory
+): Promise<PodThreeRenderRuntime> {
+  const preference = resolveRenderThreadPreference(search);
+  const capabilities = detectRenderWorkerCapabilities(canvas);
+
+  if (shouldUseRenderWorker(preference, capabilities) && workerFactory) {
+    return await WorkerPodRenderRuntime.create(canvas, options, workerFactory);
+  }
+
+  if (preference === "worker" && !shouldUseRenderWorker(preference, capabilities)) {
+    console.warn("Falling back to main-thread rendering; render worker prerequisites are missing");
+  }
+
+  const renderer = await PodThreeWorldRenderer.create(canvas, options);
+  return new MainThreadPodRenderRuntime(renderer);
+}
+
+export function resolveRenderThreadPreference(search: string): PodRenderThreadPreference {
+  const params = new URLSearchParams(search);
+  const requested = params.get("renderThread")?.trim().toLowerCase();
+  if (requested === "main" || requested === "worker") {
+    return requested;
+  }
+  return "auto";
+}
+
+export function shouldUseRenderWorker(
+  preference: PodRenderThreadPreference,
+  capabilities: PodRenderWorkerCapabilities
+): boolean {
+  if (preference !== "worker") {
+    return false;
+  }
+
+  return (
+    capabilities.hasWorkerConstructor &&
+    capabilities.hasOffscreenCanvas &&
+    capabilities.hasCanvasTransferControl
+  );
+}
+
+export function detectRenderWorkerCapabilities(
+  canvas: HTMLCanvasElement | { transferControlToOffscreen?: unknown }
+): PodRenderWorkerCapabilities {
+  return {
+    hasWorkerConstructor: typeof Worker === "function",
+    hasOffscreenCanvas: typeof OffscreenCanvas === "function",
+    hasCanvasTransferControl: typeof canvas.transferControlToOffscreen === "function"
+  };
+}
+
+class MainThreadPodRenderRuntime implements PodThreeRenderRuntime {
+  readonly backend: PodThreeRendererStats["backend"];
+  readonly qualityPreset: PodThreeRendererStats["qualityPreset"];
+  readonly renderThread: PodRenderThread = "main";
+
+  constructor(private readonly renderer: PodThreeWorldRenderer) {
+    this.backend = renderer.backend;
+    this.qualityPreset = renderer.quality.preset;
+  }
+
+  async applyFrame(frame: ThreeJsWebGpuFrame): Promise<void> {
+    await this.renderer.applyFrame(frame);
+  }
+
+  async applyLegacyFrame(frame: RenderFrame): Promise<void> {
+    await this.renderer.applyLegacyFrame(frame);
+  }
+
+  setTelemetryTrail(samples: TelemetryTrajectorySample[]): void {
+    this.renderer.setTelemetryTrail(samples);
+  }
+
+  clearTelemetryTrail(): void {
+    this.renderer.clearTelemetryTrail();
+  }
+
+  getStats(): PodThreeRendererStats {
+    return this.renderer.getStats();
+  }
+
+  dispose(): void {
+    this.renderer.dispose();
+  }
+}
+
+class WorkerPodRenderRuntime implements PodThreeRenderRuntime {
+  static async create(
+    canvas: HTMLCanvasElement,
+    options: PodThreeWorldRendererOptions,
+    workerFactory: (url: URL, options: WorkerOptions) => Worker
+  ): Promise<WorkerPodRenderRuntime> {
+    const worker = workerFactory(new URL("./render-worker.ts", import.meta.url), {
+      type: "module"
+    });
+    const offscreenCanvas = canvas.transferControlToOffscreen();
+
+    const ready = await new Promise<RenderWorkerReadyMessage>((resolve, reject) => {
+      const handleMessage = (event: MessageEvent<RenderWorkerResponse>) => {
+        const data = event.data;
+        if (data.type === "ready") {
+          worker.removeEventListener("message", handleMessage);
+          worker.removeEventListener("error", handleError);
+          resolve(data);
+          return;
+        }
+
+        if (data.type === "error") {
+          worker.removeEventListener("message", handleMessage);
+          worker.removeEventListener("error", handleError);
+          reject(new Error(data.message));
+        }
+      };
+
+      const handleError = (event: ErrorEvent) => {
+        worker.removeEventListener("message", handleMessage);
+        worker.removeEventListener("error", handleError);
+        reject(event.error ?? new Error(event.message));
+      };
+
+      worker.addEventListener("message", handleMessage);
+      worker.addEventListener("error", handleError);
+      worker.postMessage(
+        {
+          type: "init",
+          canvas: offscreenCanvas,
+          options
+        } satisfies RenderWorkerRequest,
+        [offscreenCanvas]
+      );
+    });
+
+    return new WorkerPodRenderRuntime(worker, ready);
+  }
+
+  readonly backend: PodThreeRendererStats["backend"];
+  readonly qualityPreset: PodThreeRendererStats["qualityPreset"];
+  readonly renderThread: PodRenderThread = "worker";
+  private latestStats: PodThreeRendererStats;
+
+  private constructor(
+    private readonly worker: Worker,
+    ready: RenderWorkerReadyMessage
+  ) {
+    this.backend = ready.backend;
+    this.qualityPreset = ready.qualityPreset;
+    this.latestStats = ready.stats;
+
+    this.worker.addEventListener("message", (event: MessageEvent<RenderWorkerResponse>) => {
+      if (event.data.type === "stats") {
+        this.latestStats = event.data.stats;
+        return;
+      }
+
+      if (event.data.type === "error") {
+        console.error("pod-web render worker error:", event.data.message);
+      }
+    });
+  }
+
+  async applyFrame(frame: ThreeJsWebGpuFrame): Promise<void> {
+    this.worker.postMessage({
+      type: "applyFrame",
+      frame
+    } satisfies RenderWorkerRequest);
+  }
+
+  async applyLegacyFrame(frame: RenderFrame): Promise<void> {
+    this.worker.postMessage({
+      type: "applyLegacyFrame",
+      frame
+    } satisfies RenderWorkerRequest);
+  }
+
+  setTelemetryTrail(samples: TelemetryTrajectorySample[]): void {
+    this.worker.postMessage({
+      type: "setTelemetryTrail",
+      samples
+    } satisfies RenderWorkerRequest);
+  }
+
+  clearTelemetryTrail(): void {
+    this.worker.postMessage({
+      type: "clearTelemetryTrail"
+    } satisfies RenderWorkerRequest);
+  }
+
+  getStats(): PodThreeRendererStats {
+    return this.latestStats;
+  }
+
+  dispose(): void {
+    this.worker.postMessage({ type: "dispose" } satisfies RenderWorkerRequest);
+    this.worker.terminate();
+  }
+}
+
+const defaultWorkerFactory =
+  typeof Worker === "function"
+    ? (url: URL, options: WorkerOptions) => new Worker(url, options)
+    : null;

--- a/apps/pod-web/src/render-worker.ts
+++ b/apps/pod-web/src/render-worker.ts
@@ -1,0 +1,100 @@
+/// <reference lib="webworker" />
+
+import { PodThreeWorldRenderer } from "./renderer";
+import type { RenderWorkerRequest } from "./render-runtime";
+
+const scope = self as DedicatedWorkerGlobalScope;
+
+let renderer: PodThreeWorldRenderer | null = null;
+let draining = false;
+let queuedRenderCommand:
+  | Extract<RenderWorkerRequest, { type: "applyFrame" | "applyLegacyFrame" }>
+  | null = null;
+
+scope.addEventListener("message", (event: MessageEvent<RenderWorkerRequest>) => {
+  void handleMessage(event.data);
+});
+
+async function handleMessage(message: RenderWorkerRequest): Promise<void> {
+  try {
+    switch (message.type) {
+      case "init":
+        renderer = await PodThreeWorldRenderer.create(message.canvas, message.options);
+        scope.postMessage({
+          type: "ready",
+          backend: renderer.backend,
+          qualityPreset: renderer.quality.preset,
+          stats: {
+            ...renderer.getStats(),
+            renderThread: "worker"
+          }
+        });
+        return;
+      case "applyFrame":
+      case "applyLegacyFrame":
+        queuedRenderCommand = message;
+        await drainRenderQueue();
+        return;
+      case "setTelemetryTrail":
+        renderer?.setTelemetryTrail(message.samples);
+        return;
+      case "clearTelemetryTrail":
+        renderer?.clearTelemetryTrail();
+        return;
+      case "dispose":
+        renderer?.dispose();
+        renderer = null;
+        queuedRenderCommand = null;
+        return;
+      default:
+        return assertNever(message);
+    }
+  } catch (error) {
+    postWorkerError(error);
+  }
+}
+
+async function drainRenderQueue(): Promise<void> {
+  if (draining || !renderer) {
+    return;
+  }
+
+  draining = true;
+
+  try {
+    while (queuedRenderCommand && renderer) {
+      const command = queuedRenderCommand;
+      queuedRenderCommand = null;
+
+      if (command.type === "applyFrame") {
+        await renderer.applyFrame(command.frame);
+      } else {
+        await renderer.applyLegacyFrame(command.frame);
+      }
+
+      scope.postMessage({
+        type: "stats",
+        stats: {
+          ...renderer.getStats(),
+          renderThread: "worker"
+        }
+      });
+    }
+  } catch (error) {
+    postWorkerError(error);
+  } finally {
+    draining = false;
+  }
+}
+
+function postWorkerError(error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+  scope.postMessage({
+    type: "error",
+    message
+  });
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled render worker message: ${String(value)}`);
+}

--- a/apps/pod-web/src/renderer.ts
+++ b/apps/pod-web/src/renderer.ts
@@ -56,6 +56,7 @@ let didReportInlineFnWarning = false;
 
 export interface PodThreeRendererStats {
   backend: "webgpu" | "webgl2";
+  renderThread: "main" | "worker";
   qualityPreset: PodThreeQualityPreset;
   pixelRatio: number;
   drawCalls: number;
@@ -517,6 +518,7 @@ export class PodThreeWorldRenderer {
 
     return {
       backend: this.backend,
+      renderThread: "main",
       qualityPreset: this.quality.preset,
       pixelRatio: this.renderer.getPixelRatio(),
       drawCalls: this.renderer.info.render.calls,


### PR DESCRIPTION
## Summary
- add an opt-in OffscreenCanvas render worker runtime for pod-web
- keep worker-mode sprite assets resident with worker-safe procedural ring textures
- surface render-thread stats in the HUD and document the new worker query param

## Validation
- bun test ./src/assets.test.ts ./src/render-runtime.test.ts ./src/contracts.test.ts
- bun run typecheck
- bun run build
- live smoke: http://127.0.0.1:4174/?renderThread=worker rendered on webgpu with worker thread stats and no sprite fallback warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added render worker thread capability with query parameter control (`?renderThread=worker` / `?renderThread=main`), defaulting to main-thread rendering.
  * Introduced render thread statistics reporting in performance metrics.

* **Improvements**
  * Enhanced asset loading fallback handling to prevent repeated load attempts and reduce console spam from failed assets.
  * Improved procedural sprite texture generation for worker contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->