### PR TITLE
Add shared world presentation primitives

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -782,5 +782,17 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - live browser smoke via Playwright against `http://127.0.0.1:4174/` and `http://127.0.0.1:4174/?renderThread=worker`
   - `git diff --check`
 
-**Last updated**: Iteration 81
-**Current focus**: Iteration 82 browser-first flagship world delivery, continuing with true streamed chunk residency beyond the in-memory manifest cache, authored world chunk activation/deactivation, and replacement of emulated SpacetimeDB client paths with generated typed bindings
+### Iteration 82
+- [x] Added shared presentation primitives in `pod-core` for atmosphere zones, actor presentation, and combat presentation so creators can author biome lighting, silhouette defaults, and combat readability as native engine data instead of ad hoc browser-only overrides.
+- [x] Extended authoritative `pod-net` snapshots to carry those presentation primitives, including static atmosphere anchors and non-moving entities, so browser/editor consumers can build rich world views from the same server-owned metadata humans and AI agents share.
+- [x] Updated `apps/pod-web` authoritative frame generation and renderer environment application to honor biome atmosphere, actor mesh/material overrides, aura rings, and combat ring styling directly from snapshot metadata.
+- [x] Added deterministic coverage for presentation-driven environment selection, actor affordances, updated metadata fixtures, and static-scene affordance typing across the browser tests and `pod-net` snapshot tests.
+- [x] Validated touched targets:
+  - `cargo test -p pod-net --lib`
+  - `cd apps/pod-web && bun test ./src/contracts.test.ts ./src/frame-plan.test.ts ./src/local-world.test.ts ./src/affordances.test.ts`
+  - `cd apps/pod-web && bun run typecheck`
+  - `cd apps/pod-web && bun run build`
+  - `git diff --check`
+
+**Last updated**: Iteration 82
+**Current focus**: Iteration 83 browser-first flagship world delivery, continuing with true streamed chunk residency beyond the in-memory manifest cache, authored world chunk activation/deactivation, plus higher-level creator primitives for authored factions, quest hooks, encounter tables, and biome-linked spawn distributions

