### PR TITLE
Fix pod-web worker DPI sync

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -747,5 +747,16 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - live browser smoke via Playwright against `bun run dev --host 127.0.0.1 --port 4173?renderThread=worker`
   - `git diff --check`
 
-**Last updated**: Iteration 78
-**Current focus**: Iteration 79 browser-first flagship world delivery, continuing with chunk-streamed asset residency beyond the in-memory manifest cache and replacing emulated SpacetimeDB client paths with generated typed bindings
+### Iteration 79
+- [x] Fixed worker-mode render softness by syncing logical viewport size and device pixel ratio from the main thread into the `OffscreenCanvas` runtime instead of letting the worker fall back to a `1.00x` backing store.
+- [x] Added worker-side resize propagation so creator resizing and high-DPI displays keep the off-thread renderer visually aligned with the main-thread path.
+- [x] Added deterministic Bun coverage for worker surface-metric measurement.
+- [x] Validated touched targets:
+  - `cd apps/pod-web && bun test ./src/assets.test.ts ./src/render-runtime.test.ts ./src/contracts.test.ts`
+  - `cd apps/pod-web && bun run typecheck`
+  - `cd apps/pod-web && bun run build`
+  - live browser smoke via Playwright against `bun run dev --host 127.0.0.1 --port 4174?renderThread=worker`
+  - `git diff --check`
+
+**Last updated**: Iteration 79
+**Current focus**: Iteration 80 browser-first flagship world delivery, continuing with chunk-streamed asset residency beyond the in-memory manifest cache and replacing emulated SpacetimeDB client paths with generated typed bindings

--- a/apps/pod-web/README.md
+++ b/apps/pod-web/README.md
@@ -41,6 +41,7 @@ http://127.0.0.1:5173/?server=127.0.0.1:7778&player=WebPlayer&debug=1
 - default: main-thread rendering
 - `?renderThread=worker`: transfers the canvas to a dedicated render worker via `OffscreenCanvas`
 - `?renderThread=main`: forces the existing main-thread path
+- worker mode now mirrors the main thread's logical viewport size and device pixel ratio, so it should not look softer than the main-thread path on high-DPI displays
 
 ### Browser controls
 

--- a/apps/pod-web/src/render-runtime.test.ts
+++ b/apps/pod-web/src/render-runtime.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   detectRenderWorkerCapabilities,
+  readRenderSurfaceMetrics,
   resolveRenderThreadPreference,
   shouldUseRenderWorker
 } from "./render-runtime";
@@ -43,6 +44,24 @@ describe("render worker runtime", () => {
       hasWorkerConstructor: typeof Worker === "function",
       hasOffscreenCanvas: typeof OffscreenCanvas === "function",
       hasCanvasTransferControl: true
+    });
+  });
+
+  test("measures logical canvas size and device pixel ratio for worker rendering", () => {
+    expect(
+      readRenderSurfaceMetrics(
+        {
+          clientWidth: 1280,
+          clientHeight: 720,
+          width: 300,
+          height: 150
+        },
+        2
+      )
+    ).toEqual({
+      width: 1280,
+      height: 720,
+      devicePixelRatio: 2
     });
   });
 });

--- a/apps/pod-web/src/render-runtime.ts
+++ b/apps/pod-web/src/render-runtime.ts
@@ -5,6 +5,7 @@ import type {
 } from "./contracts";
 import {
   PodThreeWorldRenderer,
+  type RenderSurfaceMetrics,
   type PodThreeRendererStats,
   type PodThreeWorldRendererOptions
 } from "./renderer";
@@ -74,6 +75,10 @@ export type RenderWorkerRequest =
       type: "clearTelemetryTrail";
     }
   | {
+      type: "resize";
+      surfaceMetrics: RenderSurfaceMetrics;
+    }
+  | {
       type: "dispose";
     };
 
