### PR TITLE
Add creator world metadata primitives

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -794,5 +794,18 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cd apps/pod-web && bun run build`
   - `git diff --check`
 
-**Last updated**: Iteration 82
-**Current focus**: Iteration 83 browser-first flagship world delivery, continuing with true streamed chunk residency beyond the in-memory manifest cache, authored world chunk activation/deactivation, plus higher-level creator primitives for authored factions, quest hooks, encounter tables, and biome-linked spawn distributions
+### Iteration 83
+- [x] Added creator-facing world primitives in `pod-core` for `FactionAffiliation`, `QuestAnchor`, `EncounterProfile`, and `SpawnProfile`, and registered them in the core type registry plus fluent world builder so authored MMO content can express faction identity, quest hooks, encounter tables, and biome spawn rules as native engine data.
+- [x] Extended authoritative `pod-net` snapshot metadata and hashing to carry those creator-world primitives, including faction context, quest anchors, encounter profile tuning, and spawn profile identity for both moving actors and static landmarks.
+- [x] Updated `apps/pod-web` metadata parsing, local test world content, and creator affordance summaries so factions, quest hooks, encounter tables, and spawn profiles are immediately visible and testable in the browser sandbox instead of remaining hidden transport-only data.
+- [x] Added deterministic coverage for snapshot capture of the new primitives plus browser-side faction/quest display and local-world authored metadata seeding.
+- [x] Validated touched targets:
+  - `cargo test -p pod-core --lib`
+  - `cargo test -p pod-net --lib`
+  - `cd apps/pod-web && bun test ./src/contracts.test.ts ./src/local-world.test.ts ./src/affordances.test.ts`
+  - `cd apps/pod-web && bun run typecheck`
+  - `cd apps/pod-web && bun run build`
+  - `git diff --check`
+
+**Last updated**: Iteration 83
+**Current focus**: Iteration 84 browser-first flagship world delivery, continuing with true streamed chunk residency beyond the in-memory manifest cache, authored world chunk activation/deactivation, and higher-level creator workflows for quest-state graphs, faction reputation progression, and encounter-table driven population across streamed world regions

--- a/apps/pod-web/src/affordances.test.ts
+++ b/apps/pod-web/src/affordances.test.ts
@@ -15,6 +15,10 @@ function metadata(
     resourceSkill: null,
     resourceTier: null,
     encounterKind: null,
+    faction: null,
+    questAnchor: null,
+    encounterProfile: null,
+    spawnProfile: null,
     atmosphere: null,
     atmosphereVolume: null,
     actorPresentation: null,
@@ -156,5 +160,81 @@ describe("target affordances", () => {
         })
       })
     ).toBe("Static scenery");
+  });
+
+  test("surfaces faction and quest metadata for creators", () => {
+    expect(
+      formatTargetSummary(
+        {
+          id: 31,
+          position: [6, 4],
+          velocity: [0, 0],
+          rotation: 0,
+          label: "Archivist Mara",
+          metadata: metadata({
+            kind: "Npc",
+            faction: {
+              factionId: "verdant-wardens",
+              roleId: "archivist",
+              disposition: "Friendly",
+              influenceRadius: 14
+            },
+            questAnchor: {
+              questIds: ["verdant-intro", "spire-records"],
+              primaryPrompt: "Ask Mara about the spire",
+              stageTags: ["intro", "lore"]
+            },
+            interaction: {
+              canInspect: true,
+              canInteract: true,
+              canAttack: false,
+              canGather: false,
+              canLoot: false,
+              canCapture: false,
+              canCommandCompanion: false,
+              canChat: true
+            }
+          })
+        },
+        {
+          id: 1,
+          position: [2, 2],
+          velocity: [0, 0],
+          rotation: 0,
+          label: "Scout",
+          metadata: metadata({
+            kind: "Player"
+          })
+        }
+      )
+    ).toBe("Archivist Mara · E(31) · npc · verdant-wardens archivist · 2 quests · 4u away");
+
+    expect(
+      describeTargetAffordances({
+        id: 31,
+        position: [6, 4],
+        velocity: [0, 0],
+        rotation: 0,
+        label: "Archivist Mara",
+        metadata: metadata({
+          kind: "Npc",
+          questAnchor: {
+            questIds: ["verdant-intro"],
+            primaryPrompt: "Ask Mara about the spire",
+            stageTags: ["intro"]
+          },
+          interaction: {
+            canInspect: true,
+            canInteract: true,
+            canAttack: false,
+            canGather: false,
+            canLoot: false,
+            canCapture: false,
+            canCommandCompanion: false,
+            canChat: true
+          }
+        })
+      })
+    ).toBe("Q quests · E interact · Enter chat");
   });
 });

--- a/apps/pod-web/src/affordances.ts
+++ b/apps/pod-web/src/affordances.ts
@@ -13,6 +13,14 @@ export function formatTargetSummary(
   if (descriptor) {
     parts.push(descriptor);
   }
+  const faction = factionSummary(target);
+  if (faction) {
+    parts.push(faction);
+  }
+  const questHooks = questHookSummary(target);
+  if (questHooks) {
+    parts.push(questHooks);
+  }
   if (target.metadata.teamId != null) {
     parts.push(`team ${target.metadata.teamId}`);
   }
@@ -133,12 +141,38 @@ function describeTargetKind(target: NetworkEntitySnapshot): string | null {
   }
 }
 
+function factionSummary(target: NetworkEntitySnapshot): string | null {
+  const faction = target.metadata.faction;
+  if (!faction) {
+    return null;
+  }
+
+  return `${faction.factionId} ${faction.roleId}`;
+}
+
+function questHookSummary(target: NetworkEntitySnapshot): string | null {
+  const questAnchor = target.metadata.questAnchor;
+  if (!questAnchor || questAnchor.questIds.length === 0) {
+    return null;
+  }
+
+  return questAnchor.questIds.length === 1
+    ? "1 quest"
+    : `${questAnchor.questIds.length} quests`;
+}
+
 function authoritativeAffordances(target: NetworkEntitySnapshot): string[] {
   const actions: string[] = [];
   const hints = target.metadata.interaction;
 
   if (target.metadata.kind === "Scenery") {
+    if ((target.metadata.questAnchor?.questIds.length ?? 0) > 0) {
+      return ["Q quests", "Static scenery"];
+    }
     return ["Static scenery"];
+  }
+  if ((target.metadata.questAnchor?.questIds.length ?? 0) > 0) {
+    actions.push("Q quests");
   }
   if (hints.canAttack) {
     actions.push("Space attack");

--- a/apps/pod-web/src/contracts.test.ts
+++ b/apps/pod-web/src/contracts.test.ts
@@ -32,6 +32,10 @@ function entityMetadata(kind: string, overrides: Record<string, unknown> = {}) {
     resource_skill: null,
     resource_tier: null,
     encounter_kind: null,
+    faction: null,
+    quest_anchor: null,
+    encounter_profile: null,
+    spawn_profile: null,
     atmosphere: null,
     atmosphere_volume: null,
     actor_presentation: null,
@@ -63,6 +67,10 @@ function typedEntityMetadata(
     resourceSkill: null,
     resourceTier: null,
     encounterKind: null,
+    faction: null,
+    questAnchor: null,
+    encounterProfile: null,
+    spawnProfile: null,
     atmosphere: null,
     atmosphereVolume: null,
     actorPresentation: null,
@@ -309,6 +317,12 @@ describe("TOON contract parsing", () => {
                 rotation: 0.4,
                 label: "Hero",
                 metadata: entityMetadata("Player", {
+                  faction: {
+                    faction_id: "verdant-wardens",
+                    role_id: "initiate",
+                    disposition: "Friendly",
+                    influence_radius: 18
+                  },
                   interaction: {
                     can_inspect: true,
                     can_interact: true,
@@ -333,6 +347,7 @@ describe("TOON contract parsing", () => {
     }
     expect(welcome.snapshot.entities[0]?.position).toEqual([12, 18]);
     expect(welcome.snapshot.entities[0]?.metadata.kind).toBe("Player");
+    expect(welcome.snapshot.entities[0]?.metadata.faction?.factionId).toBe("verdant-wardens");
 
     const delta = parseDirectConnectServerMessage(
       JSON.stringify({
@@ -352,6 +367,11 @@ describe("TOON contract parsing", () => {
                 label: "Hero",
                 metadata: entityMetadata("Player", {
                   team_id: 2,
+                  quest_anchor: {
+                    quest_ids: ["verdant-intro"],
+                    primary_prompt: "Speak with the wardens",
+                    stage_tags: ["intro"]
+                  },
                   interaction: {
                     can_inspect: true,
                     can_interact: true,
@@ -378,6 +398,9 @@ describe("TOON contract parsing", () => {
     expect(delta.delta.updated[0]?.position).toEqual([14, 19]);
     expect(delta.acknowledgedActionTick).toBe(12);
     expect(delta.delta.updated[0]?.metadata.teamId).toBe(2);
+    expect(delta.delta.updated[0]?.metadata.questAnchor?.questIds).toEqual([
+      "verdant-intro"
+    ]);
   });
 
   test("parses authoritative event batches into gameplay summaries", () => {

--- a/apps/pod-web/src/contracts.ts
+++ b/apps/pod-web/src/contracts.ts
@@ -431,6 +431,36 @@ export interface NetworkEntityInteractionHints {
   canChat: boolean;
 }
 
+export type NetworkFactionDisposition = "Friendly" | "Neutral" | "Hostile";
+
+export interface NetworkFactionAffiliation {
+  factionId: string;
+  roleId: string;
+  disposition: NetworkFactionDisposition;
+  influenceRadius: number;
+}
+
+export interface NetworkQuestAnchor {
+  questIds: string[];
+  primaryPrompt: string;
+  stageTags: string[];
+}
+
+export interface NetworkEncounterProfile {
+  tableId: string;
+  difficultyTier: number;
+  recommendedPartySize: number;
+  respawnTicks: number;
+}
+
+export interface NetworkSpawnProfile {
+  profileId: string;
+  biomeId: string;
+  spawnGroup: string;
+  respawnTicks: number;
+  leashRadius: number;
+}
+
 export interface NetworkAtmosphereProfile {
   biomeId: string;
   skyColor: RgbaTuple;
@@ -485,6 +515,10 @@ export interface NetworkEntityMetadataSnapshot {
   resourceSkill: NetworkSkillKind | null;
   resourceTier: number | null;
   encounterKind: NetworkEncounterKind | null;
+  faction: NetworkFactionAffiliation | null;
+  questAnchor: NetworkQuestAnchor | null;
+  encounterProfile: NetworkEncounterProfile | null;
+  spawnProfile: NetworkSpawnProfile | null;
   atmosphere: NetworkAtmosphereProfile | null;
   atmosphereVolume: NetworkAtmosphereVolume | null;
   actorPresentation: NetworkActorPresentation | null;
@@ -760,6 +794,12 @@ function parseNetworkEntityMetadata(value: unknown): NetworkEntityMetadataSnapsh
     resourceSkill: isSkillKind(resourceSkill) ? resourceSkill : null,
     resourceTier: optionalNumber(value.resource_tier ?? value.resourceTier) ?? null,
     encounterKind: isEncounterKind(encounterKind) ? encounterKind : null,
+    faction: parseFactionAffiliation(value.faction),
+    questAnchor: parseQuestAnchor(value.quest_anchor ?? value.questAnchor),
+    encounterProfile: parseEncounterProfile(
+      value.encounter_profile ?? value.encounterProfile
+    ),
+    spawnProfile: parseSpawnProfile(value.spawn_profile ?? value.spawnProfile),
     atmosphere: parseAtmosphereProfile(value.atmosphere),
     atmosphereVolume: parseAtmosphereVolume(value.atmosphere_volume ?? value.atmosphereVolume),
     actorPresentation: parseActorPresentation(
@@ -769,6 +809,116 @@ function parseNetworkEntityMetadata(value: unknown): NetworkEntityMetadataSnapsh
       value.combat_presentation ?? value.combatPresentation
     ),
     interaction: parseInteractionHints(value.interaction)
+  };
+}
+
+function parseStringArray(value: unknown): string[] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  const strings = value.filter((entry): entry is string => typeof entry === "string");
+  return strings.length === value.length ? strings : null;
+}
+
+function parseFactionAffiliation(value: unknown): NetworkFactionAffiliation | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const factionId = optionalString(value.faction_id ?? value.factionId);
+  const roleId = optionalString(value.role_id ?? value.roleId);
+  const disposition = value.disposition;
+  const influenceRadius = asNumber(value.influence_radius ?? value.influenceRadius);
+  if (
+    factionId == null ||
+    roleId == null ||
+    !isFactionDisposition(disposition) ||
+    influenceRadius == null
+  ) {
+    return null;
+  }
+
+  return {
+    factionId,
+    roleId,
+    disposition,
+    influenceRadius
+  };
+}
+
+function parseQuestAnchor(value: unknown): NetworkQuestAnchor | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const questIds = parseStringArray(value.quest_ids ?? value.questIds);
+  const primaryPrompt = optionalString(value.primary_prompt ?? value.primaryPrompt);
+  const stageTags = parseStringArray(value.stage_tags ?? value.stageTags);
+  if (questIds == null || primaryPrompt == null || stageTags == null) {
+    return null;
+  }
+
+  return {
+    questIds,
+    primaryPrompt,
+    stageTags
+  };
+}
+
+function parseEncounterProfile(value: unknown): NetworkEncounterProfile | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const tableId = optionalString(value.table_id ?? value.tableId);
+  const difficultyTier = asNumber(value.difficulty_tier ?? value.difficultyTier);
+  const recommendedPartySize = asNumber(
+    value.recommended_party_size ?? value.recommendedPartySize
+  );
+  const respawnTicks = asNumber(value.respawn_ticks ?? value.respawnTicks);
+  if (
+    tableId == null ||
+    difficultyTier == null ||
+    recommendedPartySize == null ||
+    respawnTicks == null
+  ) {
+    return null;
+  }
+
+  return {
+    tableId,
+    difficultyTier,
+    recommendedPartySize,
+    respawnTicks
+  };
+}
+
+function parseSpawnProfile(value: unknown): NetworkSpawnProfile | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const profileId = optionalString(value.profile_id ?? value.profileId);
+  const biomeId = optionalString(value.biome_id ?? value.biomeId);
+  const spawnGroup = optionalString(value.spawn_group ?? value.spawnGroup);
+  const respawnTicks = asNumber(value.respawn_ticks ?? value.respawnTicks);
+  const leashRadius = asNumber(value.leash_radius ?? value.leashRadius);
+  if (
+    profileId == null ||
+    biomeId == null ||
+    spawnGroup == null ||
+    respawnTicks == null ||
+    leashRadius == null
+  ) {
+    return null;
+  }
+
+  return {
+    profileId,
+    biomeId,
+    spawnGroup,
+    respawnTicks,
+    leashRadius
   };
 }
 
@@ -975,12 +1125,20 @@ function defaultNetworkEntityMetadata(): NetworkEntityMetadataSnapshot {
     resourceSkill: null,
     resourceTier: null,
     encounterKind: null,
+    faction: null,
+    questAnchor: null,
+    encounterProfile: null,
+    spawnProfile: null,
     atmosphere: null,
     atmosphereVolume: null,
     actorPresentation: null,
     combatPresentation: null,
     interaction: defaultInteractionHints()
   };
+}
+
+function isFactionDisposition(value: unknown): value is NetworkFactionDisposition {
+  return value === "Friendly" || value === "Neutral" || value === "Hostile";
 }
 
 function isEntityKind(value: unknown): value is NetworkEntityKind {

--- a/apps/pod-web/src/local-world.test.ts
+++ b/apps/pod-web/src/local-world.test.ts
@@ -44,6 +44,26 @@ describe("PodWebLocalWorld", () => {
     expect(snapshot.entities.some((entity) => entity.metadata.kind === "LootContainer")).toBe(true);
     expect(snapshot.entities.some((entity) => entity.label === "glass spire")).toBe(true);
     expect(snapshot.entities.some((entity) => entity.label === "canopy tree")).toBe(true);
+    expect(
+      snapshot.entities.some(
+        (entity) => entity.metadata.faction?.factionId === "verdant-wardens"
+      )
+    ).toBe(true);
+    expect(
+      snapshot.entities.some(
+        (entity) => (entity.metadata.questAnchor?.questIds.length ?? 0) > 0
+      )
+    ).toBe(true);
+    expect(
+      snapshot.entities.some(
+        (entity) => entity.metadata.encounterProfile?.tableId === "verdant-lynx-encounters"
+      )
+    ).toBe(true);
+    expect(
+      snapshot.entities.some(
+        (entity) => entity.metadata.spawnProfile?.biomeId === "verdant-hollow"
+      )
+    ).toBe(true);
   });
 
   test("moves the player and exposes high-signal text state", () => {

--- a/apps/pod-web/src/local-world.ts
+++ b/apps/pod-web/src/local-world.ts
@@ -802,6 +802,7 @@ function createPlayerEntity(playerName: string): LocalEntity {
     metadata: metadata("Player", {
       teamId: 1,
       combatStyle: "Melee",
+      faction: factionAffiliation("verdant-wardens", "initiate", "Friendly", 18),
       actorPresentation: {
         profileId: "hero-ranger",
         meshAssetId: "adventurer-hero",
@@ -855,6 +856,25 @@ function createNpcEntity(id: number, label: string, position: Vec2Tuple): LocalE
     metadata: metadata("Npc", {
       teamId: 2,
       combatStyle: "Magic",
+      faction: factionAffiliation("verdant-wardens", slug(label), "Friendly", 14),
+      questAnchor:
+        label === "Archivist Mara"
+          ? questAnchor(
+              ["verdant-intro", "spire-records"],
+              "Ask Mara about the glass spire",
+              ["intro", "lore"]
+            )
+          : label === "Forgekeeper Ivo"
+            ? questAnchor(
+                ["tempered-trail"],
+                "Ask Ivo to prepare expedition gear",
+                ["crafting", "gear"]
+              )
+            : questAnchor(
+                ["lynx-patrol", "hollow-watch"],
+                "Report the field state to Selene",
+                ["combat", "patrol"]
+              ),
       actorPresentation: {
         profileId: "hub-npc",
         meshAssetId: "adventurer-avatar",
@@ -907,6 +927,9 @@ function createWildCreatureEntity(
       speciesId: slug(speciesName),
       speciesName,
       encounterKind: "WildCreature",
+      faction: factionAffiliation("verdant-wilds", "predator", "Hostile", 22),
+      encounterProfile: encounterProfile(`${slug(speciesName)}-encounters`, 2, 1, 1_200),
+      spawnProfile: spawnProfile(`${slug(speciesName)}-grove`, "verdant-hollow", "wildlife", 900, 16),
       actorPresentation: {
         profileId: slug(speciesName),
         meshAssetId: "rift-beast",
@@ -965,6 +988,13 @@ function createResourceEntity(
     metadata: metadata("ResourceNode", {
       resourceSkill: skill,
       resourceTier: 1,
+      spawnProfile: spawnProfile(
+        `${slug(label)}-resource`,
+        "verdant-hollow",
+        skill === "Woodcutting" ? "forest-resources" : "mineral-resources",
+        720,
+        12
+      ),
       actorPresentation: {
         profileId: skill === "Woodcutting" ? "tree-resource" : "ore-resource",
         meshAssetId: skill === "Woodcutting" ? "canopy-tree" : "weathered-boulder",
@@ -1012,6 +1042,14 @@ function createLootEntity(
     health: null,
     maxHealth: null,
     metadata: metadata("LootContainer", {
+      questAnchor:
+        label === "Expedition Chest"
+          ? questAnchor(
+              ["ember-charm-recovery"],
+              "Recover the ember charm from the expedition chest",
+              ["loot", "artifact"]
+            )
+          : null,
       actorPresentation: {
         profileId: "loot-cache",
         meshAssetId: "supply-crate",
@@ -1063,6 +1101,7 @@ function createCompanionEntity(
       combatStyle: "Summoning",
       speciesId,
       speciesName,
+      faction: factionAffiliation("verdant-wardens", "companion", "Friendly", 10),
       actorPresentation: {
         profileId: speciesId,
         meshAssetId: "spirit-companion",
@@ -1117,6 +1156,18 @@ function createSceneryEntity(
     health: null,
     maxHealth: null,
     metadata: metadata("Scenery", {
+      faction:
+        label === "glass spire"
+          ? factionAffiliation("ancient-spirekeepers", "relic", "Neutral", 30)
+          : null,
+      questAnchor:
+        label === "glass spire"
+          ? questAnchor(
+              ["spire-attunement"],
+              "Inspect the glass spire to attune with Verdant Hollow",
+              ["exploration", "attunement"]
+            )
+          : null,
       actorPresentation: {
         profileId: slug(label),
         meshAssetId: null,
@@ -1169,6 +1220,10 @@ function metadata(
     resourceSkill: null,
     resourceTier: null,
     encounterKind: null,
+    faction: null,
+    questAnchor: null,
+    encounterProfile: null,
+    spawnProfile: null,
     atmosphere: null,
     atmosphereVolume: null,
     actorPresentation: null,
@@ -1197,6 +1252,62 @@ function verdantAtmosphereProfile(): NetworkAtmosphereProfile {
     rimIntensity: 11,
     groundColor: [0.08, 0.16, 0.12, 1],
     starfieldIntensity: 0.72
+  };
+}
+
+function factionAffiliation(
+  factionId: string,
+  roleId: string,
+  disposition: "Friendly" | "Neutral" | "Hostile",
+  influenceRadius: number
+) {
+  return {
+    factionId,
+    roleId,
+    disposition,
+    influenceRadius
+  };
+}
+
+function questAnchor(
+  questIds: string[],
+  primaryPrompt: string,
+  stageTags: string[]
+) {
+  return {
+    questIds,
+    primaryPrompt,
+    stageTags
+  };
+}
+
+function encounterProfile(
+  tableId: string,
+  difficultyTier: number,
+  recommendedPartySize: number,
+  respawnTicks: number
+) {
+  return {
+    tableId,
+    difficultyTier,
+    recommendedPartySize,
+    respawnTicks
+  };
+}
+
+function spawnProfile(
+  profileId: string,
+  biomeId: string,
+  spawnGroup: string,
+  respawnTicks: number,
+  leashRadius: number
+) {
+  return {
+    profileId,
+    biomeId,
+    spawnGroup,
+    respawnTicks,
+    leashRadius
   };
 }
 

--- a/crates/pod-core/src/app.rs
+++ b/crates/pod-core/src/app.rs
@@ -4,9 +4,10 @@ use std::collections::HashMap;
 use crate::action::AgentAction;
 use crate::component::{
     ActorPresentation, AgentControlled, AtmosphereProfile, AtmosphereVolume, ColorRect,
-    CombatLoadout, CombatPresentation, CompanionRoster, CreatureIdentity, EncounterState, Health,
-    Inventory, Label, LootContainer, Movement, Perception, ResourceNode, Script, SkillBook, Sprite,
-    Transform, Transform3D, Velocity,
+    CombatLoadout, CombatPresentation, CompanionRoster, CreatureIdentity, EncounterProfile,
+    EncounterState, FactionAffiliation, Health, Inventory, Label, LootContainer, Movement,
+    Perception, QuestAnchor, ResourceNode, Script, SkillBook, SpawnProfile, Sprite, Transform,
+    Transform3D, Velocity,
 };
 use crate::contract::{
     ToolBudget, ToolCatalog, ToolDefinition, ToolInvocationRequest, ToolInvocationResult,
@@ -299,6 +300,13 @@ impl App {
         self.types
             .register_component::<CombatPresentation>("CombatPresentation");
         self.types
+            .register_component::<FactionAffiliation>("FactionAffiliation");
+        self.types.register_component::<QuestAnchor>("QuestAnchor");
+        self.types
+            .register_component::<EncounterProfile>("EncounterProfile");
+        self.types
+            .register_component::<SpawnProfile>("SpawnProfile");
+        self.types
             .register_component::<AgentControlled>("AgentControlled");
         self.types.register_component::<Health>("Health");
         self.types.register_component::<Label>("Label");
@@ -428,6 +436,11 @@ mod tests {
             .metadata::<crate::component::Transform>()
             .expect("transform metadata");
         assert_eq!(transform.category, RegisteredTypeCategory::Component);
+        let faction = app
+            .type_registry()
+            .metadata::<crate::component::FactionAffiliation>()
+            .expect("faction metadata");
+        assert_eq!(faction.category, RegisteredTypeCategory::Component);
 
         let observation = app
             .type_registry()

--- a/crates/pod-core/src/component.rs
+++ b/crates/pod-core/src/component.rs
@@ -534,6 +534,100 @@ impl Default for CombatPresentation {
     }
 }
 
+/// Relationship of an entity to an authored faction or social group.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FactionDisposition {
+    Friendly,
+    Neutral,
+    Hostile,
+}
+
+impl Default for FactionDisposition {
+    fn default() -> Self {
+        Self::Neutral
+    }
+}
+
+/// Authored faction context used for NPCs, creatures, props, and quest hubs.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FactionAffiliation {
+    pub faction_id: String,
+    pub role_id: String,
+    pub disposition: FactionDisposition,
+    pub influence_radius: f32,
+}
+
+impl Default for FactionAffiliation {
+    fn default() -> Self {
+        Self {
+            faction_id: "neutral-world".to_string(),
+            role_id: "wanderer".to_string(),
+            disposition: FactionDisposition::Neutral,
+            influence_radius: 0.0,
+        }
+    }
+}
+
+/// World-authored quest hooks attached to NPCs, props, and landmarks.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct QuestAnchor {
+    pub quest_ids: Vec<String>,
+    pub primary_prompt: String,
+    pub stage_tags: Vec<String>,
+}
+
+impl Default for QuestAnchor {
+    fn default() -> Self {
+        Self {
+            quest_ids: Vec::new(),
+            primary_prompt: String::new(),
+            stage_tags: Vec::new(),
+        }
+    }
+}
+
+/// Encounter-table identity and tuning for authored creatures and regions.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EncounterProfile {
+    pub table_id: String,
+    pub difficulty_tier: u8,
+    pub recommended_party_size: u8,
+    pub respawn_ticks: u32,
+}
+
+impl Default for EncounterProfile {
+    fn default() -> Self {
+        Self {
+            table_id: "ambient-encounter".to_string(),
+            difficulty_tier: 1,
+            recommended_party_size: 1,
+            respawn_ticks: 60 * 45,
+        }
+    }
+}
+
+/// Spawn-table identity for authored fauna, resources, and region population groups.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SpawnProfile {
+    pub profile_id: String,
+    pub biome_id: String,
+    pub spawn_group: String,
+    pub respawn_ticks: u32,
+    pub leash_radius: f32,
+}
+
+impl Default for SpawnProfile {
+    fn default() -> Self {
+        Self {
+            profile_id: "ambient-spawn".to_string(),
+            biome_id: "neutral-shard".to_string(),
+            spawn_group: "ambient".to_string(),
+            respawn_ticks: 60 * 30,
+            leash_radius: 18.0,
+        }
+    }
+}
+
 // ============================================================
 // GAMEPLAY COMPONENTS
 // ============================================================

--- a/crates/pod-core/src/world.rs
+++ b/crates/pod-core/src/world.rs
@@ -191,6 +191,10 @@ enum ComponentToAdd {
     CombatLoadout(CombatLoadout),
     ActorPresentation(ActorPresentation),
     CombatPresentation(CombatPresentation),
+    FactionAffiliation(FactionAffiliation),
+    QuestAnchor(QuestAnchor),
+    EncounterProfile(EncounterProfile),
+    SpawnProfile(SpawnProfile),
     SkillBook(SkillBook),
     Inventory(Inventory),
     CreatureIdentity(CreatureIdentity),
@@ -293,6 +297,28 @@ impl<'w> EntityBuilder<'w> {
         self
     }
 
+    pub fn with_faction_affiliation(mut self, faction: FactionAffiliation) -> Self {
+        self.components
+            .push(ComponentToAdd::FactionAffiliation(faction));
+        self
+    }
+
+    pub fn with_quest_anchor(mut self, quest_anchor: QuestAnchor) -> Self {
+        self.components.push(ComponentToAdd::QuestAnchor(quest_anchor));
+        self
+    }
+
+    pub fn with_encounter_profile(mut self, encounter: EncounterProfile) -> Self {
+        self.components
+            .push(ComponentToAdd::EncounterProfile(encounter));
+        self
+    }
+
+    pub fn with_spawn_profile(mut self, spawn: SpawnProfile) -> Self {
+        self.components.push(ComponentToAdd::SpawnProfile(spawn));
+        self
+    }
+
     pub fn with_skill_book(mut self, skill_book: SkillBook) -> Self {
         self.components.push(ComponentToAdd::SkillBook(skill_book));
         self
@@ -381,6 +407,18 @@ impl<'w> EntityBuilder<'w> {
                 }
                 ComponentToAdd::CombatPresentation(presentation) => {
                     self.world.ecs.insert_one(entity, presentation).unwrap();
+                }
+                ComponentToAdd::FactionAffiliation(faction) => {
+                    self.world.ecs.insert_one(entity, faction).unwrap();
+                }
+                ComponentToAdd::QuestAnchor(quest_anchor) => {
+                    self.world.ecs.insert_one(entity, quest_anchor).unwrap();
+                }
+                ComponentToAdd::EncounterProfile(encounter) => {
+                    self.world.ecs.insert_one(entity, encounter).unwrap();
+                }
+                ComponentToAdd::SpawnProfile(spawn) => {
+                    self.world.ecs.insert_one(entity, spawn).unwrap();
                 }
                 ComponentToAdd::SkillBook(skill_book) => {
                     self.world.ecs.insert_one(entity, skill_book).unwrap();

--- a/crates/pod-net/src/snapshot.rs
+++ b/crates/pod-net/src/snapshot.rs
@@ -10,8 +10,9 @@ use std::ops::Deref;
 
 use pod_core::{
     Action, ActorPresentation, AtmosphereProfile, AtmosphereVolume, CombatLoadout,
-    CombatPresentation, CombatStyle, CreatureIdentity, EncounterKind, EncounterState, Health,
-    Label, LootContainer, Movement, ResourceNode, SkillKind, Team, Transform, Velocity,
+    CombatPresentation, CombatStyle, CreatureIdentity, EncounterKind, EncounterProfile,
+    EncounterState, FactionAffiliation, FactionDisposition, Health, Label, LootContainer,
+    Movement, QuestAnchor, ResourceNode, SkillKind, SpawnProfile, Team, Transform, Velocity,
 };
 
 const FIXED_TICK_DURATION_SECS: f32 = 1.0 / 60.0;
@@ -92,6 +93,10 @@ pub struct EntityMetadataSnapshot {
     pub resource_skill: Option<SkillKind>,
     pub resource_tier: Option<u8>,
     pub encounter_kind: Option<EncounterKind>,
+    pub faction: Option<FactionAffiliation>,
+    pub quest_anchor: Option<QuestAnchor>,
+    pub encounter_profile: Option<EncounterProfile>,
+    pub spawn_profile: Option<SpawnProfile>,
     pub atmosphere: Option<AtmosphereProfile>,
     pub atmosphere_volume: Option<AtmosphereVolume>,
     pub actor_presentation: Option<ActorPresentation>,
@@ -496,6 +501,10 @@ impl WorldSnapshot {
             let resource = world.ecs.get::<&ResourceNode>(entity).ok();
             let loot = world.ecs.get::<&LootContainer>(entity).ok();
             let encounter = world.ecs.get::<&EncounterState>(entity).ok();
+            let faction = world.ecs.get::<&FactionAffiliation>(entity).ok();
+            let quest_anchor = world.ecs.get::<&QuestAnchor>(entity).ok();
+            let encounter_profile = world.ecs.get::<&EncounterProfile>(entity).ok();
+            let spawn_profile = world.ecs.get::<&SpawnProfile>(entity).ok();
             let atmosphere = world.ecs.get::<&AtmosphereProfile>(entity).ok();
             let atmosphere_volume = world.ecs.get::<&AtmosphereVolume>(entity).ok();
             let actor_presentation = world.ecs.get::<&ActorPresentation>(entity).ok();
@@ -546,6 +555,10 @@ impl WorldSnapshot {
                     resource_skill: resource.as_ref().map(|resource| resource.skill),
                     resource_tier: resource.as_ref().map(|resource| resource.tier),
                     encounter_kind: encounter.as_ref().map(|encounter| encounter.kind),
+                    faction: faction.map(|value| value.deref().clone()),
+                    quest_anchor: quest_anchor.map(|value| value.deref().clone()),
+                    encounter_profile: encounter_profile.map(|value| value.deref().clone()),
+                    spawn_profile: spawn_profile.map(|value| value.deref().clone()),
                     atmosphere: atmosphere.map(|value| value.deref().clone()),
                     atmosphere_volume: atmosphere_volume.map(|value| *value.deref()),
                     actor_presentation: actor_presentation.map(|value| value.deref().clone()),
@@ -1084,6 +1097,72 @@ fn hash_option_atmosphere(hash: &mut u64, atmosphere: Option<&AtmosphereProfile>
     }
 }
 
+fn hash_string_list(hash: &mut u64, values: &[String]) {
+    hash_u64(hash, values.len() as u64);
+    for value in values {
+        hash_option_str(hash, Some(value.as_str()));
+    }
+}
+
+fn hash_option_faction(hash: &mut u64, faction: Option<&FactionAffiliation>) {
+    match faction {
+        Some(faction) => {
+            hash_u64(hash, 1);
+            hash_option_str(hash, Some(faction.faction_id.as_str()));
+            hash_option_str(hash, Some(faction.role_id.as_str()));
+            hash_option_str(
+                hash,
+                Some(match faction.disposition {
+                    FactionDisposition::Friendly => "Friendly",
+                    FactionDisposition::Neutral => "Neutral",
+                    FactionDisposition::Hostile => "Hostile",
+                }),
+            );
+            hash_f32(hash, faction.influence_radius);
+        }
+        None => hash_u64(hash, 0),
+    }
+}
+
+fn hash_option_quest_anchor(hash: &mut u64, quest_anchor: Option<&QuestAnchor>) {
+    match quest_anchor {
+        Some(quest_anchor) => {
+            hash_u64(hash, 1);
+            hash_string_list(hash, &quest_anchor.quest_ids);
+            hash_option_str(hash, Some(quest_anchor.primary_prompt.as_str()));
+            hash_string_list(hash, &quest_anchor.stage_tags);
+        }
+        None => hash_u64(hash, 0),
+    }
+}
+
+fn hash_option_encounter_profile(hash: &mut u64, encounter: Option<&EncounterProfile>) {
+    match encounter {
+        Some(encounter) => {
+            hash_u64(hash, 1);
+            hash_option_str(hash, Some(encounter.table_id.as_str()));
+            hash_u64(hash, encounter.difficulty_tier as u64);
+            hash_u64(hash, encounter.recommended_party_size as u64);
+            hash_u64(hash, encounter.respawn_ticks as u64);
+        }
+        None => hash_u64(hash, 0),
+    }
+}
+
+fn hash_option_spawn_profile(hash: &mut u64, spawn: Option<&SpawnProfile>) {
+    match spawn {
+        Some(spawn) => {
+            hash_u64(hash, 1);
+            hash_option_str(hash, Some(spawn.profile_id.as_str()));
+            hash_option_str(hash, Some(spawn.biome_id.as_str()));
+            hash_option_str(hash, Some(spawn.spawn_group.as_str()));
+            hash_u64(hash, spawn.respawn_ticks as u64);
+            hash_f32(hash, spawn.leash_radius);
+        }
+        None => hash_u64(hash, 0),
+    }
+}
+
 fn hash_option_atmosphere_volume(hash: &mut u64, volume: Option<&AtmosphereVolume>) {
     match volume {
         Some(volume) => {
@@ -1146,6 +1225,10 @@ fn hash_entity_metadata(hash: &mut u64, metadata: &EntityMetadataSnapshot) {
     hash_option_str(hash, metadata.resource_skill.map(skill_kind_name));
     hash_option_u8(hash, metadata.resource_tier);
     hash_option_str(hash, metadata.encounter_kind.map(encounter_kind_name));
+    hash_option_faction(hash, metadata.faction.as_ref());
+    hash_option_quest_anchor(hash, metadata.quest_anchor.as_ref());
+    hash_option_encounter_profile(hash, metadata.encounter_profile.as_ref());
+    hash_option_spawn_profile(hash, metadata.spawn_profile.as_ref());
     hash_option_atmosphere(hash, metadata.atmosphere.as_ref());
     hash_option_atmosphere_volume(hash, metadata.atmosphere_volume.as_ref());
     hash_option_actor_presentation(hash, metadata.actor_presentation.as_ref());
@@ -1282,7 +1365,8 @@ mod tests {
     use super::*;
     use pod_core::{
         ActorPresentation, AtmosphereProfile, AtmosphereVolume, CombatLoadout, CombatPresentation,
-        CreatureIdentity, IdleAgent, LootContainer, ResourceNode,
+        CreatureIdentity, EncounterProfile, FactionAffiliation, FactionDisposition, IdleAgent,
+        LootContainer, QuestAnchor, ResourceNode, SpawnProfile,
     };
 
     #[test]
@@ -1335,6 +1419,25 @@ mod tests {
                 is_wild: true,
                 ..CreatureIdentity::default()
             })
+            .with_faction_affiliation(FactionAffiliation {
+                faction_id: "verdant-wilds".into(),
+                role_id: "stalker".into(),
+                disposition: FactionDisposition::Hostile,
+                influence_radius: 18.0,
+            })
+            .with_encounter_profile(EncounterProfile {
+                table_id: "verdant-predators".into(),
+                difficulty_tier: 2,
+                recommended_party_size: 1,
+                respawn_ticks: 1_800,
+            })
+            .with_spawn_profile(SpawnProfile {
+                profile_id: "predator-grove".into(),
+                biome_id: "verdant-hollow".into(),
+                spawn_group: "predators".into(),
+                respawn_ticks: 900,
+                leash_radius: 14.0,
+            })
             .build();
         world
             .spawn_at(4.0, 4.0)
@@ -1348,6 +1451,11 @@ mod tests {
             .with_atmosphere_volume(AtmosphereVolume {
                 radius: 128.0,
                 priority: 3,
+            })
+            .with_quest_anchor(QuestAnchor {
+                quest_ids: vec!["discover-verdant-hollow".into()],
+                primary_prompt: "Inspect the spire".into(),
+                stage_tags: vec!["exploration".into(), "intro".into()],
             })
             .build();
 
@@ -1407,6 +1515,30 @@ mod tests {
                 .map(|presentation| presentation.profile_id.as_str()),
             Some("ember-crit")
         );
+        assert_eq!(
+            creature
+                .metadata
+                .faction
+                .as_ref()
+                .map(|faction| faction.faction_id.as_str()),
+            Some("verdant-wilds")
+        );
+        assert_eq!(
+            creature
+                .metadata
+                .encounter_profile
+                .as_ref()
+                .map(|encounter| encounter.table_id.as_str()),
+            Some("verdant-predators")
+        );
+        assert_eq!(
+            creature
+                .metadata
+                .spawn_profile
+                .as_ref()
+                .map(|spawn| spawn.profile_id.as_str()),
+            Some("predator-grove")
+        );
 
         let atmosphere = snapshot
             .entities
@@ -1428,6 +1560,14 @@ mod tests {
                 .as_ref()
                 .map(|volume| volume.priority),
             Some(3)
+        );
+        assert_eq!(
+            atmosphere
+                .metadata
+                .quest_anchor
+                .as_ref()
+                .map(|quest| quest.primary_prompt.as_str()),
+            Some("Inspect the spire")
         );
     }
 


### PR DESCRIPTION
## Summary\n- add native pod-core primitives for factions, quest anchors, encounter profiles, and spawn profiles\n- carry the new creator metadata through authoritative pod-net snapshots and browser parsing\n- surface the metadata in the browser sandbox and creator affordance summaries\n\n## Validation\n- cargo test -p pod-core --lib\n- cargo test -p pod-net --lib\n- cd apps/pod-web && bun test ./src/contracts.test.ts ./src/local-world.test.ts ./src/affordances.test.ts\n- cd apps/pod-web && bun run typecheck\n- cd apps/pod-web && bun run build\n- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added faction, quest anchor, encounter profile, and spawn profile metadata to entities.
  * Enhanced entity affordances display with faction and quest-related information for creators.

* **Tests**
  * Added comprehensive test coverage for new entity metadata fields and affordances.

* **Documentation**
  * Updated implementation plan for Iteration 83.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->