--- a/apps/pod-web/src/affordances.test.ts
+++ b/apps/pod-web/src/affordances.test.ts
@@ -15,6 +15,10 @@ function metadata(
     resourceSkill: null,
     resourceTier: null,
     encounterKind: null,
+    atmosphere: null,
+    atmosphereVolume: null,
+    actorPresentation: null,
+    combatPresentation: null,
     interaction: {
       canInspect: false,
       canInteract: false,

--- a/apps/pod-web/src/contracts.test.ts
+++ b/apps/pod-web/src/contracts.test.ts
@@ -8,6 +8,7 @@ import {
   encodeDirectConnectConnectMessage,
   encodeDirectConnectDebugTelemetryMessage,
   encodeDirectConnectFullSnapshotRequest,
+  type NetworkEntityMetadataSnapshot,
   type NetworkWorldSnapshot,
   parseAgentTickRollup,
   parseAgentToolCallEvent,
@@ -31,6 +32,10 @@ function entityMetadata(kind: string, overrides: Record<string, unknown> = {}) {
     resource_skill: null,
     resource_tier: null,
     encounter_kind: null,
+    atmosphere: null,
+    atmosphere_volume: null,
+    actor_presentation: null,
+    combat_presentation: null,
     interaction: {
       can_inspect: true,
       can_interact: false,
@@ -40,6 +45,37 @@ function entityMetadata(kind: string, overrides: Record<string, unknown> = {}) {
       can_capture: false,
       can_command_companion: false,
       can_chat: false
+    },
+    ...overrides
+  };
+}
+
+function typedEntityMetadata(
+  kind: NetworkEntityMetadataSnapshot["kind"],
+  overrides: Partial<NetworkEntityMetadataSnapshot> = {}
+): NetworkEntityMetadataSnapshot {
+  return {
+    kind,
+    teamId: null,
+    combatStyle: null,
+    speciesId: null,
+    speciesName: null,
+    resourceSkill: null,
+    resourceTier: null,
+    encounterKind: null,
+    atmosphere: null,
+    atmosphereVolume: null,
+    actorPresentation: null,
+    combatPresentation: null,
+    interaction: {
+      canInspect: true,
+      canInteract: false,
+      canAttack: false,
+      canGather: false,
+      canLoot: false,
+      canCapture: false,
+      canCommandCompanion: false,
+      canChat: false
     },
     ...overrides
   };
@@ -397,15 +433,9 @@ describe("TOON contract parsing", () => {
           velocity: [0, 0],
           rotation: 0,
           label: "Hero",
-          metadata: {
-            kind: "Player",
+          metadata: typedEntityMetadata("Player", {
             teamId: 1,
             combatStyle: "Melee",
-            speciesId: null,
-            speciesName: null,
-            resourceSkill: null,
-            resourceTier: null,
-            encounterKind: null,
             interaction: {
               canInspect: true,
               canInteract: true,
@@ -416,7 +446,7 @@ describe("TOON contract parsing", () => {
               canCommandCompanion: false,
               canChat: true
             }
-          }
+          })
         },
         {
           id: 2,
@@ -424,15 +454,7 @@ describe("TOON contract parsing", () => {
           velocity: [0, 0],
           rotation: 0,
           label: "Wall-East",
-          metadata: {
-            kind: "Scenery",
-            teamId: null,
-            combatStyle: null,
-            speciesId: null,
-            speciesName: null,
-            resourceSkill: null,
-            resourceTier: null,
-            encounterKind: null,
+          metadata: typedEntityMetadata("Scenery", {
             interaction: {
               canInspect: true,
               canInteract: false,
@@ -443,7 +465,7 @@ describe("TOON contract parsing", () => {
               canCommandCompanion: false,
               canChat: false
             }
-          }
+          })
         }
       ]
     };
@@ -459,15 +481,9 @@ describe("TOON contract parsing", () => {
             velocity: [4, 0],
             rotation: 0.3,
             label: "Hero",
-            metadata: {
-              kind: "Player",
+            metadata: typedEntityMetadata("Player", {
               teamId: 1,
               combatStyle: "Melee",
-              speciesId: null,
-              speciesName: null,
-              resourceSkill: null,
-              resourceTier: null,
-              encounterKind: null,
               interaction: {
                 canInspect: true,
                 canInteract: true,
@@ -478,7 +494,7 @@ describe("TOON contract parsing", () => {
                 canCommandCompanion: false,
                 canChat: true
               }
-            }
+            })
           },
         {
           id: 3,
@@ -486,14 +502,10 @@ describe("TOON contract parsing", () => {
           velocity: [0, 0],
             rotation: 0,
             label: "Monster-Wolf",
-            metadata: {
-              kind: "WildCreature",
-              teamId: null,
+            metadata: typedEntityMetadata("WildCreature", {
               combatStyle: "Melee",
               speciesId: "embercub",
               speciesName: "Wild Embercub",
-              resourceSkill: null,
-              resourceTier: null,
               encounterKind: "WildCreature",
               interaction: {
                 canInspect: true,
@@ -505,7 +517,7 @@ describe("TOON contract parsing", () => {
                 canCommandCompanion: false,
                 canChat: false
             }
-          }
+          })
         },
         {
           id: 4,
@@ -513,15 +525,7 @@ describe("TOON contract parsing", () => {
           velocity: [0, 0],
           rotation: 0,
           label: "Glass Spire",
-          metadata: {
-            kind: "Scenery",
-            teamId: null,
-            combatStyle: null,
-            speciesId: null,
-            speciesName: null,
-            resourceSkill: null,
-            resourceTier: null,
-            encounterKind: null,
+          metadata: typedEntityMetadata("Scenery", {
             interaction: {
               canInspect: true,
               canInteract: false,
@@ -532,7 +536,7 @@ describe("TOON contract parsing", () => {
               canCommandCompanion: false,
               canChat: false
             }
-          }
+          })
         },
         {
           id: 5,
@@ -540,15 +544,7 @@ describe("TOON contract parsing", () => {
           velocity: [0, 0],
           rotation: 0,
           label: "Canopy Tree",
-          metadata: {
-            kind: "Scenery",
-            teamId: null,
-            combatStyle: null,
-            speciesId: null,
-            speciesName: null,
-            resourceSkill: null,
-            resourceTier: null,
-            encounterKind: null,
+          metadata: typedEntityMetadata("Scenery", {
             interaction: {
               canInspect: true,
               canInteract: false,
@@ -559,7 +555,7 @@ describe("TOON contract parsing", () => {
               canCommandCompanion: false,
               canChat: false
             }
-          }
+          })
         }
       ],
       destroyed: [2]
@@ -582,6 +578,120 @@ describe("TOON contract parsing", () => {
     expect(frame.meshBatches.some((batch) => batch.mesh === "glass-spire")).toBe(true);
     expect(frame.meshBatches.some((batch) => batch.mesh === "canopy-tree")).toBe(true);
     expect(frame.spriteBatches.some((batch) => batch.texture === "selection-ring")).toBe(true);
+  });
+
+  test("builds presentation-driven environments and actor affordances", () => {
+    const snapshot: NetworkWorldSnapshot = {
+      tick: 18,
+      entities: [
+        {
+          id: 1,
+          position: [8, 10],
+          velocity: [0, 0],
+          rotation: 0.25,
+          label: "Hero",
+          metadata: typedEntityMetadata("Player", {
+            actorPresentation: {
+              profileId: "heroic-adventurer",
+              meshAssetId: "adventurer-hero",
+              materialPaletteId: "verdant",
+              animationSetId: "hero-runescape",
+              scaleMultiplier: 1.15,
+              footprintRadius: 1.1,
+              selectionRingScale: 3.2,
+              auraColor: [0.32, 0.86, 0.74, 0.28]
+            },
+            combatPresentation: {
+              profileId: "heroic-combat",
+              hitFlashColor: [1, 0.72, 0.34, 0.38],
+              criticalRingColor: [1, 0.28, 0.2, 0.42],
+              selectionRingColor: [0.62, 0.98, 0.84, 0.55],
+              emissiveBoost: [0.05, 0.04, 0.02],
+              impactScale: 1.45
+            }
+          })
+        },
+        {
+          id: 7,
+          position: [9, 9],
+          velocity: [0, 0],
+          rotation: 0,
+          label: "Glass Spire",
+          metadata: typedEntityMetadata("Scenery", {
+            atmosphere: {
+              biomeId: "verdant-hollow",
+              skyColor: [0.12, 0.16, 0.22, 1],
+              fogColor: [0.18, 0.25, 0.29, 1],
+              fogNear: 18,
+              fogFar: 130,
+              ambientColor: [0.58, 0.82, 0.94],
+              ambientIntensity: 1.35,
+              sunColor: [0.96, 0.88, 0.74],
+              sunIntensity: 2.9,
+              sunDirection: [18, 34, 12],
+              fillColor: [0.34, 0.8, 0.92],
+              fillIntensity: 0.92,
+              fillDirection: [-14, 16, -6],
+              rimColor: [0.42, 0.96, 1],
+              rimIntensity: 13,
+              groundColor: [0.1, 0.14, 0.18, 1],
+              starfieldIntensity: 0.42
+            },
+            atmosphereVolume: {
+              radius: 8,
+              priority: 3
+            }
+          })
+        },
+        {
+          id: 9,
+          position: [12, 10],
+          velocity: [0, 0],
+          rotation: 0.4,
+          health: 10,
+          maxHealth: 40,
+          label: "Rift Beast",
+          metadata: typedEntityMetadata("WildCreature", {
+            speciesId: "rift-beast",
+            speciesName: "Rift Beast",
+            combatPresentation: {
+              profileId: "beast-combat",
+              hitFlashColor: [1, 0.64, 0.44, 0.34],
+              criticalRingColor: [1, 0.18, 0.16, 0.5],
+              selectionRingColor: [0.82, 0.34, 0.3, 0.28],
+              emissiveBoost: [0.08, 0.02, 0.01],
+              impactScale: 1.75
+            }
+          })
+        }
+      ]
+    };
+
+    const frame = buildAuthoritativeWorldFrame(snapshot, {
+      controlledEntity: 1,
+      viewportWidth: 1600,
+      viewportHeight: 900
+    });
+
+    expect(frame.environment.biomeId).toBe("verdant-hollow");
+    expect(frame.environment.fogFar).toBe(130);
+    expect(frame.meshBatches.some((batch) => batch.material.includes(":verdant"))).toBe(true);
+    const selectionRing = frame.spriteBatches.find(
+      (batch) => batch.texture === "selection-ring"
+    );
+    expect(selectionRing?.instances[0]?.scale).toEqual([3.2, 3.2, 1]);
+    expect(selectionRing?.instances[0]?.color).toEqual([0.62, 0.98, 0.84, 0.55]);
+
+    const auraRing = frame.spriteBatches.find((batch) => batch.texture === "mist-ring");
+    expect(auraRing?.instances[0]?.color).toEqual([0.32, 0.86, 0.74, 0.28]);
+
+    const criticalRing = frame.spriteBatches.find(
+      (batch) =>
+        batch.texture === "danger-ring" &&
+        batch.instances.some((instance) => instance.sourceEntity === 9)
+    );
+    expect(criticalRing?.instances[0]?.scale).toEqual([4.2, 4.2, 1]);
+    expect(criticalRing?.instances[0]?.color).toEqual([1, 0.18, 0.16, 0.5]);
   });
 
   test("encodes browser direct-connect client messages with Rust enum tags", () => {

--- a/apps/pod-web/src/contracts.ts
+++ b/apps/pod-web/src/contracts.ts
@@ -113,9 +113,30 @@ export interface ThreeJsWebGpuHints {
   maxPixelRatio: number;
 }
 
+export interface ThreeJsEnvironment {
+  biomeId: string;
+  skyColor: RgbaTuple;
+  fogColor: RgbaTuple;
+  fogNear: number;
+  fogFar: number;
+  ambientColor: Vec3Tuple;
+  ambientIntensity: number;
+  sunColor: Vec3Tuple;
+  sunIntensity: number;
+  sunDirection: Vec3Tuple;
+  fillColor: Vec3Tuple;
+  fillIntensity: number;
+  fillDirection: Vec3Tuple;
+  rimColor: Vec3Tuple;
+  rimIntensity: number;
+  groundColor: RgbaTuple;
+  starfieldIntensity: number;
+}
+
 export interface ThreeJsWebGpuFrame {
   camera: CameraState;
   backgroundColor: RgbaTuple;
+  environment: ThreeJsEnvironment;
   overlayCommands: RenderCommand[];
   meshBatches: ThreeJsMeshBatch[];
   spriteBatches: ThreeJsSpriteBatch[];
@@ -410,6 +431,51 @@ export interface NetworkEntityInteractionHints {
   canChat: boolean;
 }
 
+export interface NetworkAtmosphereProfile {
+  biomeId: string;
+  skyColor: RgbaTuple;
+  fogColor: RgbaTuple;
+  fogNear: number;
+  fogFar: number;
+  ambientColor: Vec3Tuple;
+  ambientIntensity: number;
+  sunColor: Vec3Tuple;
+  sunIntensity: number;
+  sunDirection: Vec3Tuple;
+  fillColor: Vec3Tuple;
+  fillIntensity: number;
+  fillDirection: Vec3Tuple;
+  rimColor: Vec3Tuple;
+  rimIntensity: number;
+  groundColor: RgbaTuple;
+  starfieldIntensity: number;
+}
+
+export interface NetworkAtmosphereVolume {
+  radius: number;
+  priority: number;
+}
+
+export interface NetworkActorPresentation {
+  profileId: string;
+  meshAssetId: string | null;
+  materialPaletteId: string;
+  animationSetId: string;
+  scaleMultiplier: number;
+  footprintRadius: number;
+  selectionRingScale: number;
+  auraColor: RgbaTuple;
+}
+
+export interface NetworkCombatPresentation {
+  profileId: string;
+  hitFlashColor: RgbaTuple;
+  criticalRingColor: RgbaTuple;
+  selectionRingColor: RgbaTuple;
+  emissiveBoost: Vec3Tuple;
+  impactScale: number;
+}
+
 export interface NetworkEntityMetadataSnapshot {
   kind: NetworkEntityKind;
   teamId: number | null;
@@ -419,6 +485,10 @@ export interface NetworkEntityMetadataSnapshot {
   resourceSkill: NetworkSkillKind | null;
   resourceTier: number | null;
   encounterKind: NetworkEncounterKind | null;
+  atmosphere: NetworkAtmosphereProfile | null;
+  atmosphereVolume: NetworkAtmosphereVolume | null;
+  actorPresentation: NetworkActorPresentation | null;
+  combatPresentation: NetworkCombatPresentation | null;
   interaction: NetworkEntityInteractionHints;
 }
 
@@ -579,6 +649,44 @@ function vec2Tuple(value: unknown): Vec2Tuple | null {
   return null;
 }
 
+function vec3Tuple(value: unknown): Vec3Tuple | null {
+  if (
+    Array.isArray(value) &&
+    value.length >= 3 &&
+    typeof value[0] === "number" &&
+    typeof value[1] === "number" &&
+    typeof value[2] === "number"
+  ) {
+    return [value[0], value[1], value[2]];
+  }
+
+  if (isRecord(value)) {
+    const x = asNumber(value.x);
+    const y = asNumber(value.y);
+    const z = asNumber(value.z);
+    if (x != null && y != null && z != null) {
+      return [x, y, z];
+    }
+  }
+
+  return null;
+}
+
+function rgbaTuple(value: unknown): RgbaTuple | null {
+  if (
+    Array.isArray(value) &&
+    value.length >= 4 &&
+    typeof value[0] === "number" &&
+    typeof value[1] === "number" &&
+    typeof value[2] === "number" &&
+    typeof value[3] === "number"
+  ) {
+    return [value[0], value[1], value[2], value[3]];
+  }
+
+  return null;
+}
+
 function decodeStructuredString(value: string): unknown {
   try {
     return JSON.parse(value) as unknown;
@@ -652,7 +760,176 @@ function parseNetworkEntityMetadata(value: unknown): NetworkEntityMetadataSnapsh
     resourceSkill: isSkillKind(resourceSkill) ? resourceSkill : null,
     resourceTier: optionalNumber(value.resource_tier ?? value.resourceTier) ?? null,
     encounterKind: isEncounterKind(encounterKind) ? encounterKind : null,
+    atmosphere: parseAtmosphereProfile(value.atmosphere),
+    atmosphereVolume: parseAtmosphereVolume(value.atmosphere_volume ?? value.atmosphereVolume),
+    actorPresentation: parseActorPresentation(
+      value.actor_presentation ?? value.actorPresentation
+    ),
+    combatPresentation: parseCombatPresentation(
+      value.combat_presentation ?? value.combatPresentation
+    ),
     interaction: parseInteractionHints(value.interaction)
+  };
+}
+
+function parseAtmosphereProfile(value: unknown): NetworkAtmosphereProfile | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const biomeId = optionalString(value.biome_id ?? value.biomeId);
+  const skyColor = rgbaTuple(value.sky_color ?? value.skyColor);
+  const fogColor = rgbaTuple(value.fog_color ?? value.fogColor);
+  const fogNear = asNumber(value.fog_near ?? value.fogNear);
+  const fogFar = asNumber(value.fog_far ?? value.fogFar);
+  const ambientColor = vec3Tuple(value.ambient_color ?? value.ambientColor);
+  const ambientIntensity = asNumber(value.ambient_intensity ?? value.ambientIntensity);
+  const sunColor = vec3Tuple(value.sun_color ?? value.sunColor);
+  const sunIntensity = asNumber(value.sun_intensity ?? value.sunIntensity);
+  const sunDirection = vec3Tuple(value.sun_direction ?? value.sunDirection);
+  const fillColor = vec3Tuple(value.fill_color ?? value.fillColor);
+  const fillIntensity = asNumber(value.fill_intensity ?? value.fillIntensity);
+  const fillDirection = vec3Tuple(value.fill_direction ?? value.fillDirection);
+  const rimColor = vec3Tuple(value.rim_color ?? value.rimColor);
+  const rimIntensity = asNumber(value.rim_intensity ?? value.rimIntensity);
+  const groundColor = rgbaTuple(value.ground_color ?? value.groundColor);
+  const starfieldIntensity = asNumber(value.starfield_intensity ?? value.starfieldIntensity);
+
+  if (
+    biomeId == null ||
+    skyColor == null ||
+    fogColor == null ||
+    fogNear == null ||
+    fogFar == null ||
+    ambientColor == null ||
+    ambientIntensity == null ||
+    sunColor == null ||
+    sunIntensity == null ||
+    sunDirection == null ||
+    fillColor == null ||
+    fillIntensity == null ||
+    fillDirection == null ||
+    rimColor == null ||
+    rimIntensity == null ||
+    groundColor == null ||
+    starfieldIntensity == null
+  ) {
+    return null;
+  }
+
+  return {
+    biomeId,
+    skyColor,
+    fogColor,
+    fogNear,
+    fogFar,
+    ambientColor,
+    ambientIntensity,
+    sunColor,
+    sunIntensity,
+    sunDirection,
+    fillColor,
+    fillIntensity,
+    fillDirection,
+    rimColor,
+    rimIntensity,
+    groundColor,
+    starfieldIntensity
+  };
+}
+
+function parseAtmosphereVolume(value: unknown): NetworkAtmosphereVolume | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const radius = asNumber(value.radius);
+  const priority = asNumber(value.priority);
+  if (radius == null || priority == null) {
+    return null;
+  }
+
+  return {
+    radius,
+    priority
+  };
+}
+
+function parseActorPresentation(value: unknown): NetworkActorPresentation | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const profileId = optionalString(value.profile_id ?? value.profileId);
+  const materialPaletteId = optionalString(
+    value.material_palette_id ?? value.materialPaletteId
+  );
+  const animationSetId = optionalString(value.animation_set_id ?? value.animationSetId);
+  const scaleMultiplier = asNumber(value.scale_multiplier ?? value.scaleMultiplier);
+  const footprintRadius = asNumber(value.footprint_radius ?? value.footprintRadius);
+  const selectionRingScale = asNumber(
+    value.selection_ring_scale ?? value.selectionRingScale
+  );
+  const auraColor = rgbaTuple(value.aura_color ?? value.auraColor);
+
+  if (
+    profileId == null ||
+    materialPaletteId == null ||
+    animationSetId == null ||
+    scaleMultiplier == null ||
+    footprintRadius == null ||
+    selectionRingScale == null ||
+    auraColor == null
+  ) {
+    return null;
+  }
+
+  return {
+    profileId,
+    meshAssetId: optionalString(value.mesh_asset_id ?? value.meshAssetId) ?? null,
+    materialPaletteId,
+    animationSetId,
+    scaleMultiplier,
+    footprintRadius,
+    selectionRingScale,
+    auraColor
+  };
+}
+
+function parseCombatPresentation(value: unknown): NetworkCombatPresentation | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const profileId = optionalString(value.profile_id ?? value.profileId);
+  const hitFlashColor = rgbaTuple(value.hit_flash_color ?? value.hitFlashColor);
+  const criticalRingColor = rgbaTuple(
+    value.critical_ring_color ?? value.criticalRingColor
+  );
+  const selectionRingColor = rgbaTuple(
+    value.selection_ring_color ?? value.selectionRingColor
+  );
+  const emissiveBoost = vec3Tuple(value.emissive_boost ?? value.emissiveBoost);
+  const impactScale = asNumber(value.impact_scale ?? value.impactScale);
+
+  if (
+    profileId == null ||
+    hitFlashColor == null ||
+    criticalRingColor == null ||
+    selectionRingColor == null ||
+    emissiveBoost == null ||
+    impactScale == null
+  ) {
+    return null;
+  }
+
+  return {
+    profileId,
+    hitFlashColor,
+    criticalRingColor,
+    selectionRingColor,
+    emissiveBoost,
+    impactScale
   };
 }
 
@@ -698,6 +975,10 @@ function defaultNetworkEntityMetadata(): NetworkEntityMetadataSnapshot {
     resourceSkill: null,
     resourceTier: null,
     encounterKind: null,
+    atmosphere: null,
+    atmosphereVolume: null,
+    actorPresentation: null,
+    combatPresentation: null,
     interaction: defaultInteractionHints()
   };
 }
@@ -1452,6 +1733,11 @@ interface EntityRenderProfile {
   renderOrder: number;
   roughness: number;
   metallic: number;
+  selectionRingScale: number;
+  selectionRingColor: RgbaTuple;
+  criticalRingColor: RgbaTuple;
+  auraColor: RgbaTuple;
+  impactScale: number;
 }
 
 function yawQuaternion(yaw: number): Vec4Tuple {
@@ -1490,6 +1776,28 @@ function defaultFrameHints(): ThreeJsWebGpuHints {
     opaqueDepthWrite: true,
     transparentDepthWrite: false,
     maxPixelRatio: 2
+  };
+}
+
+function defaultEnvironment(): ThreeJsEnvironment {
+  return {
+    biomeId: "neutral-shard",
+    skyColor: [0.04, 0.06, 0.1, 1],
+    fogColor: [0.035, 0.06, 0.1, 1],
+    fogNear: 28,
+    fogFar: 180,
+    ambientColor: [0.66, 0.82, 1],
+    ambientIntensity: 1.2,
+    sunColor: [1, 0.94, 0.82],
+    sunIntensity: 2.6,
+    sunDirection: [24, 42, 18],
+    fillColor: [0.42, 0.74, 1],
+    fillIntensity: 0.7,
+    fillDirection: [-18, 14, -10],
+    rimColor: [0.29, 0.76, 1],
+    rimIntensity: 12,
+    groundColor: [0.055, 0.09, 0.14, 1],
+    starfieldIntensity: 0.9
   };
 }
 
@@ -1596,6 +1904,104 @@ function teamTint(teamId: number | null, controlled: boolean): RgbaTuple {
   return palette[teamId % palette.length] ?? palette[0];
 }
 
+function addVec3(left: Vec3Tuple, right: Vec3Tuple): Vec3Tuple {
+  return [left[0] + right[0], left[1] + right[1], left[2] + right[2]];
+}
+
+function finalizeEntityRenderProfile(
+  baseProfile: Omit<
+    EntityRenderProfile,
+    | "selectionRingScale"
+    | "selectionRingColor"
+    | "criticalRingColor"
+    | "auraColor"
+    | "impactScale"
+  >,
+  entity: NetworkEntitySnapshot,
+  isControlled: boolean
+): EntityRenderProfile {
+  const actor = entity.metadata.actorPresentation;
+  const combat = entity.metadata.combatPresentation;
+  const defaultSelectionRingColor: RgbaTuple = isControlled
+    ? [0.62, 0.98, 0.84, 0.34]
+    : [0.56, 0.82, 1, 0.16];
+
+  return {
+    ...baseProfile,
+    mesh: actor?.meshAssetId ?? baseProfile.mesh,
+    material:
+      actor && actor.materialPaletteId !== "default"
+        ? `${baseProfile.material}:${actor.materialPaletteId}`
+        : baseProfile.material,
+    emissive: addVec3(baseProfile.emissive, combat?.emissiveBoost ?? [0, 0, 0]),
+    scale:
+      actor != null
+        ? [
+            baseProfile.scale[0] * actor.scaleMultiplier,
+            baseProfile.scale[1] * actor.scaleMultiplier,
+            baseProfile.scale[2] * actor.scaleMultiplier
+          ]
+        : baseProfile.scale,
+    selectionRingScale: actor?.selectionRingScale ?? 2.4,
+    selectionRingColor: combat?.selectionRingColor ?? defaultSelectionRingColor,
+    criticalRingColor: combat?.criticalRingColor ?? [0.92, 0.34, 0.3, 0.22],
+    auraColor: actor?.auraColor ?? [0, 0, 0, 0],
+    impactScale: combat?.impactScale ?? 1
+  };
+}
+
+function resolveFrameEnvironment(
+  snapshot: NetworkWorldSnapshot,
+  focusEntity: NetworkEntitySnapshot | null
+): ThreeJsEnvironment {
+  const defaultValue = defaultEnvironment();
+  if (!focusEntity) {
+    return defaultValue;
+  }
+
+  const focusPosition = focusEntity.position;
+  let selected:
+    | {
+        atmosphere: NetworkAtmosphereProfile;
+        volume: NetworkAtmosphereVolume | null;
+        distance: number;
+      }
+    | null = null;
+
+  for (const entity of snapshot.entities) {
+    const atmosphere = entity.metadata.atmosphere;
+    if (!atmosphere) {
+      continue;
+    }
+
+    const volume = entity.metadata.atmosphereVolume;
+    const distance = Math.hypot(
+      entity.position[0] - focusPosition[0],
+      entity.position[1] - focusPosition[1]
+    );
+    if (volume && distance > volume.radius) {
+      continue;
+    }
+
+    if (!selected) {
+      selected = { atmosphere, volume, distance };
+      continue;
+    }
+
+    const selectedPriority = selected.volume?.priority ?? 0;
+    const nextPriority = volume?.priority ?? 0;
+    if (nextPriority > selectedPriority) {
+      selected = { atmosphere, volume, distance };
+      continue;
+    }
+    if (nextPriority === selectedPriority && distance < selected.distance) {
+      selected = { atmosphere, volume, distance };
+    }
+  }
+
+  return selected?.atmosphere ?? defaultValue;
+}
+
 function entityRenderProfile(
   entity: NetworkEntitySnapshot,
   controlledEntity: number | null
@@ -1607,7 +2013,7 @@ function entityRenderProfile(
 
   if (kind === "ResourceNode") {
     const isWood = entity.metadata.resourceSkill === "Woodcutting";
-    return {
+    return finalizeEntityRenderProfile({
       mesh: isWood ? "canopy-tree" : "weathered-boulder",
       material: isWood ? "forest-resource" : "ore-vein",
       tint: isWood ? [0.28, 0.62, 0.34, 1] : [0.74, 0.54, 0.28, 1],
@@ -1617,11 +2023,11 @@ function entityRenderProfile(
       renderOrder: 1,
       roughness: isWood ? 0.9 : 0.86,
       metallic: isWood ? 0.04 : 0.1
-    };
+    }, entity, isControlled);
   }
 
   if (kind === "LootContainer") {
-    return {
+    return finalizeEntityRenderProfile({
       mesh: "supply-crate",
       material: "bronze-cache",
       tint: [0.78, 0.58, 0.34, 1],
@@ -1631,11 +2037,11 @@ function entityRenderProfile(
       renderOrder: 2,
       roughness: 0.8,
       metallic: 0.12
-    };
+    }, entity, isControlled);
   }
 
   if (kind === "WildCreature") {
-    return {
+    return finalizeEntityRenderProfile({
       mesh: "rift-beast",
       material: `rift-hide:${band}:${entity.metadata.speciesId ?? "wild"}`,
       tint:
@@ -1650,11 +2056,11 @@ function entityRenderProfile(
       renderOrder: 3,
       roughness: 0.82,
       metallic: 0.08
-    };
+    }, entity, isControlled);
   }
 
   if (kind === "Companion") {
-    return {
+    return finalizeEntityRenderProfile({
       mesh: "spirit-companion",
       material: `summon-shell:${band}:${entity.metadata.speciesId ?? "companion"}`,
       tint: [0.42, 0.88, 0.74, 1],
@@ -1664,11 +2070,11 @@ function entityRenderProfile(
       renderOrder: 4,
       roughness: 0.42,
       metallic: 0.12
-    };
+    }, entity, isControlled);
   }
 
   if (kind === "Npc") {
-    return {
+    return finalizeEntityRenderProfile({
       mesh: "adventurer-avatar",
       material: `npc-cloth:${band}:${entity.metadata.combatStyle ?? "Melee"}`,
       tint:
@@ -1681,11 +2087,11 @@ function entityRenderProfile(
       renderOrder: 5,
       roughness: 0.66,
       metallic: 0.08
-    };
+    }, entity, isControlled);
   }
 
   if (label.includes("wall")) {
-    return {
+    return finalizeEntityRenderProfile({
       mesh: "basalt-column",
       material: "obsidian-wall",
       tint: [0.24, 0.3, 0.38, 1],
@@ -1695,11 +2101,11 @@ function entityRenderProfile(
       renderOrder: 0,
       roughness: 0.94,
       metallic: 0.06
-    };
+    }, entity, isControlled);
   }
 
   if (label.includes("spire") || label.includes("obelisk") || label.includes("crystal")) {
-    return {
+    return finalizeEntityRenderProfile({
       mesh: "glass-spire",
       material: "glass-shrine",
       tint: [0.54, 0.76, 0.94, 1],
@@ -1709,11 +2115,11 @@ function entityRenderProfile(
       renderOrder: 1,
       roughness: 0.22,
       metallic: 0.08
-    };
+    }, entity, isControlled);
   }
 
   if (label.includes("tree") || label.includes("pine") || label.includes("birch")) {
-    return {
+    return finalizeEntityRenderProfile({
       mesh: "canopy-tree",
       material: "forest-canopy",
       tint: [0.34, 0.66, 0.4, 1],
@@ -1723,11 +2129,11 @@ function entityRenderProfile(
       renderOrder: 1,
       roughness: 0.9,
       metallic: 0.04
-    };
+    }, entity, isControlled);
   }
 
   if (label.includes("pillar") || label.includes("column")) {
-    return {
+    return finalizeEntityRenderProfile({
       mesh: "basalt-column",
       material: "rift-pillar",
       tint: [0.34, 0.38, 0.46, 1],
@@ -1737,11 +2143,11 @@ function entityRenderProfile(
       renderOrder: 1,
       roughness: 0.9,
       metallic: 0.08
-    };
+    }, entity, isControlled);
   }
 
   if (label.includes("obstacle") || label.includes("rock") || label.includes("boulder")) {
-    return {
+    return finalizeEntityRenderProfile({
       mesh: "weathered-boulder",
       material: "arena-stone",
       tint: [0.5, 0.42, 0.32, 1],
@@ -1751,7 +2157,7 @@ function entityRenderProfile(
       renderOrder: 1,
       roughness: 0.96,
       metallic: 0.04
-    };
+    }, entity, isControlled);
   }
 
   if (
@@ -1761,7 +2167,7 @@ function entityRenderProfile(
       label.includes("beast") ||
       label.includes("npc"))
   ) {
-    return {
+    return finalizeEntityRenderProfile({
       mesh: label.includes("npc") ? "adventurer-avatar" : "rift-beast",
       material: label.includes("npc") ? `npc-cloth:${band}:legacy` : `rift-hide:${band}:legacy`,
       tint:
@@ -1776,7 +2182,7 @@ function entityRenderProfile(
       renderOrder: label.includes("npc") ? 5 : 3,
       roughness: 0.82,
       metallic: 0.08
-    };
+    }, entity, isControlled);
   }
 
   if (
@@ -1786,7 +2192,7 @@ function entityRenderProfile(
       label.includes("summon") ||
       label.includes("spirit"))
   ) {
-    return {
+    return finalizeEntityRenderProfile({
       mesh: "spirit-companion",
       material: `summon-shell:${band}:legacy`,
       tint: [0.42, 0.88, 0.74, 1],
@@ -1796,9 +2202,9 @@ function entityRenderProfile(
       renderOrder: 4,
       roughness: 0.42,
       metallic: 0.12
-    };
+    }, entity, isControlled);
   }
-  return {
+  return finalizeEntityRenderProfile({
     mesh: isControlled ? "adventurer-hero" : "adventurer-avatar",
     material: `traveler-cloth:${band}:${isControlled ? "hero" : kind.toLowerCase()}`,
     tint:
@@ -1813,7 +2219,7 @@ function entityRenderProfile(
     renderOrder: 6,
     roughness: 0.64,
     metallic: 0.08
-  };
+  }, entity, isControlled);
 }
 
 function meshBatchKey(profile: EntityRenderProfile): string {
@@ -1833,6 +2239,7 @@ export function buildAuthoritativeWorldFrame(
   const controlledEntity = options.controlledEntity ?? null;
   const controlled = snapshot.entities.find((entity) => entity.id === controlledEntity) ?? null;
   const focus = controlled ?? snapshot.entities[0] ?? null;
+  const environment = resolveFrameEnvironment(snapshot, focus);
   const focusPosition = focus
     ? [focus.position[0] * WORLD_TO_RENDER_SCALE, focus.position[1] * WORLD_TO_RENDER_SCALE]
     : [0, 0];
@@ -1888,6 +2295,33 @@ export function buildAuthoritativeWorldFrame(
     }
 
     const band = healthBand(entity);
+    if (profile.auraColor[3] > 0.001) {
+      spriteBatches.push({
+        texture: "mist-ring",
+        frame: 0,
+        layer: profile.layer + 1,
+        billboard: false,
+        phase: "transparent",
+        sortDepth: position[2],
+        renderOrder: profile.renderOrder + 10,
+        transparent: true,
+        depthWrite: false,
+        depthTest: true,
+        instances: [
+          {
+            position: [position[0], 0.12, position[2]],
+            rotation: GROUND_RING_ROTATION,
+            scale: [
+              profile.selectionRingScale * 1.4,
+              profile.selectionRingScale * 1.4,
+              1
+            ],
+            color: profile.auraColor,
+            sourceEntity: entity.id
+          }
+        ]
+      });
+    }
     if (controlledEntity != null && entity.id === controlledEntity) {
       spriteBatches.push({
         texture: "selection-ring",
@@ -1904,8 +2338,8 @@ export function buildAuthoritativeWorldFrame(
           {
             position: [position[0], 0.08, position[2]],
             rotation: GROUND_RING_ROTATION,
-            scale: [2.6, 2.6, 1],
-            color: [0.62, 0.98, 0.84, 0.34],
+            scale: [profile.selectionRingScale, profile.selectionRingScale, 1],
+            color: profile.selectionRingColor,
             sourceEntity: entity.id
           }
         ]
@@ -1926,8 +2360,12 @@ export function buildAuthoritativeWorldFrame(
           {
             position: [position[0], 0.06, position[2]],
             rotation: GROUND_RING_ROTATION,
-            scale: [2.1, 2.1, 1],
-            color: [0.92, 0.34, 0.3, 0.22],
+            scale: [
+              profile.selectionRingScale * profile.impactScale,
+              profile.selectionRingScale * profile.impactScale,
+              1
+            ],
+            color: profile.criticalRingColor,
             sourceEntity: entity.id
           }
         ]
@@ -1944,7 +2382,8 @@ export function buildAuthoritativeWorldFrame(
       viewportWidth: options.viewportWidth ?? defaultViewportWidth(),
       viewportHeight: options.viewportHeight ?? defaultViewportHeight()
     },
-    backgroundColor: options.backgroundColor ?? [0.04, 0.06, 0.1, 1],
+    backgroundColor: options.backgroundColor ?? environment.skyColor,
+    environment,
     overlayCommands: [],
     meshBatches: Array.from(meshBatches.values()).sort((left, right) => {
       if (left.renderOrder !== right.renderOrder) {
@@ -1961,6 +2400,7 @@ export function legacyFrameToThreeJsFrame(frame: RenderFrame): ThreeJsWebGpuFram
   return {
     camera: frame.camera,
     backgroundColor: frame.backgroundColor,
+    environment: defaultEnvironment(),
     overlayCommands: frame.commands.filter((command) => command.visible),
     meshBatches: [],
     spriteBatches: [],

--- a/apps/pod-web/src/frame-plan.test.ts
+++ b/apps/pod-web/src/frame-plan.test.ts
@@ -4,6 +4,28 @@ import type { ThreeJsWebGpuFrame } from "./contracts";
 import { buildCameraPose, buildFramePlan, splitSpriteBatchesByTint } from "./frame-plan";
 import { resolveQualityProfile } from "./quality";
 
+function testEnvironment(): ThreeJsWebGpuFrame["environment"] {
+  return {
+    biomeId: "test-biome",
+    skyColor: [0.04, 0.06, 0.1, 1],
+    fogColor: [0.035, 0.06, 0.1, 1],
+    fogNear: 28,
+    fogFar: 180,
+    ambientColor: [0.66, 0.82, 1],
+    ambientIntensity: 1.2,
+    sunColor: [1, 0.94, 0.82],
+    sunIntensity: 2.6,
+    sunDirection: [24, 42, 18],
+    fillColor: [0.42, 0.74, 1],
+    fillIntensity: 0.7,
+    fillDirection: [-18, 14, -10],
+    rimColor: [0.29, 0.76, 1],
+    rimIntensity: 12,
+    groundColor: [0.055, 0.09, 0.14, 1],
+    starfieldIntensity: 0.9
+  };
+}
+
 describe("buildCameraPose", () => {
   test("maps 2D camera target and zoom into a perspective rig", () => {
     const pose = buildCameraPose({
@@ -101,6 +123,7 @@ describe("buildFramePlan", () => {
         viewportHeight: 720
       },
       backgroundColor: [0, 0, 0, 1],
+      environment: testEnvironment(),
       overlayCommands: [],
       meshBatches: [
         {
@@ -186,6 +209,7 @@ describe("buildFramePlan", () => {
         viewportHeight: 720
       },
       backgroundColor: [0, 0, 0, 1],
+      environment: testEnvironment(),
       overlayCommands: [],
       meshBatches: [
         {
@@ -264,6 +288,7 @@ describe("buildFramePlan", () => {
         viewportHeight: 720
       },
       backgroundColor: [0, 0, 0, 1],
+      environment: testEnvironment(),
       overlayCommands: [],
       meshBatches: [
         {
@@ -328,6 +353,7 @@ describe("buildFramePlan", () => {
         viewportHeight: 720
       },
       backgroundColor: [0, 0, 0, 1],
+      environment: testEnvironment(),
       overlayCommands: [],
       meshBatches: [
         {

--- a/apps/pod-web/src/local-world.ts
+++ b/apps/pod-web/src/local-world.ts
@@ -1,6 +1,7 @@
 import type {
   BrowserAction,
   BrowserCompanionCommand,
+  NetworkAtmosphereProfile,
   NetworkCombatStyle,
   NetworkEncounterKind,
   NetworkEntityInteractionHints,
@@ -801,6 +802,24 @@ function createPlayerEntity(playerName: string): LocalEntity {
     metadata: metadata("Player", {
       teamId: 1,
       combatStyle: "Melee",
+      actorPresentation: {
+        profileId: "hero-ranger",
+        meshAssetId: "adventurer-hero",
+        materialPaletteId: "verdant-hero",
+        animationSetId: "humanoid-explorer",
+        scaleMultiplier: 1.04,
+        footprintRadius: 1.15,
+        selectionRingScale: 2.8,
+        auraColor: [0.18, 0.38, 0.52, 0.14]
+      },
+      combatPresentation: {
+        profileId: "hero-combat",
+        hitFlashColor: [0.96, 0.42, 0.26, 0.22],
+        criticalRingColor: [0.96, 0.42, 0.26, 0.26],
+        selectionRingColor: [0.62, 0.98, 0.84, 0.38],
+        emissiveBoost: [0.08, 0.06, 0.02],
+        impactScale: 1.12
+      },
       interaction: interactionHints({
         canInspect: true,
         canInteract: true,
@@ -836,6 +855,16 @@ function createNpcEntity(id: number, label: string, position: Vec2Tuple): LocalE
     metadata: metadata("Npc", {
       teamId: 2,
       combatStyle: "Magic",
+      actorPresentation: {
+        profileId: "hub-npc",
+        meshAssetId: "adventurer-avatar",
+        materialPaletteId: "archive-cloth",
+        animationSetId: "humanoid-idle",
+        scaleMultiplier: 1,
+        footprintRadius: 1,
+        selectionRingScale: 2.2,
+        auraColor: [0, 0, 0, 0]
+      },
       interaction: interactionHints({
         canInspect: true,
         canInteract: true,
@@ -878,6 +907,24 @@ function createWildCreatureEntity(
       speciesId: slug(speciesName),
       speciesName,
       encounterKind: "WildCreature",
+      actorPresentation: {
+        profileId: slug(speciesName),
+        meshAssetId: "rift-beast",
+        materialPaletteId: "wild-creature",
+        animationSetId: "beast-stalker",
+        scaleMultiplier: 1.08,
+        footprintRadius: 1.45,
+        selectionRingScale: 2.5,
+        auraColor: [0.42, 0.12, 0.08, 0.08]
+      },
+      combatPresentation: {
+        profileId: "wild-danger",
+        hitFlashColor: [0.92, 0.36, 0.24, 0.2],
+        criticalRingColor: [0.92, 0.36, 0.24, 0.24],
+        selectionRingColor: [0.62, 0.78, 0.92, 0.14],
+        emissiveBoost: [0.04, 0.02, 0.01],
+        impactScale: 1.1
+      },
       interaction: interactionHints({
         canInspect: true,
         canAttack: true,
@@ -918,6 +965,16 @@ function createResourceEntity(
     metadata: metadata("ResourceNode", {
       resourceSkill: skill,
       resourceTier: 1,
+      actorPresentation: {
+        profileId: skill === "Woodcutting" ? "tree-resource" : "ore-resource",
+        meshAssetId: skill === "Woodcutting" ? "canopy-tree" : "weathered-boulder",
+        materialPaletteId: skill === "Woodcutting" ? "verdant-resource" : "ore-seam",
+        animationSetId: "static-prop",
+        scaleMultiplier: 1,
+        footprintRadius: 1.4,
+        selectionRingScale: 2.2,
+        auraColor: [0, 0, 0, 0]
+      },
       interaction: interactionHints({
         canInspect: true,
         canGather: true
@@ -955,6 +1012,16 @@ function createLootEntity(
     health: null,
     maxHealth: null,
     metadata: metadata("LootContainer", {
+      actorPresentation: {
+        profileId: "loot-cache",
+        meshAssetId: "supply-crate",
+        materialPaletteId: "bronze-cache",
+        animationSetId: "static-prop",
+        scaleMultiplier: 1,
+        footprintRadius: 1.1,
+        selectionRingScale: 2.1,
+        auraColor: [0.48, 0.32, 0.08, 0.1]
+      },
       interaction: interactionHints({
         canInspect: true,
         canLoot: true
@@ -996,6 +1063,24 @@ function createCompanionEntity(
       combatStyle: "Summoning",
       speciesId,
       speciesName,
+      actorPresentation: {
+        profileId: speciesId,
+        meshAssetId: "spirit-companion",
+        materialPaletteId: "summon-shell",
+        animationSetId: "companion-hover",
+        scaleMultiplier: 1,
+        footprintRadius: 0.95,
+        selectionRingScale: 2.2,
+        auraColor: [0.28, 0.82, 0.7, 0.18]
+      },
+      combatPresentation: {
+        profileId: "companion-combat",
+        hitFlashColor: [0.4, 0.92, 0.78, 0.18],
+        criticalRingColor: [0.4, 0.92, 0.78, 0.22],
+        selectionRingColor: [0.42, 0.88, 0.74, 0.28],
+        emissiveBoost: [0.03, 0.08, 0.06],
+        impactScale: 1.05
+      },
       interaction: interactionHints({
         canInspect: true,
         canCommandCompanion: true
@@ -1032,6 +1117,27 @@ function createSceneryEntity(
     health: null,
     maxHealth: null,
     metadata: metadata("Scenery", {
+      actorPresentation: {
+        profileId: slug(label),
+        meshAssetId: null,
+        materialPaletteId: "world-prop",
+        animationSetId: "static-prop",
+        scaleMultiplier: 1,
+        footprintRadius: 1.6,
+        selectionRingScale: 2.4,
+        auraColor: [0, 0, 0, 0]
+      },
+      atmosphere:
+        label === "glass spire"
+          ? verdantAtmosphereProfile()
+          : null,
+      atmosphereVolume:
+        label === "glass spire"
+          ? {
+              radius: 9.5,
+              priority: 3
+            }
+          : null,
       interaction: interactionHints({
         canInspect: true
       })
@@ -1063,8 +1169,34 @@ function metadata(
     resourceSkill: null,
     resourceTier: null,
     encounterKind: null,
+    atmosphere: null,
+    atmosphereVolume: null,
+    actorPresentation: null,
+    combatPresentation: null,
     interaction: interactionHints(),
     ...overrides
+  };
+}
+
+function verdantAtmosphereProfile(): NetworkAtmosphereProfile {
+  return {
+    biomeId: "verdant-hollow",
+    skyColor: [0.05, 0.08, 0.12, 1],
+    fogColor: [0.06, 0.12, 0.1, 1],
+    fogNear: 22,
+    fogFar: 148,
+    ambientColor: [0.7, 0.88, 0.84],
+    ambientIntensity: 1.28,
+    sunColor: [1, 0.95, 0.82],
+    sunIntensity: 2.7,
+    sunDirection: [20, 38, 12],
+    fillColor: [0.42, 0.78, 0.92],
+    fillIntensity: 0.78,
+    fillDirection: [-16, 11, -8],
+    rimColor: [0.34, 0.9, 0.82],
+    rimIntensity: 11,
+    groundColor: [0.08, 0.16, 0.12, 1],
+    starfieldIntensity: 0.72
   };
 }
 

--- a/apps/pod-web/src/renderer.ts
+++ b/apps/pod-web/src/renderer.ts
@@ -22,6 +22,7 @@ import {
   type RenderCommand,
   type RenderFrame,
   type TelemetryTrajectorySample,
+  type ThreeJsEnvironment,
   type ThreeJsWebGpuFrame
 } from "./contracts";
 import {
@@ -53,6 +54,10 @@ const INLINE_TSL_FN_WARNING =
   "THREE.TSL: Return statement used in an inline 'Fn()'. Define a layout struct to allow return values.";
 let installedThreeConsoleFilter = false;
 let didReportInlineFnWarning = false;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
 
 export interface PodThreeRendererStats {
   backend: "webgpu" | "webgl2";
@@ -122,6 +127,12 @@ export class PodThreeWorldRenderer {
   private readonly overlayObjects = new Array<THREE.Object3D>();
   private readonly resizeObserver: ResizeObserver | null;
   private readonly options: PodThreeWorldRendererOptions;
+  private hemisphereLight: THREE.HemisphereLight | null = null;
+  private sunLight: THREE.DirectionalLight | null = null;
+  private fillLight: THREE.DirectionalLight | null = null;
+  private rimLight: THREE.PointLight | null = null;
+  private groundMaterial: THREE.MeshStandardMaterial | null = null;
+  private starfieldMaterial: THREE.PointsMaterial | null = null;
   private adaptivePixelRatio: number;
   private smoothedFrameMs = 16.7;
   private adjustmentCooldown = 0;
@@ -178,7 +189,7 @@ export class PodThreeWorldRenderer {
   }
 
   async applyFrame(frame: ThreeJsWebGpuFrame): Promise<void> {
-    this.scene.background = new THREE.Color(...frame.backgroundColor.slice(0, 3));
+    this.applyEnvironment(frame.environment);
 
     const planned = buildFramePlan(frame, {
       ...this.options.cameraRig,
@@ -230,6 +241,7 @@ export class PodThreeWorldRenderer {
 
     const hemisphere = new THREE.HemisphereLight(0xa8d1ff, 0x14263f, 1.2);
     this.scene.add(hemisphere);
+    this.hemisphereLight = hemisphere;
 
     const sun = new THREE.DirectionalLight(0xfff0cf, 2.6);
     sun.position.set(24, 42, 18);
@@ -242,23 +254,25 @@ export class PodThreeWorldRenderer {
     sun.shadow.camera.top = 60;
     sun.shadow.camera.bottom = -60;
     this.scene.add(sun);
+    this.sunLight = sun;
 
     const fill = new THREE.DirectionalLight(0x6cbcff, 0.7);
     fill.position.set(-18, 14, -10);
     this.scene.add(fill);
+    this.fillLight = fill;
 
     const rim = new THREE.PointLight(0x4bc1ff, 12, 180, 2.2);
     rim.position.set(0, 26, 0);
     this.scene.add(rim);
+    this.rimLight = rim;
 
-    const ground = new THREE.Mesh(
-      new THREE.CircleGeometry(140, 64),
-      new THREE.MeshStandardMaterial({
-        color: 0x0e1724,
-        roughness: 0.95,
-        metalness: 0.02
-      })
-    );
+    const groundMaterial = new THREE.MeshStandardMaterial({
+      color: 0x0e1724,
+      roughness: 0.95,
+      metalness: 0.02
+    });
+    this.groundMaterial = groundMaterial;
+    const ground = new THREE.Mesh(new THREE.CircleGeometry(140, 64), groundMaterial);
     ground.rotation.x = -Math.PI / 2;
     ground.receiveShadow = true;
     this.scene.add(ground);
@@ -269,23 +283,88 @@ export class PodThreeWorldRenderer {
       this.scene.add(grid);
     }
 
-    const skyline = new THREE.Points(
-      createStarfieldGeometry(640, 220),
-      new THREE.PointsMaterial({
-        color: 0xcde7ff,
-        size: 0.9,
-        sizeAttenuation: true,
-        transparent: true,
-        opacity: 0.9,
-        depthWrite: false
-      })
-    );
+    const starfieldMaterial = new THREE.PointsMaterial({
+      color: 0xcde7ff,
+      size: 0.9,
+      sizeAttenuation: true,
+      transparent: true,
+      opacity: 0.9,
+      depthWrite: false
+    });
+    this.starfieldMaterial = starfieldMaterial;
+    const skyline = new THREE.Points(createStarfieldGeometry(640, 220), starfieldMaterial);
     skyline.position.y = 36;
     this.scene.add(skyline);
 
     this.overlayScene.background = null;
     this.overlayCamera.position.set(0, 0, 5);
     this.overlayCamera.lookAt(0, 0, 0);
+  }
+
+  private applyEnvironment(environment: ThreeJsEnvironment): void {
+    this.scene.background = new THREE.Color(...environment.skyColor.slice(0, 3));
+    const fog = this.scene.fog;
+    if (fog instanceof THREE.Fog) {
+      fog.color.setRGB(
+        environment.fogColor[0],
+        environment.fogColor[1],
+        environment.fogColor[2]
+      );
+      fog.near = environment.fogNear;
+      fog.far = environment.fogFar;
+    }
+
+    this.hemisphereLight?.color.setRGB(
+      environment.ambientColor[0],
+      environment.ambientColor[1],
+      environment.ambientColor[2]
+    );
+    this.hemisphereLight?.groundColor.setRGB(
+      environment.groundColor[0] * 0.75,
+      environment.groundColor[1] * 0.75,
+      environment.groundColor[2] * 0.75
+    );
+    if (this.hemisphereLight) {
+      this.hemisphereLight.intensity = environment.ambientIntensity;
+    }
+
+    this.sunLight?.color.setRGB(
+      environment.sunColor[0],
+      environment.sunColor[1],
+      environment.sunColor[2]
+    );
+    this.sunLight?.position.set(...environment.sunDirection);
+    if (this.sunLight) {
+      this.sunLight.intensity = environment.sunIntensity;
+    }
+
+    this.fillLight?.color.setRGB(
+      environment.fillColor[0],
+      environment.fillColor[1],
+      environment.fillColor[2]
+    );
+    this.fillLight?.position.set(...environment.fillDirection);
+    if (this.fillLight) {
+      this.fillLight.intensity = environment.fillIntensity;
+    }
+
+    this.rimLight?.color.setRGB(
+      environment.rimColor[0],
+      environment.rimColor[1],
+      environment.rimColor[2]
+    );
+    if (this.rimLight) {
+      this.rimLight.intensity = environment.rimIntensity;
+    }
+
+    this.groundMaterial?.color.setRGB(
+      environment.groundColor[0],
+      environment.groundColor[1],
+      environment.groundColor[2]
+    );
+    if (this.starfieldMaterial) {
+      this.starfieldMaterial.opacity = clamp(environment.starfieldIntensity, 0, 1);
+    }
   }
 
   private applyCamera(

--- a/apps/pod-web/src/sample-frame.ts
+++ b/apps/pod-web/src/sample-frame.ts
@@ -1,4 +1,5 @@
 import type {
+  ThreeJsEnvironment,
   ThreeJsInstance,
   ThreeJsMeshBatch,
   ThreeJsSpriteBatch,
@@ -18,6 +19,7 @@ export function createDemoFrame(seconds: number): ThreeJsWebGpuFrame {
       viewportHeight: window.innerHeight
     },
     backgroundColor: [0.05, 0.09, 0.15, 1],
+    environment: createDemoEnvironment(),
     overlayCommands: [],
     meshBatches: createMeshBatches(seconds),
     spriteBatches: createSpriteBatches(seconds),
@@ -35,6 +37,28 @@ export function createDemoFrame(seconds: number): ThreeJsWebGpuFrame {
       transparentDepthWrite: false,
       maxPixelRatio: 2
     }
+  };
+}
+
+function createDemoEnvironment(): ThreeJsEnvironment {
+  return {
+    biomeId: "demo-rift",
+    skyColor: [0.05, 0.09, 0.15, 1],
+    fogColor: [0.06, 0.11, 0.16, 1],
+    fogNear: 24,
+    fogFar: 190,
+    ambientColor: [0.64, 0.8, 1],
+    ambientIntensity: 1.18,
+    sunColor: [1, 0.95, 0.84],
+    sunIntensity: 2.8,
+    sunDirection: [28, 38, 16],
+    fillColor: [0.4, 0.72, 1],
+    fillIntensity: 0.78,
+    fillDirection: [-20, 12, -8],
+    rimColor: [0.33, 0.82, 1],
+    rimIntensity: 11.5,
+    groundColor: [0.06, 0.1, 0.15, 1],
+    starfieldIntensity: 0.82
   };
 }
 

--- a/crates/pod-core/src/app.rs
+++ b/crates/pod-core/src/app.rs
@@ -3,9 +3,10 @@ use std::collections::HashMap;
 
 use crate::action::AgentAction;
 use crate::component::{
-    AgentControlled, ColorRect, CombatLoadout, CompanionRoster, CreatureIdentity, EncounterState,
-    Health, Inventory, Label, LootContainer, Movement, Perception, ResourceNode, Script, SkillBook,
-    Sprite, Transform, Transform3D, Velocity,
+    ActorPresentation, AgentControlled, AtmosphereProfile, AtmosphereVolume, ColorRect,
+    CombatLoadout, CombatPresentation, CompanionRoster, CreatureIdentity, EncounterState, Health,
+    Inventory, Label, LootContainer, Movement, Perception, ResourceNode, Script, SkillBook, Sprite,
+    Transform, Transform3D, Velocity,
 };
 use crate::contract::{
     ToolBudget, ToolCatalog, ToolDefinition, ToolInvocationRequest, ToolInvocationResult,
@@ -289,6 +290,14 @@ impl App {
         self.types.register_component::<Velocity>("Velocity");
         self.types.register_component::<Sprite>("Sprite");
         self.types.register_component::<ColorRect>("ColorRect");
+        self.types
+            .register_component::<AtmosphereProfile>("AtmosphereProfile");
+        self.types
+            .register_component::<AtmosphereVolume>("AtmosphereVolume");
+        self.types
+            .register_component::<ActorPresentation>("ActorPresentation");
+        self.types
+            .register_component::<CombatPresentation>("CombatPresentation");
         self.types
             .register_component::<AgentControlled>("AgentControlled");
         self.types.register_component::<Health>("Health");

--- a/crates/pod-core/src/component.rs
+++ b/crates/pod-core/src/component.rs
@@ -420,6 +420,120 @@ impl ColorRect {
     }
 }
 
+/// Zone or biome atmosphere that drives sky, fog, and lighting defaults.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AtmosphereProfile {
+    pub biome_id: String,
+    pub sky_color: [f32; 4],
+    pub fog_color: [f32; 4],
+    pub fog_near: f32,
+    pub fog_far: f32,
+    pub ambient_color: [f32; 3],
+    pub ambient_intensity: f32,
+    pub sun_color: [f32; 3],
+    pub sun_intensity: f32,
+    pub sun_direction: [f32; 3],
+    pub fill_color: [f32; 3],
+    pub fill_intensity: f32,
+    pub fill_direction: [f32; 3],
+    pub rim_color: [f32; 3],
+    pub rim_intensity: f32,
+    pub ground_color: [f32; 4],
+    pub starfield_intensity: f32,
+}
+
+impl Default for AtmosphereProfile {
+    fn default() -> Self {
+        Self {
+            biome_id: "neutral-shard".to_string(),
+            sky_color: [0.04, 0.06, 0.1, 1.0],
+            fog_color: [0.035, 0.06, 0.1, 1.0],
+            fog_near: 28.0,
+            fog_far: 180.0,
+            ambient_color: [0.66, 0.82, 1.0],
+            ambient_intensity: 1.2,
+            sun_color: [1.0, 0.94, 0.82],
+            sun_intensity: 2.6,
+            sun_direction: [24.0, 42.0, 18.0],
+            fill_color: [0.42, 0.74, 1.0],
+            fill_intensity: 0.7,
+            fill_direction: [-18.0, 14.0, -10.0],
+            rim_color: [0.29, 0.76, 1.0],
+            rim_intensity: 12.0,
+            ground_color: [0.055, 0.09, 0.14, 1.0],
+            starfield_intensity: 0.9,
+        }
+    }
+}
+
+/// Radius/priority used to select atmosphere volumes around the player.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct AtmosphereVolume {
+    pub radius: f32,
+    pub priority: u8,
+}
+
+impl Default for AtmosphereVolume {
+    fn default() -> Self {
+        Self {
+            radius: 220.0,
+            priority: 0,
+        }
+    }
+}
+
+/// Presentation defaults for actor silhouettes, animation sets, and selection affordances.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ActorPresentation {
+    pub profile_id: String,
+    pub mesh_asset_id: Option<String>,
+    pub material_palette_id: String,
+    pub animation_set_id: String,
+    pub scale_multiplier: f32,
+    pub footprint_radius: f32,
+    pub selection_ring_scale: f32,
+    pub aura_color: [f32; 4],
+}
+
+impl Default for ActorPresentation {
+    fn default() -> Self {
+        Self {
+            profile_id: "default-actor".to_string(),
+            mesh_asset_id: None,
+            material_palette_id: "default".to_string(),
+            animation_set_id: "humanoid-explorer".to_string(),
+            scale_multiplier: 1.0,
+            footprint_radius: 1.0,
+            selection_ring_scale: 2.2,
+            aura_color: [0.0, 0.0, 0.0, 0.0],
+        }
+    }
+}
+
+/// Reusable combat readability defaults for hit flashes, ring colors, and impact sizing.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CombatPresentation {
+    pub profile_id: String,
+    pub hit_flash_color: [f32; 4],
+    pub critical_ring_color: [f32; 4],
+    pub selection_ring_color: [f32; 4],
+    pub emissive_boost: [f32; 3],
+    pub impact_scale: f32,
+}
+
+impl Default for CombatPresentation {
+    fn default() -> Self {
+        Self {
+            profile_id: "default-combat".to_string(),
+            hit_flash_color: [0.92, 0.34, 0.30, 0.22],
+            critical_ring_color: [0.92, 0.34, 0.30, 0.22],
+            selection_ring_color: [0.62, 0.98, 0.84, 0.34],
+            emissive_boost: [0.08, 0.06, 0.02],
+            impact_scale: 1.0,
+        }
+    }
+}
+
 // ============================================================
 // GAMEPLAY COMPONENTS
 // ============================================================

--- a/crates/pod-core/src/world.rs
+++ b/crates/pod-core/src/world.rs
@@ -182,11 +182,15 @@ enum ComponentToAdd {
     Health(Health),
     Sprite(Sprite),
     ColorRect(ColorRect),
+    AtmosphereProfile(AtmosphereProfile),
+    AtmosphereVolume(AtmosphereVolume),
     Label(Label),
     Perception(Perception),
     Movement(Movement),
     Script(Script),
     CombatLoadout(CombatLoadout),
+    ActorPresentation(ActorPresentation),
+    CombatPresentation(CombatPresentation),
     SkillBook(SkillBook),
     Inventory(Inventory),
     CreatureIdentity(CreatureIdentity),
@@ -230,6 +234,17 @@ impl<'w> EntityBuilder<'w> {
         self
     }
 
+    pub fn with_atmosphere_profile(mut self, atmosphere: AtmosphereProfile) -> Self {
+        self.components
+            .push(ComponentToAdd::AtmosphereProfile(atmosphere));
+        self
+    }
+
+    pub fn with_atmosphere_volume(mut self, volume: AtmosphereVolume) -> Self {
+        self.components.push(ComponentToAdd::AtmosphereVolume(volume));
+        self
+    }
+
     pub fn with_movement(mut self, max_speed: f32) -> Self {
         self.components.push(ComponentToAdd::Movement(Movement {
             max_speed,
@@ -263,6 +278,18 @@ impl<'w> EntityBuilder<'w> {
 
     pub fn with_combat_loadout(mut self, loadout: CombatLoadout) -> Self {
         self.components.push(ComponentToAdd::CombatLoadout(loadout));
+        self
+    }
+
+    pub fn with_actor_presentation(mut self, presentation: ActorPresentation) -> Self {
+        self.components
+            .push(ComponentToAdd::ActorPresentation(presentation));
+        self
+    }
+
+    pub fn with_combat_presentation(mut self, presentation: CombatPresentation) -> Self {
+        self.components
+            .push(ComponentToAdd::CombatPresentation(presentation));
         self
     }
 
@@ -328,6 +355,12 @@ impl<'w> EntityBuilder<'w> {
                 ComponentToAdd::ColorRect(cr) => {
                     self.world.ecs.insert_one(entity, cr).unwrap();
                 }
+                ComponentToAdd::AtmosphereProfile(atmosphere) => {
+                    self.world.ecs.insert_one(entity, atmosphere).unwrap();
+                }
+                ComponentToAdd::AtmosphereVolume(volume) => {
+                    self.world.ecs.insert_one(entity, volume).unwrap();
+                }
                 ComponentToAdd::Label(l) => {
                     self.world.ecs.insert_one(entity, l).unwrap();
                 }
@@ -342,6 +375,12 @@ impl<'w> EntityBuilder<'w> {
                 }
                 ComponentToAdd::CombatLoadout(loadout) => {
                     self.world.ecs.insert_one(entity, loadout).unwrap();
+                }
+                ComponentToAdd::ActorPresentation(presentation) => {
+                    self.world.ecs.insert_one(entity, presentation).unwrap();
+                }
+                ComponentToAdd::CombatPresentation(presentation) => {
+                    self.world.ecs.insert_one(entity, presentation).unwrap();
                 }
                 ComponentToAdd::SkillBook(skill_book) => {
                     self.world.ecs.insert_one(entity, skill_book).unwrap();

--- a/crates/pod-net/src/snapshot.rs
+++ b/crates/pod-net/src/snapshot.rs
@@ -6,9 +6,11 @@
 use glam::Vec2;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::ops::Deref;
 
 use pod_core::{
-    Action, CombatLoadout, CombatStyle, CreatureIdentity, EncounterKind, EncounterState, Health,
+    Action, ActorPresentation, AtmosphereProfile, AtmosphereVolume, CombatLoadout,
+    CombatPresentation, CombatStyle, CreatureIdentity, EncounterKind, EncounterState, Health,
     Label, LootContainer, Movement, ResourceNode, SkillKind, Team, Transform, Velocity,
 };
 
@@ -80,7 +82,7 @@ pub struct EntityInteractionHints {
 }
 
 /// Rich per-entity metadata for browser/editor presentation and creator tooling.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub struct EntityMetadataSnapshot {
     pub kind: EntityKind,
     pub team_id: Option<u8>,
@@ -90,6 +92,10 @@ pub struct EntityMetadataSnapshot {
     pub resource_skill: Option<SkillKind>,
     pub resource_tier: Option<u8>,
     pub encounter_kind: Option<EncounterKind>,
+    pub atmosphere: Option<AtmosphereProfile>,
+    pub atmosphere_volume: Option<AtmosphereVolume>,
+    pub actor_presentation: Option<ActorPresentation>,
+    pub combat_presentation: Option<CombatPresentation>,
     pub interaction: EntityInteractionHints,
 }
 
@@ -490,6 +496,10 @@ impl WorldSnapshot {
             let resource = world.ecs.get::<&ResourceNode>(entity).ok();
             let loot = world.ecs.get::<&LootContainer>(entity).ok();
             let encounter = world.ecs.get::<&EncounterState>(entity).ok();
+            let atmosphere = world.ecs.get::<&AtmosphereProfile>(entity).ok();
+            let atmosphere_volume = world.ecs.get::<&AtmosphereVolume>(entity).ok();
+            let actor_presentation = world.ecs.get::<&ActorPresentation>(entity).ok();
+            let combat_presentation = world.ecs.get::<&CombatPresentation>(entity).ok();
 
             let health = health_opt.as_ref().map(|h| h.current);
             let max_health = health_opt.as_ref().map(|h| h.max);
@@ -536,6 +546,10 @@ impl WorldSnapshot {
                     resource_skill: resource.as_ref().map(|resource| resource.skill),
                     resource_tier: resource.as_ref().map(|resource| resource.tier),
                     encounter_kind: encounter.as_ref().map(|encounter| encounter.kind),
+                    atmosphere: atmosphere.map(|value| value.deref().clone()),
+                    atmosphere_volume: atmosphere_volume.map(|value| *value.deref()),
+                    actor_presentation: actor_presentation.map(|value| value.deref().clone()),
+                    combat_presentation: combat_presentation.map(|value| value.deref().clone()),
                     interaction,
                 },
             });
@@ -1032,6 +1046,87 @@ fn hash_bool(hash: &mut u64, value: bool) {
     hash_u64(hash, value as u64);
 }
 
+fn hash_rgba(hash: &mut u64, value: [f32; 4]) {
+    for channel in value {
+        hash_f32(hash, channel);
+    }
+}
+
+fn hash_rgb(hash: &mut u64, value: [f32; 3]) {
+    for channel in value {
+        hash_f32(hash, channel);
+    }
+}
+
+fn hash_option_atmosphere(hash: &mut u64, atmosphere: Option<&AtmosphereProfile>) {
+    match atmosphere {
+        Some(atmosphere) => {
+            hash_u64(hash, 1);
+            hash_option_str(hash, Some(atmosphere.biome_id.as_str()));
+            hash_rgba(hash, atmosphere.sky_color);
+            hash_rgba(hash, atmosphere.fog_color);
+            hash_f32(hash, atmosphere.fog_near);
+            hash_f32(hash, atmosphere.fog_far);
+            hash_rgb(hash, atmosphere.ambient_color);
+            hash_f32(hash, atmosphere.ambient_intensity);
+            hash_rgb(hash, atmosphere.sun_color);
+            hash_f32(hash, atmosphere.sun_intensity);
+            hash_rgb(hash, atmosphere.sun_direction);
+            hash_rgb(hash, atmosphere.fill_color);
+            hash_f32(hash, atmosphere.fill_intensity);
+            hash_rgb(hash, atmosphere.fill_direction);
+            hash_rgb(hash, atmosphere.rim_color);
+            hash_f32(hash, atmosphere.rim_intensity);
+            hash_rgba(hash, atmosphere.ground_color);
+            hash_f32(hash, atmosphere.starfield_intensity);
+        }
+        None => hash_u64(hash, 0),
+    }
+}
+
+fn hash_option_atmosphere_volume(hash: &mut u64, volume: Option<&AtmosphereVolume>) {
+    match volume {
+        Some(volume) => {
+            hash_u64(hash, 1);
+            hash_f32(hash, volume.radius);
+            hash_u64(hash, volume.priority as u64);
+        }
+        None => hash_u64(hash, 0),
+    }
+}
+
+fn hash_option_actor_presentation(hash: &mut u64, presentation: Option<&ActorPresentation>) {
+    match presentation {
+        Some(presentation) => {
+            hash_u64(hash, 1);
+            hash_option_str(hash, Some(presentation.profile_id.as_str()));
+            hash_option_str(hash, presentation.mesh_asset_id.as_deref());
+            hash_option_str(hash, Some(presentation.material_palette_id.as_str()));
+            hash_option_str(hash, Some(presentation.animation_set_id.as_str()));
+            hash_f32(hash, presentation.scale_multiplier);
+            hash_f32(hash, presentation.footprint_radius);
+            hash_f32(hash, presentation.selection_ring_scale);
+            hash_rgba(hash, presentation.aura_color);
+        }
+        None => hash_u64(hash, 0),
+    }
+}
+
+fn hash_option_combat_presentation(hash: &mut u64, presentation: Option<&CombatPresentation>) {
+    match presentation {
+        Some(presentation) => {
+            hash_u64(hash, 1);
+            hash_option_str(hash, Some(presentation.profile_id.as_str()));
+            hash_rgba(hash, presentation.hit_flash_color);
+            hash_rgba(hash, presentation.critical_ring_color);
+            hash_rgba(hash, presentation.selection_ring_color);
+            hash_rgb(hash, presentation.emissive_boost);
+            hash_f32(hash, presentation.impact_scale);
+        }
+        None => hash_u64(hash, 0),
+    }
+}
+
 fn hash_option_u8(hash: &mut u64, value: Option<u8>) {
     match value {
         Some(value) => {
@@ -1051,6 +1146,10 @@ fn hash_entity_metadata(hash: &mut u64, metadata: &EntityMetadataSnapshot) {
     hash_option_str(hash, metadata.resource_skill.map(skill_kind_name));
     hash_option_u8(hash, metadata.resource_tier);
     hash_option_str(hash, metadata.encounter_kind.map(encounter_kind_name));
+    hash_option_atmosphere(hash, metadata.atmosphere.as_ref());
+    hash_option_atmosphere_volume(hash, metadata.atmosphere_volume.as_ref());
+    hash_option_actor_presentation(hash, metadata.actor_presentation.as_ref());
+    hash_option_combat_presentation(hash, metadata.combat_presentation.as_ref());
     hash_bool(hash, metadata.interaction.can_inspect);
     hash_bool(hash, metadata.interaction.can_interact);
     hash_bool(hash, metadata.interaction.can_attack);
@@ -1181,7 +1280,10 @@ fn encounter_kind_name(kind: EncounterKind) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pod_core::{CombatLoadout, CreatureIdentity, IdleAgent, LootContainer, ResourceNode};
+    use pod_core::{
+        ActorPresentation, AtmosphereProfile, AtmosphereVolume, CombatLoadout, CombatPresentation,
+        CreatureIdentity, IdleAgent, LootContainer, ResourceNode,
+    };
 
     #[test]
     fn test_snapshot_default() {
@@ -1212,6 +1314,21 @@ mod tests {
             .with_label("Wild Embercub", Team::None)
             .with_health(24.0)
             .with_combat_loadout(CombatLoadout::default())
+            .with_actor_presentation(ActorPresentation {
+                profile_id: "wild-creature".into(),
+                mesh_asset_id: Some("rift-beast".into()),
+                material_palette_id: "ember".into(),
+                animation_set_id: "beast-stalker".into(),
+                scale_multiplier: 1.15,
+                footprint_radius: 1.45,
+                selection_ring_scale: 2.8,
+                aura_color: [0.92, 0.46, 0.22, 0.2],
+            })
+            .with_combat_presentation(CombatPresentation {
+                profile_id: "ember-crit".into(),
+                critical_ring_color: [0.95, 0.32, 0.18, 0.28],
+                ..CombatPresentation::default()
+            })
             .with_creature_identity(CreatureIdentity {
                 species_id: "embercub".into(),
                 species_name: "Wild Embercub".into(),
@@ -1219,10 +1336,24 @@ mod tests {
                 ..CreatureIdentity::default()
             })
             .build();
+        world
+            .spawn_at(4.0, 4.0)
+            .with_label("Verdant Atmosphere Anchor", Team::None)
+            .with_atmosphere_profile(AtmosphereProfile {
+                biome_id: "verdant-hollow".into(),
+                fog_color: [0.05, 0.11, 0.09, 1.0],
+                ground_color: [0.08, 0.15, 0.1, 1.0],
+                ..AtmosphereProfile::default()
+            })
+            .with_atmosphere_volume(AtmosphereVolume {
+                radius: 128.0,
+                priority: 3,
+            })
+            .build();
 
         let snapshot = WorldSnapshot::capture(&world);
 
-        assert_eq!(snapshot.entities.len(), 4);
+        assert_eq!(snapshot.entities.len(), 5);
 
         let player = snapshot
             .entities
@@ -1260,6 +1391,44 @@ mod tests {
             Some("Wild Embercub")
         );
         assert!(creature.metadata.interaction.can_capture);
+        assert_eq!(
+            creature
+                .metadata
+                .actor_presentation
+                .as_ref()
+                .and_then(|presentation| presentation.mesh_asset_id.as_deref()),
+            Some("rift-beast")
+        );
+        assert_eq!(
+            creature
+                .metadata
+                .combat_presentation
+                .as_ref()
+                .map(|presentation| presentation.profile_id.as_str()),
+            Some("ember-crit")
+        );
+
+        let atmosphere = snapshot
+            .entities
+            .iter()
+            .find(|entity| entity.label.as_deref() == Some("Verdant Atmosphere Anchor"))
+            .expect("atmosphere anchor present");
+        assert_eq!(
+            atmosphere
+                .metadata
+                .atmosphere
+                .as_ref()
+                .map(|atmosphere| atmosphere.biome_id.as_str()),
+            Some("verdant-hollow")
+        );
+        assert_eq!(
+            atmosphere
+                .metadata
+                .atmosphere_volume
+                .as_ref()
+                .map(|volume| volume.priority),
+            Some(3)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary\n- add shared pod-core presentation primitives for atmosphere, actor presentation, and combat presentation\n- carry those authoritative primitives through pod-net snapshots for static and dynamic entities\n- honor the new metadata in pod-web frame generation, renderer environment lighting, and browser tests\n\n## Validation\n- cargo test -p pod-core --lib\n- cargo test -p pod-net --lib\n- cd apps/pod-web && bun test ./src/contracts.test.ts ./src/frame-plan.test.ts ./src/local-world.test.ts ./src/affordances.test.ts\n- cd apps/pod-web && bun run typecheck\n- cd apps/pod-web && bun run build\n- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Entity presentation system with customizable visual effects (selection rings, aura colors, critical rings)
  * Atmosphere and environment profiles enabling dynamic lighting and weather effects
  * Enhanced combat visuals including impact scaling and hit flash effects
  * Actor presentation data for mesh, animation, and scale customization per entity

* **Tests**
  * Added comprehensive test coverage for presentation-driven environments and actor affordances

* **Documentation**
  * Updated iteration planning documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->