### PR TITLE
Add pod-web chunk-aware asset warmup

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -770,5 +770,17 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - live browser smoke via Playwright against `http://127.0.0.1:4174/` and `http://127.0.0.1:4174/?renderThread=worker`
   - Figma capture of the upgraded world test scene
 
-**Last updated**: Iteration 80
-**Current focus**: Iteration 81 browser-first flagship world delivery, continuing with chunk-streamed asset residency beyond the in-memory manifest cache, cleanup of remaining WebGPU texture warnings, and replacement of emulated SpacetimeDB client paths with generated typed bindings
+### Iteration 81
+- [x] Extended `apps/pod-web` frame planning with chunk-aware visibility and warmup metadata, including explicit `visibleWorldChunks`, `preloadedWorldChunks`, and prewarm request lists for nearby mesh and sprite assets instead of only prefetching whatever is already visible.
+- [x] Updated `PodThreeWorldRenderer` and the browser HUD to surface chunk residency alongside asset residency, so creators can see what the runtime is actively drawing versus warming for nearby traversal.
+- [x] Removed the remaining built-in overlay SVG texture path from the runtime texture loader by routing shipped ring overlays through the procedural texture path on all render threads, eliminating the prior `CopyExternalImageToTexture()` warning from POD-owned assets.
+- [x] Added deterministic Bun coverage for chunk planning/warmup behavior and the new procedural-overlay routing.
+- [x] Validated touched targets:
+  - `cd apps/pod-web && bun test ./src/frame-plan.test.ts ./src/assets.test.ts`
+  - `cd apps/pod-web && bun run typecheck`
+  - `cd apps/pod-web && bun run build`
+  - live browser smoke via Playwright against `http://127.0.0.1:4174/` and `http://127.0.0.1:4174/?renderThread=worker`
+  - `git diff --check`
+
+**Last updated**: Iteration 81
+**Current focus**: Iteration 82 browser-first flagship world delivery, continuing with true streamed chunk residency beyond the in-memory manifest cache, authored world chunk activation/deactivation, and replacement of emulated SpacetimeDB client paths with generated typed bindings

--- a/apps/pod-web/src/assets.test.ts
+++ b/apps/pod-web/src/assets.test.ts
@@ -8,7 +8,8 @@ import {
   ManifestBackedPodThreeAssetRegistry,
   parsePodThreeAssetManifest,
   resolveManifestMeshAsset,
-  resolveManifestSpriteAsset
+  resolveManifestSpriteAsset,
+  shouldUseProceduralSpriteTexture
 } from "./assets";
 import type { ThreeJsMeshBatch } from "./contracts";
 