@@ -130,6 +135,20 @@ export function detectRenderWorkerCapabilities(
     hasWorkerConstructor: typeof Worker === "function",
     hasOffscreenCanvas: typeof OffscreenCanvas === "function",
     hasCanvasTransferControl: typeof canvas.transferControlToOffscreen === "function"
+  };
+}
+
+export function readRenderSurfaceMetrics(
+  canvas: Pick<HTMLCanvasElement, "clientWidth" | "clientHeight" | "width" | "height">,
+  devicePixelRatio =
+    typeof window === "object" && typeof window.devicePixelRatio === "number"
+      ? window.devicePixelRatio
+      : 1
+): RenderSurfaceMetrics {
+  return {
+    width: Math.max(canvas.clientWidth || canvas.width || 1, 1),
+    height: Math.max(canvas.clientHeight || canvas.height || 1, 1),
+    devicePixelRatio: Math.max(devicePixelRatio, 1)
   };
 }
 
@@ -208,27 +227,46 @@ class WorkerPodRenderRuntime implements PodThreeRenderRuntime {
         {
           type: "init",
           canvas: offscreenCanvas,
-          options
+          options: {
+            ...options,
+            surfaceMetrics: readRenderSurfaceMetrics(canvas)
+          }
         } satisfies RenderWorkerRequest,
         [offscreenCanvas]
       );
     });
 
-    return new WorkerPodRenderRuntime(worker, ready);
+    return new WorkerPodRenderRuntime(worker, ready, canvas);
   }
 
   readonly backend: PodThreeRendererStats["backend"];
   readonly qualityPreset: PodThreeRendererStats["qualityPreset"];
   readonly renderThread: PodRenderThread = "worker";
   private latestStats: PodThreeRendererStats;
+  private readonly resizeObserver: ResizeObserver | null;
+  private readonly handleWindowResize = () => {
+    this.syncSurfaceMetrics();
+  };
 
   private constructor(
     private readonly worker: Worker,
-    ready: RenderWorkerReadyMessage
+    ready: RenderWorkerReadyMessage,
+    private readonly canvas: HTMLCanvasElement
   ) {
     this.backend = ready.backend;
     this.qualityPreset = ready.qualityPreset;
     this.latestStats = ready.stats;
+
+    this.resizeObserver =
+      typeof ResizeObserver !== "undefined"
+        ? new ResizeObserver(() => {
+            this.syncSurfaceMetrics();
+          })
+        : null;
+    this.resizeObserver?.observe(canvas);
+    if (typeof window === "object") {
+      window.addEventListener("resize", this.handleWindowResize);
+    }
 
     this.worker.addEventListener("message", (event: MessageEvent<RenderWorkerResponse>) => {
       if (event.data.type === "stats") {
@@ -240,6 +278,8 @@ class WorkerPodRenderRuntime implements PodThreeRenderRuntime {
         console.error("pod-web render worker error:", event.data.message);
       }
     });
+
+    this.syncSurfaceMetrics();
   }
 
   async applyFrame(frame: ThreeJsWebGpuFrame): Promise<void> {
@@ -274,8 +314,19 @@ class WorkerPodRenderRuntime implements PodThreeRenderRuntime {
   }
 
   dispose(): void {
+    this.resizeObserver?.disconnect();
+    if (typeof window === "object") {
+      window.removeEventListener("resize", this.handleWindowResize);
+    }
     this.worker.postMessage({ type: "dispose" } satisfies RenderWorkerRequest);
     this.worker.terminate();
+  }
+
+  private syncSurfaceMetrics(): void {
+    this.worker.postMessage({
+      type: "resize",
+      surfaceMetrics: readRenderSurfaceMetrics(this.canvas)
+    } satisfies RenderWorkerRequest);
   }
 }
 

--- a/apps/pod-web/src/render-worker.ts
+++ b/apps/pod-web/src/render-worker.ts
@@ -41,6 +41,18 @@ async function handleMessage(message: RenderWorkerRequest): Promise<void> {
       case "clearTelemetryTrail":
         renderer?.clearTelemetryTrail();
         return;
+      case "resize":
+        renderer?.setSurfaceMetrics(message.surfaceMetrics);
+        if (renderer) {
+          scope.postMessage({
+            type: "stats",
+            stats: {
+              ...renderer.getStats(),
+              renderThread: "worker"
+            }
+          });
+        }
+        return;
       case "dispose":
         renderer?.dispose();
         renderer = null;

--- a/apps/pod-web/src/renderer.ts
+++ b/apps/pod-web/src/renderer.ts
@@ -69,6 +69,12 @@ export interface PodThreeRendererStats {
   pendingSpriteAssets: number;
 }
 
+export interface RenderSurfaceMetrics {
+  width: number;
+  height: number;
+  devicePixelRatio: number;
+}
+
 export interface PodThreeWorldRendererOptions {
   assetRegistry?: PodThreeAssetRegistry;
   cameraRig?: PodThreeCameraRigOptions;
@@ -78,6 +84,7 @@ export interface PodThreeWorldRendererOptions {
   enableShadows?: boolean;
   showGrid?: boolean;
   maxPixelRatio?: number;
+  surfaceMetrics?: RenderSurfaceMetrics;
 }
 
 export class PodThreeWorldRenderer {
@@ -116,6 +123,7 @@ export class PodThreeWorldRenderer {
   private adaptivePixelRatio: number;
   private smoothedFrameMs = 16.7;
   private adjustmentCooldown = 0;
+  private surfaceMetrics: RenderSurfaceMetrics | null;
   private telemetryTrail: THREE.Line<THREE.BufferGeometry, THREE.LineBasicMaterial> | null =
     null;
 
@@ -127,13 +135,14 @@ export class PodThreeWorldRenderer {
   ) {
     this.backend = backend;
     this.assetRegistry = options.assetRegistry ?? new DefaultPodThreeAssetRegistry();
+    this.surfaceMetrics = options.surfaceMetrics ?? null;
     const deviceMemory = readNavigatorDeviceMemory();
     const baseQuality = resolveQualityProfile({
       backend,
       preferredPreset: options.qualityPreset,
       hardwareConcurrency: readNavigatorHardwareConcurrency(),
       deviceMemory,
-      devicePixelRatio: readDevicePixelRatio()
+      devicePixelRatio: this.surfaceMetrics?.devicePixelRatio ?? readDevicePixelRatio()
     });
     this.quality = {
       ...baseQuality,
@@ -202,6 +211,11 @@ export class PodThreeWorldRenderer {
     this.clearOverlay();
     this.clearTelemetryTrail();
     this.renderer.dispose();
+  }
+
+  setSurfaceMetrics(metrics: RenderSurfaceMetrics): void {
+    this.surfaceMetrics = metrics;
+    this.resize();
   }
 
   private bootstrapScenes(): void {
@@ -500,8 +514,11 @@ export class PodThreeWorldRenderer {
   }
 
   private resize(): void {
-    const { width, height } = readRenderSurfaceSize(this.canvas);
-    const pixelRatio = Math.min(readDevicePixelRatio(), this.adaptivePixelRatio);
+    const { width, height } = readRenderSurfaceSize(this.canvas, this.surfaceMetrics);
+    const pixelRatio = Math.min(
+      this.surfaceMetrics?.devicePixelRatio ?? readDevicePixelRatio(),
+      this.adaptivePixelRatio
+    );
     this.renderer.setPixelRatio(pixelRatio);
     this.renderer.setSize(width, height, false);
     this.camera.aspect = width / Math.max(height, 1);
@@ -820,8 +837,16 @@ function readDevicePixelRatio(): number {
 }
 
 function readRenderSurfaceSize(
-  canvas: HTMLCanvasElement | OffscreenCanvas
+  canvas: HTMLCanvasElement | OffscreenCanvas,
+  surfaceMetrics: RenderSurfaceMetrics | null = null
 ): { width: number; height: number } {
+  if (surfaceMetrics) {
+    return {
+      width: Math.max(Math.round(surfaceMetrics.width), 1),
+      height: Math.max(Math.round(surfaceMetrics.height), 1)
+    };
+  }
+
   if (isHtmlCanvasElement(canvas)) {
     return {
       width:


### PR DESCRIPTION
## Summary
- sync logical canvas size and device pixel ratio into the render worker
- keep worker-mode resize updates aligned with the main-thread canvas surface
- record the DPI parity fix in the pod-web docs and implementation plan

## Validation
- bun test ./src/assets.test.ts ./src/render-runtime.test.ts ./src/contracts.test.ts
- bun run typecheck
- bun run build
- live smoke: http://127.0.0.1:4174/?renderThread=worker now reports 2.00x DPR instead of 1.00x and no longer looks soft