@@ -66,6 +67,13 @@ describe("createMeshMaterial", () => {
 });
 
 describe("createProceduralSpriteTexture", () => {
+  test("routes shipped ring overlays through the procedural texture path", () => {
+    expect(shouldUseProceduralSpriteTexture("/assets/textures/selection-ring.svg")).toBe(true);
+    expect(shouldUseProceduralSpriteTexture("/assets/textures/danger-ring.svg")).toBe(true);
+    expect(shouldUseProceduralSpriteTexture("/assets/textures/mist-ring.svg")).toBe(true);
+    expect(shouldUseProceduralSpriteTexture("/assets/textures/canopy-tree.png")).toBe(false);
+  });
+
   test("creates a worker-safe ring texture for SVG overlay assets", () => {
     const texture = createProceduralSpriteTexture("/assets/textures/selection-ring.svg");
     const image = texture.image as { data: Uint8Array; width: number; height: number };

--- a/apps/pod-web/src/assets.ts
+++ b/apps/pod-web/src/assets.ts
@@ -59,6 +59,16 @@ export interface PodThreeAssetResidencyStats {
   pendingSpriteAssets: number;
 }
 
+export function shouldUseProceduralSpriteTexture(assetPath: string): boolean {
+  const normalized = normalizeAssetKey(assetPath);
+  return (
+    assetPath.trim().toLowerCase().endsWith(".svg") &&
+    (normalized.includes("selection-ring") ||
+      normalized.includes("danger-ring") ||
+      normalized.includes("mist-ring"))
+  );
+}
+
 export type PodThreeAssetCategory =
   | "character"
   | "companion"
@@ -855,7 +865,9 @@ async function createRuntimeAssetLoaders(options: {
         loaderOptions: { anisotropy: number; colorSpace: "srgb" | "none" }
       ): Promise<Texture> {
         const texture =
-          typeof document === "object"
+          shouldUseProceduralSpriteTexture(path)
+            ? createProceduralSpriteTexture(path)
+            : typeof document === "object"
             ? await textureLoader.loadAsync(path)
             : path.endsWith(".svg")
               ? createProceduralSpriteTexture(path)

--- a/apps/pod-web/src/frame-plan.test.ts
+++ b/apps/pod-web/src/frame-plan.test.ts
@@ -316,6 +316,130 @@ describe("buildFramePlan", () => {
     expect(plan.meshBatches).toHaveLength(1);
     expect(plan.meshBatches[0]?.visibleCount).toBe(1);
   });
+
+  test("tracks visible chunks separately from nearby warm chunks", () => {
+    const frame: ThreeJsWebGpuFrame = {
+      camera: {
+        x: 0,
+        y: 0,
+        zoom: 1,
+        rotation: Math.PI,
+        viewportWidth: 1280,
+        viewportHeight: 720
+      },
+      backgroundColor: [0, 0, 0, 1],
+      overlayCommands: [],
+      meshBatches: [
+        {
+          mesh: "tower",
+          material: "stone",
+          layer: 0,
+          phase: "opaque",
+          sortDepth: 0,
+          renderOrder: 0,
+          transparent: false,
+          doubleSided: false,
+          castShadows: true,
+          receiveShadows: true,
+          tint: [1, 1, 1, 1],
+          roughness: 1,
+          metallic: 0,
+          emissive: [0, 0, 0],
+          depthWrite: true,
+          depthTest: true,
+          instances: [{ position: [0, 0, 0], rotation: [0, 0, 0, 1], scale: [1, 1, 1] }]
+        },
+        {
+          mesh: "canopy-tree",
+          material: "leaf",
+          layer: 0,
+          phase: "opaque",
+          sortDepth: 0,
+          renderOrder: 1,
+          transparent: false,
+          doubleSided: false,
+          castShadows: true,
+          receiveShadows: true,
+          tint: [1, 1, 1, 1],
+          roughness: 1,
+          metallic: 0,
+          emissive: [0, 0, 0],
+          depthWrite: true,
+          depthTest: true,
+          instances: [
+            { position: [30, 0, 0], rotation: [0, 0, 0, 1], scale: [1, 1, 1] },
+            { position: [34, 0, 0], rotation: [0, 0, 0, 1], scale: [1, 1, 1] }
+          ]
+        }
+      ],
+      spriteBatches: [
+        {
+          texture: "mist",
+          frame: 0,
+          layer: 2,
+          billboard: true,
+          phase: "transparent",
+          sortDepth: 18,
+          renderOrder: 2,
+          transparent: true,
+          depthWrite: false,
+          depthTest: true,
+          instances: [
+            {
+              position: [32, 0, 0],
+              rotation: [0, 0, 0, 1],
+              scale: [2, 2, 1],
+              color: [1, 1, 1, 0.25]
+            }
+          ]
+        }
+      ],
+      hints: {
+        renderer: "three/webgpu",
+        preferredBackend: "webgpu",
+        fallbackBackend: "webgl2",
+        useInstancing: true,
+        sortMetric: "world-z",
+        sortOpaqueFrontToBack: true,
+        preserveInstanceOrder: true,
+        sortTransparentBackToFront: true,
+        transparentInstancingStrategy: "shared-sort-depth",
+        opaqueDepthWrite: true,
+        transparentDepthWrite: false,
+        maxPixelRatio: 2
+      }
+    };
+
+    const plan = buildFramePlan(frame, {
+      frustumCulling: false,
+      fov: 140,
+      pitch: 0,
+      height: 0,
+      baseDistance: 12,
+      minDistance: 12,
+      maxDistance: 12,
+      meshCullDistance: 14,
+      spriteCullDistance: 14,
+      worldChunkSize: 24,
+      preloadChunkRadius: 1
+    });
+
+    expect(plan.visibleWorldChunks).toEqual(["0:0"]);
+    expect(plan.preloadedWorldChunks).toContain("1:0");
+    expect(plan.preloadedWorldChunks).toHaveLength(9);
+    expect(plan.meshBatches).toHaveLength(1);
+    expect(plan.spriteBatches).toHaveLength(0);
+    expect(plan.prewarmMeshRequests).toHaveLength(3);
+    expect(
+      plan.prewarmMeshRequests.map((request) => [request.batch.mesh, request.lodLevel])
+    ).toEqual([
+      ["canopy-tree", 0],
+      ["canopy-tree", 1],
+      ["tower", 0]
+    ]);
+    expect(plan.prewarmSpriteRequests).toHaveLength(1);
+    expect(plan.prewarmSpriteRequests[0]?.batch.texture).toBe("mist");
+  });
 });
 
 describe("resolveQualityProfile", () => {

--- a/apps/pod-web/src/frame-plan.ts
+++ b/apps/pod-web/src/frame-plan.ts
@@ -32,6 +32,8 @@ export interface PodThreePlanningOptions extends PodThreeCameraRigOptions {
   highDetailDistance?: number;
   mediumDetailDistance?: number;
   shadowDistance?: number;
+  worldChunkSize?: number;
+  preloadChunkRadius?: number;
 }
 
 export interface PlannedCameraPose {
@@ -60,10 +62,27 @@ export interface PlannedSpriteBatch {
   matrices: Matrix4[];
 }
 
+export interface PlannedMeshPrewarmRequest {
+  key: string;
+  batch: ThreeJsMeshBatch;
+  lodLevel: 0 | 1 | 2;
+  chunkKey: string;
+}
+
+export interface PlannedSpritePrewarmRequest {
+  key: string;
+  batch: Pick<ThreeJsSpriteBatch, "texture" | "frame">;
+  chunkKey: string;
+}
+
 export interface PlannedFrame {
   camera: PlannedCameraPose;
   meshBatches: PlannedMeshBatch[];
   spriteBatches: PlannedSpriteBatch[];
+  visibleWorldChunks: string[];
+  preloadedWorldChunks: string[];
+  prewarmMeshRequests: PlannedMeshPrewarmRequest[];
+  prewarmSpriteRequests: PlannedSpritePrewarmRequest[];
 }
 
 export function buildCameraPose(
@@ -114,26 +133,69 @@ export function buildFramePlan(
   const highDetailDistance = options.highDetailDistance ?? 36;
   const mediumDetailDistance = options.mediumDetailDistance ?? 108;
   const shadowDistance = options.shadowDistance ?? 72;
+  const worldChunkSize = options.worldChunkSize ?? 24;
+  const preloadChunkRadius = options.preloadChunkRadius ?? 1;
+  const visibleWorldChunks = new Set<string>();
+  const meshPrewarmDistance =
+    Number.isFinite(meshCullDistance)
+      ? meshCullDistance + worldChunkSize * Math.max(preloadChunkRadius, 1)
+      : Number.POSITIVE_INFINITY;
+  const spritePrewarmDistance =
+    Number.isFinite(spriteCullDistance)
+      ? spriteCullDistance + worldChunkSize * Math.max(preloadChunkRadius, 1)
+      : Number.POSITIVE_INFINITY;
+  const meshBatches = planMeshBatches(
+    frame.meshBatches,
+    frustum,
+    cameraPosition,
+    highDetailDistance,
+    mediumDetailDistance,
+    meshCullDistance,
+    shadowDistance,
+    frustumCulling,
+    visibleWorldChunks,
+    worldChunkSize
+  );
+  const spriteBatches = planSpriteBatches(
+    frame.spriteBatches,
+    frustum,
+    cameraPosition,
+    spriteCullDistance,
+    camera.quaternion,
+    frustumCulling,
+    visibleWorldChunks,
+    worldChunkSize
+  );
+  const cameraChunkKey = chunkKeyFromCoordinates(frame.camera.x, frame.camera.y, worldChunkSize);
+  const preloadedWorldChunks = expandChunkKeys(
+    visibleWorldChunks.size > 0 ? visibleWorldChunks : [cameraChunkKey],
+    preloadChunkRadius,
+    cameraChunkKey
+  );
 
   return {
     camera,
-    meshBatches: planMeshBatches(
+    meshBatches,
+    spriteBatches,
+    visibleWorldChunks: Array.from(visibleWorldChunks).sort((left, right) =>
+      left.localeCompare(right)
+    ),
+    preloadedWorldChunks,
+    prewarmMeshRequests: collectMeshPrewarmRequests(
       frame.meshBatches,
-      frustum,
+      preloadedWorldChunks,
       cameraPosition,
       highDetailDistance,
       mediumDetailDistance,
-      meshCullDistance,
-      shadowDistance,
-      frustumCulling
+      meshPrewarmDistance,
+      worldChunkSize
     ),
-    spriteBatches: planSpriteBatches(
+    prewarmSpriteRequests: collectSpritePrewarmRequests(
       frame.spriteBatches,
-      frustum,
+      preloadedWorldChunks,
+      spritePrewarmDistance,
       cameraPosition,
-      spriteCullDistance,
-      camera.quaternion,
-      frustumCulling
+      worldChunkSize
     )
   };
 }
@@ -282,7 +344,9 @@ function planMeshBatches(
   mediumDetailDistance: number,
   meshCullDistance: number,
   shadowDistance: number,
-  frustumCulling: boolean
+  frustumCulling: boolean,
+  visibleWorldChunks: Set<string>,
+  worldChunkSize: number
 ): PlannedMeshBatch[] {
   const planned = new Array<PlannedMeshBatch>();
 
@@ -309,6 +373,7 @@ function planMeshBatches(
         continue;
       }
 
+      visibleWorldChunks.add(chunkKeyFromInstance(instance, worldChunkSize));
       const lodLevel = classifyLod(distance, highDetailDistance, mediumDetailDistance);
       const group = lodGroups.get(lodLevel) ?? {
         matrices: [],
@@ -357,7 +422,9 @@ function planSpriteBatches(
   cameraPosition: Vector3,
   spriteCullDistance: number,
   cameraQuaternion: Quaternion,
-  frustumCulling: boolean
+  frustumCulling: boolean,
+  visibleWorldChunks: Set<string>,
+  worldChunkSize: number
 ): PlannedSpriteBatch[] {
   const visibleBatches = batches
     .map((batch) => ({
@@ -371,7 +438,12 @@ function planSpriteBatches(
           return false;
         }
 
-        return !frustumCulling || frustum.intersectsSphere(new Sphere(center, radius));
+        const visible =
+          !frustumCulling || frustum.intersectsSphere(new Sphere(center, radius));
+        if (visible) {
+          visibleWorldChunks.add(chunkKeyFromInstance(instance, worldChunkSize));
+        }
+        return visible;
       })
     }))
     .filter((batch) => batch.instances.length > 0);
@@ -406,4 +478,132 @@ function classifyLod(
 
 function estimateInstanceRadius(instance: ThreeJsInstance): number {
   return Math.max(...instance.scale) * DEFAULT_RADIUS;
+}
+
+function collectMeshPrewarmRequests(
+  batches: ThreeJsMeshBatch[],
+  preloadedChunkKeys: string[],
+  cameraPosition: Vector3,
+  highDetailDistance: number,
+  mediumDetailDistance: number,
+  meshPrewarmDistance: number,
+  worldChunkSize: number
+): PlannedMeshPrewarmRequest[] {
+  const requests = new Map<string, PlannedMeshPrewarmRequest>();
+  const preloadedChunkSet = new Set(preloadedChunkKeys);
+
+  for (const batch of batches) {
+    for (const instance of batch.instances) {
+      const chunkKey = chunkKeyFromInstance(instance, worldChunkSize);
+      if (!preloadedChunkSet.has(chunkKey)) {
+        continue;
+      }
+
+      const distance = new Vector3(...instance.position).distanceTo(cameraPosition);
+      if (distance - estimateInstanceRadius(instance) > meshPrewarmDistance) {
+        continue;
+      }
+
+      const lodLevel = classifyLod(distance, highDetailDistance, mediumDetailDistance);
+      const key = createMeshBatchKey(batch, lodLevel);
+      if (!requests.has(key)) {
+        requests.set(key, {
+          key,
+          batch,
+          lodLevel,
+          chunkKey
+        });
+      }
+    }
+  }
+
+  return Array.from(requests.values()).sort((left, right) => left.key.localeCompare(right.key));
+}
+
+function collectSpritePrewarmRequests(
+  batches: ThreeJsSpriteBatch[],
+  preloadedChunkKeys: string[],
+  spritePrewarmDistance: number,
+  cameraPosition: Vector3,
+  worldChunkSize: number
+): PlannedSpritePrewarmRequest[] {
+  const requests = new Map<string, PlannedSpritePrewarmRequest>();
+  const preloadedChunkSet = new Set(preloadedChunkKeys);
+
+  for (const batch of batches) {
+    for (const instance of batch.instances) {
+      const chunkKey = chunkKeyFromInstance(instance, worldChunkSize);
+      if (!preloadedChunkSet.has(chunkKey)) {
+        continue;
+      }
+
+      const distance = new Vector3(...instance.position).distanceTo(cameraPosition);
+      if (distance - estimateInstanceRadius(instance) > spritePrewarmDistance) {
+        continue;
+      }
+
+      const key = `${batch.texture}:frame:${batch.frame}`;
+      if (!requests.has(key)) {
+        requests.set(key, {
+          key,
+          batch: {
+            texture: batch.texture,
+            frame: batch.frame
+          },
+          chunkKey
+        });
+      }
+    }
+  }
+
+  return Array.from(requests.values()).sort((left, right) => left.key.localeCompare(right.key));
+}
+
+function expandChunkKeys(
+  sourceKeys: Iterable<string>,
+  radius: number,
+  fallbackChunkKey: string
+): string[] {
+  const expanded = new Set<string>();
+  const normalizedRadius = Math.max(Math.floor(radius), 0);
+  let didExpand = false;
+
+  for (const sourceKey of sourceKeys) {
+    didExpand = true;
+    const [chunkX, chunkZ] = parseChunkKey(sourceKey);
+    for (let offsetX = -normalizedRadius; offsetX <= normalizedRadius; offsetX += 1) {
+      for (let offsetZ = -normalizedRadius; offsetZ <= normalizedRadius; offsetZ += 1) {
+        expanded.add(formatChunkKey(chunkX + offsetX, chunkZ + offsetZ));
+      }
+    }
+  }
+
+  if (!didExpand) {
+    expanded.add(fallbackChunkKey);
+  }
+
+  return Array.from(expanded).sort((left, right) => left.localeCompare(right));
+}
+
+function chunkKeyFromInstance(
+  instance: Pick<ThreeJsInstance, "position">,
+  worldChunkSize: number
+): string {
+  return chunkKeyFromCoordinates(instance.position[0], instance.position[2], worldChunkSize);
+}
+
+function chunkKeyFromCoordinates(x: number, z: number, worldChunkSize: number): string {
+  return formatChunkKey(
+    Math.floor(x / Math.max(worldChunkSize, 1)),
+    Math.floor(z / Math.max(worldChunkSize, 1))
+  );
+}
+
+function formatChunkKey(chunkX: number, chunkZ: number): string {
+  return `${chunkX}:${chunkZ}`;
+}
+
+function parseChunkKey(chunkKey: string): [number, number] {
+  const [rawX = "0", rawZ = "0"] = chunkKey.split(":");
+  return [Number.parseInt(rawX, 10) || 0, Number.parseInt(rawZ, 10) || 0];
 }

--- a/apps/pod-web/src/main.ts
+++ b/apps/pod-web/src/main.ts
@@ -759,7 +759,9 @@ async function renderCurrentFrame(timestamp: number): Promise<void> {
   const stats = renderer.getStats();
   runtimeStatsLabel.textContent = `${stats.drawCalls} calls · ${stats.triangles} tris · ${stats.pixelRatio.toFixed(
     2
-  )}x DPR · ${stats.frameMs.toFixed(1)}ms · ${stats.renderThread} thread · assets ${
+  )}x DPR · ${stats.frameMs.toFixed(1)}ms · ${stats.renderThread} thread · chunks ${
+    stats.visibleWorldChunks
+  } visible / ${stats.preloadedWorldChunks} warm · assets ${
     stats.residentGeometryAssets + stats.residentSpriteAssets
   } resident / ${stats.pendingGeometryAssets + stats.pendingSpriteAssets} pending`;
   renderTelemetryHud();

--- a/apps/pod-web/src/renderer.ts
+++ b/apps/pod-web/src/renderer.ts
@@ -67,6 +67,8 @@ export interface PodThreeRendererStats {
   residentSpriteAssets: number;
   pendingGeometryAssets: number;
   pendingSpriteAssets: number;
+  visibleWorldChunks: number;
+  preloadedWorldChunks: number;
 }
 
 export interface RenderSurfaceMetrics {
@@ -124,6 +126,8 @@ export class PodThreeWorldRenderer {
   private smoothedFrameMs = 16.7;
   private adjustmentCooldown = 0;
   private surfaceMetrics: RenderSurfaceMetrics | null;
+  private visibleWorldChunks = 0;
+  private preloadedWorldChunks = 0;
   private telemetryTrail: THREE.Line<THREE.BufferGeometry, THREE.LineBasicMaterial> | null =
     null;
 
@@ -180,6 +184,8 @@ export class PodThreeWorldRenderer {
       ...this.options.cameraRig,
       ...planningOptionsFromQuality(this.quality)
     });
+    this.visibleWorldChunks = planned.visibleWorldChunks.length;
+    this.preloadedWorldChunks = planned.preloadedWorldChunks.length;
     this.applyCamera(planned.camera, frame.camera);
     await this.prewarmPlannedAssets(planned);
     await this.syncMeshBatches(planned.meshBatches);
@@ -545,7 +551,9 @@ export class PodThreeWorldRenderer {
       residentGeometryAssets: residency.residentGeometryAssets,
       residentSpriteAssets: residency.residentSpriteAssets,
       pendingGeometryAssets: residency.pendingGeometryAssets,
-      pendingSpriteAssets: residency.pendingSpriteAssets
+      pendingSpriteAssets: residency.pendingSpriteAssets,
+      visibleWorldChunks: this.visibleWorldChunks,
+      preloadedWorldChunks: this.preloadedWorldChunks
     };
   }
 
@@ -554,17 +562,16 @@ export class PodThreeWorldRenderer {
   ): Promise<void> {
     await Promise.all([
       this.assetRegistry.prefetchMeshes?.(
-        planned.meshBatches
-          .filter((batch) => batch.visibleCount > 0)
-          .map((batch) => ({ batch: batch.batch, lodLevel: batch.lodLevel }))
+        planned.prewarmMeshRequests.map((request) => ({
+          batch: request.batch,
+          lodLevel: request.lodLevel
+        }))
       ),
       this.assetRegistry.prefetchSprites?.(
-        planned.spriteBatches
-          .filter((batch) => batch.visibleCount > 0)
-          .map((batch) => ({
+        planned.prewarmSpriteRequests.map((request) => ({
             batch: {
-              texture: batch.batch.texture,
-              frame: batch.batch.frame
+              texture: request.batch.texture,
+              frame: request.batch.frame
             },
             anisotropy: this.quality.anisotropy
           }))


### PR DESCRIPTION
## Summary
- add chunk-aware frame planning and asset warmup metadata to pod-web
- surface visible/warm chunk counts in the browser HUD and renderer stats
- route shipped SVG ring overlays through the procedural texture path to remove the old WebGPU texture warning

## Testing
- cd apps/pod-web && bun test ./src/frame-plan.test.ts ./src/assets.test.ts
- cd apps/pod-web && bun run typecheck
- cd apps/pod-web && bun run build
- live browser smoke via Playwright against http://127.0.0.1:4174/ and http://127.0.0.1:4174/?renderThread=worker
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced world chunking system to track visible and preloaded asset chunks separately.
  * Added asset prewarming functionality for optimized mesh and sprite loading based on chunk proximity.
  * Implemented procedural texture routing for SVG ring overlays.

* **Tests**
  * Added test coverage for chunk visibility tracking and prewarming behavior.

* **Chores**
  * Updated implementation plan to Iteration 81 with new chunk-aware visibility enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->