### PR TITLE
Add authoritative streamed population state

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -830,5 +830,21 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cargo test -p pod-editor --lib`
   - `git diff --check`
 
-**Last updated**: Iteration 85
-**Current focus**: Iteration 86 shard-side streamed population rules and browser/editor consumption of authoritative region population state, followed by denser flagship world authoring beyond the local sandbox
+### Iteration 86
+- [x] Added deterministic shard-side streamed population reconciliation in `pod-core`, including active-chunk tracking from authoritative agents, neighbor-chunk activation, inactive streamed-entity eviction, encounter-table-driven spawn filling, and TOON-exportable world/chunk/region population state.
+- [x] Extended `pod-net` snapshots and delta application with authoritative `WorldPopulationState`, including digest coverage and direct-connect/client snapshot propagation so browser consumers receive region/chunk pressure, spawn budget, and density metadata from the real shard path.
+- [x] Updated `apps/pod-web` and `pod-editor` to consume authoritative population state, surfacing region/chunk population summaries in the browser HUD and adding TOON import plus dashboard rendering for editor-side shard population inspection.
+- [x] Replaced the old server default map with a streamed `Verdant Hollow` shard layout in `pod-server`, including authored chunks/regions/encounter tables and deterministic runtime seeding so the flagship MMO world no longer depends on local-only browser sandbox density.
+- [x] Added deterministic coverage for streamed population spawning/re-homing in `pod-core`, authoritative population parsing in browser tests, editor TOON population import, and server-map shard seeding.
+- [x] Validated touched targets:
+  - `cargo test -p pod-core --lib`
+  - `cargo test -p pod-net --lib`
+  - `cargo test -p pod-editor --lib`
+  - `cargo test -p pod-server --bin pod-server`
+  - `cd apps/pod-web && bun test ./src/contracts.test.ts ./src/local-world.test.ts ./src/affordances.test.ts`
+  - `cd apps/pod-web && bun run typecheck`
+  - `cd apps/pod-web && bun run build`
+  - `git diff --check`
+
+**Last updated**: Iteration 86
+**Current focus**: Iteration 87 authoritative streamed respawn tuning and richer shard-backed flagship biome authoring, followed by browser/editor heatmaps and creator controls for live regional population balancing

--- a/apps/pod-server/src/main.rs
+++ b/apps/pod-server/src/main.rs
@@ -105,12 +105,16 @@ mod config {
 
 #[allow(dead_code)]
 mod map {
-    use pod_core::World;
+    use pod_core::{
+        EncounterSpawnEntry, RegionEncounterTable, Team, World, WorldChunkDefinition,
+        WorldRegionDefinition,
+    };
 
     /// Load a map by name into the world
     pub fn load_default_map(world: &mut World, map_name: &str) {
         match map_name {
-            "default" | _ => load_arena_map(world),
+            "arena" => load_arena_map(world),
+            "default" | "verdant-hollow" | _ => load_verdant_hollow(world),
         }
     }
 
@@ -186,6 +190,191 @@ mod map {
             .build();
 
         info!("Arena map loaded: 4 walls + 5 obstacles");
+    }
+
+    fn load_verdant_hollow(world: &mut World) {
+        use log::info;
+
+        let mut heart = WorldRegionDefinition::new(
+            "verdant-heart",
+            "Verdant Heart",
+            "verdant-hollow",
+        );
+        heart.chunk_keys = vec!["-1:-1".into(), "-1:0".into(), "0:-1".into(), "0:0".into()];
+        heart.active_quest_graph_ids = vec!["verdant-intro".into(), "tempered-trail".into()];
+        heart.dominant_faction_track_id = "verdant-wardens".into();
+        heart.encounter_table_ids = vec![
+            "verdant-heart-wildlife".into(),
+            "verdant-heart-resources".into(),
+        ];
+
+        let mut spirewatch =
+            WorldRegionDefinition::new("spirewatch", "Spirewatch Rise", "verdant-hollow");
+        spirewatch.chunk_keys = vec!["0:1".into(), "1:1".into()];
+        spirewatch.active_quest_graph_ids = vec!["spire-attunement".into()];
+        spirewatch.dominant_faction_track_id = "ancient-spirekeepers".into();
+        spirewatch.encounter_table_ids = vec![
+            "spirewatch-encounters".into(),
+            "spirewatch-resources".into(),
+        ];
+
+        let chunks = vec![
+            authored_chunk(
+                "-1:-1",
+                "verdant-heart",
+                "verdant-hollow",
+                vec!["-1:0", "0:-1"],
+                vec!["verdant-heart-wildlife", "verdant-heart-resources"],
+                vec!["verdant-intro"],
+                vec!["verdant-wardens"],
+            ),
+            authored_chunk(
+                "-1:0",
+                "verdant-heart",
+                "verdant-hollow",
+                vec!["-1:-1", "0:0"],
+                vec!["verdant-heart-wildlife", "verdant-heart-resources"],
+                vec!["verdant-intro", "tempered-trail"],
+                vec!["verdant-wardens"],
+            ),
+            authored_chunk(
+                "0:-1",
+                "verdant-heart",
+                "verdant-hollow",
+                vec!["-1:-1", "0:0", "0:1"],
+                vec!["verdant-heart-wildlife", "verdant-heart-resources"],
+                vec!["verdant-intro"],
+                vec!["verdant-wardens"],
+            ),
+            authored_chunk(
+                "0:0",
+                "verdant-heart",
+                "verdant-hollow",
+                vec!["-1:0", "0:-1", "0:1", "1:1"],
+                vec!["verdant-heart-wildlife", "verdant-heart-resources"],
+                vec!["verdant-intro", "tempered-trail"],
+                vec!["verdant-wardens"],
+            ),
+            authored_chunk(
+                "0:1",
+                "spirewatch",
+                "verdant-hollow",
+                vec!["0:0", "1:1"],
+                vec!["spirewatch-encounters", "spirewatch-resources"],
+                vec!["spire-attunement"],
+                vec!["ancient-spirekeepers"],
+            ),
+            authored_chunk(
+                "1:1",
+                "spirewatch",
+                "verdant-hollow",
+                vec!["0:0", "0:1"],
+                vec!["spirewatch-encounters", "spirewatch-resources"],
+                vec!["spire-attunement"],
+                vec!["ancient-spirekeepers"],
+            ),
+        ];
+
+        let encounter_tables = vec![
+            encounter_table(
+                "verdant-heart-wildlife",
+                "verdant-hollow",
+                "wildlife",
+                3,
+                vec![spawn_entry("verdant-lynx", 8, 1, 2)],
+            ),
+            encounter_table(
+                "verdant-heart-resources",
+                "verdant-hollow",
+                "resources",
+                2,
+                vec![spawn_entry("copper-vein-resource", 10, 1, 1)],
+            ),
+            encounter_table(
+                "spirewatch-encounters",
+                "verdant-hollow",
+                "wildlife",
+                2,
+                vec![spawn_entry("rift-beast", 5, 1, 1)],
+            ),
+            encounter_table(
+                "spirewatch-resources",
+                "verdant-hollow",
+                "resources",
+                1,
+                vec![spawn_entry("moonstone-outcrop-resource", 6, 1, 1)],
+            ),
+        ];
+
+        world.set_streaming_metadata(160.0, chunks, vec![heart, spirewatch], encounter_tables);
+
+        world
+            .spawn_at(0.0, -20.0)
+            .with_color(54.0, 54.0, [0.18, 0.54, 0.30, 1.0])
+            .with_label("canopy tree", Team::None)
+            .build();
+        world
+            .spawn_at(62.0, 68.0)
+            .with_color(42.0, 60.0, [0.62, 0.74, 0.84, 1.0])
+            .with_label("glass spire", Team::None)
+            .build();
+        world
+            .spawn_at(-48.0, 36.0)
+            .with_color(38.0, 38.0, [0.36, 0.30, 0.26, 1.0])
+            .with_label("weathered boulder", Team::None)
+            .build();
+        world
+            .spawn_at(28.0, -64.0)
+            .with_color(30.0, 42.0, [0.44, 0.30, 0.22, 1.0])
+            .with_label("warden totem", Team::None)
+            .build();
+
+        info!("Verdant Hollow loaded: streamed flagship region map");
+    }
+
+    fn authored_chunk(
+        chunk_key: &str,
+        region_id: &str,
+        biome_id: &str,
+        neighbors: Vec<&str>,
+        encounter_table_ids: Vec<&str>,
+        quest_graph_ids: Vec<&str>,
+        faction_track_ids: Vec<&str>,
+    ) -> WorldChunkDefinition {
+        let mut chunk = WorldChunkDefinition::new(chunk_key, region_id, biome_id);
+        chunk.neighbor_chunk_keys = neighbors.into_iter().map(str::to_string).collect();
+        chunk.encounter_table_ids = encounter_table_ids.into_iter().map(str::to_string).collect();
+        chunk.quest_graph_ids = quest_graph_ids.into_iter().map(str::to_string).collect();
+        chunk.faction_track_ids = faction_track_ids.into_iter().map(str::to_string).collect();
+        chunk
+    }
+
+    fn spawn_entry(
+        archetype_id: &str,
+        weight: u16,
+        min_count: u8,
+        max_count: u8,
+    ) -> EncounterSpawnEntry {
+        EncounterSpawnEntry {
+            archetype_id: archetype_id.to_string(),
+            weight,
+            min_count,
+            max_count,
+            required_stage_tags: Vec::new(),
+            required_reputation_tiers: Vec::new(),
+        }
+    }
+
+    fn encounter_table(
+        table_id: &str,
+        biome_id: &str,
+        spawn_group: &str,
+        ambient_cap: u16,
+        entries: Vec<EncounterSpawnEntry>,
+    ) -> RegionEncounterTable {
+        let mut table = RegionEncounterTable::new(table_id, biome_id, spawn_group, entries);
+        table.ambient_cap = ambient_cap;
+        table
     }
 }
 
@@ -982,7 +1171,8 @@ Configuration:
 
 #[cfg(test)]
 mod runtime_tests {
-    use super::{config::ServerConfig, parse_bind_target};
+    use super::{config::ServerConfig, map::load_default_map, parse_bind_target};
+    use pod_core::{IdleAgent, World};
 
     #[test]
     fn parse_bind_target_splits_host_and_port() {
@@ -1011,6 +1201,24 @@ mod runtime_tests {
         restore_var("POD_RUNTIME_MODE", original_runtime);
         restore_var("POD_ENABLE_WEBSOCKET", original_ws_enabled);
         restore_var("POD_WEBSOCKET_PORT", original_ws_port);
+    }
+
+    #[test]
+    fn default_map_seeds_streamed_population_for_authoritative_worlds() {
+        let mut world = World::new(7);
+        load_default_map(&mut world, "default");
+        world.add_agent(Box::new(IdleAgent::new()));
+        world.reconcile_streaming_population();
+
+        let population = world.population_state();
+        assert!(!population.regions.is_empty());
+        assert!(!population.chunks.is_empty());
+        assert!(
+            population
+                .chunks
+                .iter()
+                .any(|chunk| chunk.counts.wild_creatures > 0 || chunk.counts.resource_nodes > 0)
+        );
     }
 
     fn restore_var(key: &str, value: Option<std::ffi::OsString>) {

--- a/apps/pod-web/index.html
+++ b/apps/pod-web/index.html
@@ -169,6 +169,8 @@
           <dd id="connection-label">offline demo / bridge mode</dd>
           <dt>World</dt>
           <dd id="world-label">demo scene</dd>
+          <dt>Population</dt>
+          <dd id="population-label">No authoritative population state yet</dd>
           <dt>Target</dt>
           <dd id="target-label">No target selected</dd>
           <dt>Suggested</dt>

--- a/apps/pod-web/src/contracts.test.ts
+++ b/apps/pod-web/src/contracts.test.ts
@@ -101,6 +101,14 @@ function typedEntityMetadata(
   };
 }
 
+function populationState(tick: number) {
+  return {
+    tick,
+    chunks: [],
+    regions: []
+  };
+}
+
 describe("TOON contract parsing", () => {
   test("accepts versioned tick telemetry TOON documents", () => {
     const document = encode({
@@ -479,6 +487,7 @@ describe("TOON contract parsing", () => {
   test("applies authoritative state deltas and builds a live world frame", () => {
     const baseline: NetworkWorldSnapshot = {
       tick: 10,
+      population: populationState(10),
       entities: [
         {
           id: 1,
@@ -527,6 +536,58 @@ describe("TOON contract parsing", () => {
       baseline,
       {
         tick: 11,
+        population: {
+          tick: 11,
+          chunks: [
+            {
+              chunkKey: "0:0",
+              regionId: "verdant-heart",
+              regionName: "Verdant Heart",
+              biomeId: "verdant-hollow",
+              questGraphIds: ["verdant-intro"],
+              factionTrackId: "verdant-wardens",
+              encounterTableIds: ["verdant-heart-wildlife"],
+              counts: {
+                players: 1,
+                npcs: 0,
+                wildCreatures: 1,
+                companions: 0,
+                resourceNodes: 0,
+                lootContainers: 0,
+                scenery: 2
+              },
+              activeEntityCount: 4,
+              ambientPopulationCap: 6,
+              spawnBudgetRemaining: 4,
+              populationPressure: 0.33
+            }
+          ],
+          regions: [
+            {
+              regionId: "verdant-heart",
+              regionName: "Verdant Heart",
+              primaryBiomeId: "verdant-hollow",
+              chunkKeys: ["0:0"],
+              activeQuestGraphIds: ["verdant-intro"],
+              dominantFactionTrackId: "verdant-wardens",
+              encounterTableIds: ["verdant-heart-wildlife"],
+              activeChunkCount: 1,
+              counts: {
+                players: 1,
+                npcs: 0,
+                wildCreatures: 1,
+                companions: 0,
+                resourceNodes: 0,
+                lootContainers: 0,
+                scenery: 2
+              },
+              activeEntityCount: 4,
+              ambientPopulationCap: 6,
+              spawnBudgetRemaining: 4,
+              populationPressure: 0.33
+            }
+          ]
+        },
         updated: [
           {
             id: 1,
@@ -618,6 +679,8 @@ describe("TOON contract parsing", () => {
 
     expect(next.tick).toBe(11);
     expect(next.entities.map((entity) => entity.id)).toEqual([1, 3, 4, 5]);
+    expect(next.population.regions[0]?.regionId).toBe("verdant-heart");
+    expect(next.population.chunks[0]?.ambientPopulationCap).toBe(6);
 
     const frame = buildAuthoritativeWorldFrame(next, {
       controlledEntity: 1,
@@ -636,6 +699,7 @@ describe("TOON contract parsing", () => {
   test("builds presentation-driven environments and actor affordances", () => {
     const snapshot: NetworkWorldSnapshot = {
       tick: 18,
+      population: populationState(18),
       entities: [
         {
           id: 1,
@@ -786,5 +850,85 @@ describe("TOON contract parsing", () => {
         ]
       }
     });
+  });
+
+  test("parses authoritative world population summaries from snapshots", () => {
+    const message = parseDirectConnectServerMessage(
+      JSON.stringify({
+        Welcome: {
+          client_id: "client-1",
+          reconnect_token: "resume-1",
+          tick: 24,
+          controlled_entity: 1,
+          authoritative_digest: 77,
+          snapshot: {
+            tick: 24,
+            entities: [],
+            population: {
+              tick: 24,
+              chunks: [
+                {
+                  chunk_key: "0:0",
+                  region_id: "verdant-heart",
+                  region_name: "Verdant Heart",
+                  biome_id: "verdant-hollow",
+                  quest_graph_ids: ["verdant-intro"],
+                  faction_track_id: "verdant-wardens",
+                  encounter_table_ids: ["verdant-heart-wildlife"],
+                  counts: {
+                    players: 1,
+                    npcs: 2,
+                    wild_creatures: 3,
+                    companions: 1,
+                    resource_nodes: 2,
+                    loot_containers: 1,
+                    scenery: 5
+                  },
+                  active_entity_count: 15,
+                  ambient_population_cap: 8,
+                  spawn_budget_remaining: 1,
+                  population_pressure: 0.875
+                }
+              ],
+              regions: [
+                {
+                  region_id: "verdant-heart",
+                  region_name: "Verdant Heart",
+                  primary_biome_id: "verdant-hollow",
+                  chunk_keys: ["0:0", "0:1"],
+                  active_quest_graph_ids: ["verdant-intro"],
+                  dominant_faction_track_id: "verdant-wardens",
+                  encounter_table_ids: ["verdant-heart-wildlife"],
+                  active_chunk_count: 1,
+                  counts: {
+                    players: 1,
+                    npcs: 2,
+                    wild_creatures: 3,
+                    companions: 1,
+                    resource_nodes: 2,
+                    loot_containers: 1,
+                    scenery: 5
+                  },
+                  active_entity_count: 15,
+                  ambient_population_cap: 8,
+                  spawn_budget_remaining: 1,
+                  population_pressure: 0.875
+                }
+              ]
+            }
+          }
+        }
+      })
+    );
+
+    expect(message.kind).toBe("welcome");
+    if (message.kind !== "welcome") {
+      throw new Error("expected welcome");
+    }
+
+    expect(message.snapshot.population.tick).toBe(24);
+    expect(message.snapshot.population.chunks[0]?.chunkKey).toBe("0:0");
+    expect(message.snapshot.population.chunks[0]?.counts.wildCreatures).toBe(3);
+    expect(message.snapshot.population.regions[0]?.populationPressure).toBe(0.875);
   });
 });

--- a/apps/pod-web/src/contracts.ts
+++ b/apps/pod-web/src/contracts.ts
@@ -544,15 +544,64 @@ export interface NetworkEntitySnapshot {
   metadata: NetworkEntityMetadataSnapshot;
 }
 
+export interface NetworkPopulationBreakdown {
+  players: number;
+  npcs: number;
+  wildCreatures: number;
+  companions: number;
+  resourceNodes: number;
+  lootContainers: number;
+  scenery: number;
+}
+
+export interface NetworkChunkPopulationState {
+  chunkKey: string;
+  regionId: string | null;
+  regionName: string | null;
+  biomeId: string | null;
+  questGraphIds: string[];
+  factionTrackId: string | null;
+  encounterTableIds: string[];
+  counts: NetworkPopulationBreakdown;
+  activeEntityCount: number;
+  ambientPopulationCap: number;
+  spawnBudgetRemaining: number;
+  populationPressure: number;
+}
+
+export interface NetworkRegionPopulationState {
+  regionId: string;
+  regionName: string;
+  primaryBiomeId: string;
+  chunkKeys: string[];
+  activeQuestGraphIds: string[];
+  dominantFactionTrackId: string | null;
+  encounterTableIds: string[];
+  activeChunkCount: number;
+  counts: NetworkPopulationBreakdown;
+  activeEntityCount: number;
+  ambientPopulationCap: number;
+  spawnBudgetRemaining: number;
+  populationPressure: number;
+}
+
+export interface NetworkWorldPopulationState {
+  tick: number;
+  chunks: NetworkChunkPopulationState[];
+  regions: NetworkRegionPopulationState[];
+}
+
 export interface NetworkWorldSnapshot {
   tick: number;
   entities: NetworkEntitySnapshot[];
+  population: NetworkWorldPopulationState;
 }
 
 export interface NetworkStateDelta {
   tick: number;
   updated: NetworkEntitySnapshot[];
   destroyed: number[];
+  population: NetworkWorldPopulationState;
 }
 
 export interface NetworkGameEvent {
@@ -1129,6 +1178,147 @@ function defaultInteractionHints(): NetworkEntityInteractionHints {
   };
 }
 
+function defaultPopulationBreakdown(): NetworkPopulationBreakdown {
+  return {
+    players: 0,
+    npcs: 0,
+    wildCreatures: 0,
+    companions: 0,
+    resourceNodes: 0,
+    lootContainers: 0,
+    scenery: 0
+  };
+}
+
+function parsePopulationBreakdown(value: unknown): NetworkPopulationBreakdown {
+  if (!isRecord(value)) {
+    return defaultPopulationBreakdown();
+  }
+
+  return {
+    players: asNumber(value.players) ?? 0,
+    npcs: asNumber(value.npcs) ?? 0,
+    wildCreatures:
+      asNumber(value.wild_creatures ?? value.wildCreatures) ?? 0,
+    companions: asNumber(value.companions) ?? 0,
+    resourceNodes:
+      asNumber(value.resource_nodes ?? value.resourceNodes) ?? 0,
+    lootContainers:
+      asNumber(value.loot_containers ?? value.lootContainers) ?? 0,
+    scenery: asNumber(value.scenery) ?? 0
+  };
+}
+
+function defaultWorldPopulationState(tick = 0): NetworkWorldPopulationState {
+  return {
+    tick,
+    chunks: [],
+    regions: []
+  };
+}
+
+function parseChunkPopulationState(value: unknown): NetworkChunkPopulationState | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const chunkKey = optionalString(value.chunk_key ?? value.chunkKey);
+  if (chunkKey == null) {
+    return null;
+  }
+
+  return {
+    chunkKey,
+    regionId: optionalString(value.region_id ?? value.regionId) ?? null,
+    regionName: optionalString(value.region_name ?? value.regionName) ?? null,
+    biomeId: optionalString(value.biome_id ?? value.biomeId) ?? null,
+    questGraphIds: parseStringArray(value.quest_graph_ids ?? value.questGraphIds) ?? [],
+    factionTrackId:
+      optionalString(value.faction_track_id ?? value.factionTrackId) ?? null,
+    encounterTableIds:
+      parseStringArray(value.encounter_table_ids ?? value.encounterTableIds) ?? [],
+    counts: parsePopulationBreakdown(value.counts),
+    activeEntityCount:
+      asNumber(value.active_entity_count ?? value.activeEntityCount) ?? 0,
+    ambientPopulationCap:
+      asNumber(value.ambient_population_cap ?? value.ambientPopulationCap) ?? 0,
+    spawnBudgetRemaining:
+      asNumber(value.spawn_budget_remaining ?? value.spawnBudgetRemaining) ?? 0,
+    populationPressure:
+      asNumber(value.population_pressure ?? value.populationPressure) ?? 0
+  };
+}
+
+function parseRegionPopulationState(value: unknown): NetworkRegionPopulationState | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const regionId = optionalString(value.region_id ?? value.regionId);
+  const regionName = optionalString(value.region_name ?? value.regionName);
+  const primaryBiomeId = optionalString(
+    value.primary_biome_id ?? value.primaryBiomeId
+  );
+  if (regionId == null || regionName == null || primaryBiomeId == null) {
+    return null;
+  }
+
+  return {
+    regionId,
+    regionName,
+    primaryBiomeId,
+    chunkKeys: parseStringArray(value.chunk_keys ?? value.chunkKeys) ?? [],
+    activeQuestGraphIds:
+      parseStringArray(value.active_quest_graph_ids ?? value.activeQuestGraphIds) ?? [],
+    dominantFactionTrackId:
+      optionalString(
+        value.dominant_faction_track_id ?? value.dominantFactionTrackId
+      ) ?? null,
+    encounterTableIds:
+      parseStringArray(value.encounter_table_ids ?? value.encounterTableIds) ?? [],
+    activeChunkCount:
+      asNumber(value.active_chunk_count ?? value.activeChunkCount) ?? 0,
+    counts: parsePopulationBreakdown(value.counts),
+    activeEntityCount:
+      asNumber(value.active_entity_count ?? value.activeEntityCount) ?? 0,
+    ambientPopulationCap:
+      asNumber(value.ambient_population_cap ?? value.ambientPopulationCap) ?? 0,
+    spawnBudgetRemaining:
+      asNumber(value.spawn_budget_remaining ?? value.spawnBudgetRemaining) ?? 0,
+    populationPressure:
+      asNumber(value.population_pressure ?? value.populationPressure) ?? 0
+  };
+}
+
+function parseWorldPopulationState(
+  value: unknown,
+  tickFallback: number
+): NetworkWorldPopulationState {
+  if (!isRecord(value)) {
+    return defaultWorldPopulationState(tickFallback);
+  }
+
+  const tick = asNumber(value.tick) ?? tickFallback;
+  const chunks = Array.isArray(value.chunks)
+    ? value.chunks
+        .map((chunk) => parseChunkPopulationState(chunk))
+        .filter((chunk): chunk is NetworkChunkPopulationState => chunk != null)
+        .sort((left, right) => left.chunkKey.localeCompare(right.chunkKey))
+    : [];
+  const regions = Array.isArray(value.regions)
+    ? value.regions
+        .map((region) => parseRegionPopulationState(region))
+        .filter((region): region is NetworkRegionPopulationState => region != null)
+        .sort((left, right) => left.regionId.localeCompare(right.regionId))
+    : [];
+
+  return {
+    tick,
+    chunks,
+    regions
+  };
+}
+
 function defaultNetworkEntityMetadata(): NetworkEntityMetadataSnapshot {
   return {
     kind: "Unknown",
@@ -1226,7 +1416,11 @@ function parseNetworkWorldSnapshot(value: unknown): NetworkWorldSnapshot | null 
 
   return {
     tick: value.tick,
-    entities
+    entities,
+    population: parseWorldPopulationState(
+      value.population ?? value.population_state,
+      value.tick
+    )
   };
 }
 
@@ -1251,7 +1445,11 @@ function parseNetworkStateDelta(value: unknown): NetworkStateDelta | null {
   return {
     tick: value.tick,
     updated,
-    destroyed
+    destroyed,
+    population: parseWorldPopulationState(
+      value.population ?? value.population_state,
+      value.tick
+    )
   };
 }
 
@@ -1873,7 +2071,8 @@ export function applyNetworkStateDelta(
   if (isFullSnapshot) {
     return {
       tick: delta.tick,
-      entities: delta.updated.slice().sort((left, right) => left.id - right.id)
+      entities: delta.updated.slice().sort((left, right) => left.id - right.id),
+      population: delta.population
     };
   }
 
@@ -1894,7 +2093,8 @@ export function applyNetworkStateDelta(
 
   return {
     tick: delta.tick,
-    entities: Array.from(entitiesById.values()).sort((left, right) => left.id - right.id)
+    entities: Array.from(entitiesById.values()).sort((left, right) => left.id - right.id),
+    population: delta.population
   };
 }
 

--- a/apps/pod-web/src/local-world.ts
+++ b/apps/pod-web/src/local-world.ts
@@ -10,7 +10,11 @@ import type {
   NetworkEntitySnapshot,
   NetworkEventBatch,
   NetworkGameEvent,
+  NetworkPopulationBreakdown,
+  NetworkChunkPopulationState,
+  NetworkRegionPopulationState,
   NetworkSkillKind,
+  NetworkWorldPopulationState,
   NetworkWorldSnapshot,
   Vec2Tuple
 } from "./contracts";
@@ -263,11 +267,19 @@ export class PodWebLocalWorld {
   }
 
   snapshotState(): NetworkWorldSnapshot {
+    const entities = this.state.entities
+      .map((entity) => toSnapshot(entity))
+      .sort((left, right) => left.id - right.id);
+
     return {
       tick: this.state.tick,
-      entities: this.state.entities
-        .map((entity) => toSnapshot(entity))
-        .sort((left, right) => left.id - right.id)
+      entities,
+      population: summarizePopulationState(
+        this.state.tick,
+        entities,
+        this.state.regions,
+        this.state.encounterTables
+      )
     };
   }
 
@@ -1227,7 +1239,13 @@ export function renderGameToText(
       chunkSize: LOCAL_WORLD_CHUNK_SIZE,
       activeChunks: debugState.activeChunkKeys,
       currentRegionId: debugState.currentRegionId,
-      currentRegionName: debugState.currentRegionName
+      currentRegionName: debugState.currentRegionName,
+      regionPopulation:
+        player?.metadata.regionId == null
+          ? null
+          : snapshot.population.regions.find(
+              (region) => region.regionId === player.metadata.regionId
+            ) ?? null
     },
     progression: {
       questGraphs: debugState.questGraphs,
@@ -2380,6 +2398,195 @@ function activeReputationTierIds(state: LocalWorldState): Set<string> {
     tiers.add(currentFactionTier(track).tierId);
   }
   return tiers;
+}
+
+function emptyPopulationBreakdown(): NetworkPopulationBreakdown {
+  return {
+    players: 0,
+    npcs: 0,
+    wildCreatures: 0,
+    companions: 0,
+    resourceNodes: 0,
+    lootContainers: 0,
+    scenery: 0
+  };
+}
+
+function incrementPopulationBreakdown(
+  counts: NetworkPopulationBreakdown,
+  entity: NetworkEntitySnapshot
+): void {
+  switch (entity.metadata.kind) {
+    case "Player":
+      counts.players += 1;
+      break;
+    case "Npc":
+      counts.npcs += 1;
+      break;
+    case "WildCreature":
+      counts.wildCreatures += 1;
+      break;
+    case "Companion":
+      counts.companions += 1;
+      break;
+    case "ResourceNode":
+      counts.resourceNodes += 1;
+      break;
+    case "LootContainer":
+      counts.lootContainers += 1;
+      break;
+    default:
+      counts.scenery += 1;
+      break;
+  }
+}
+
+function totalPopulationBreakdown(counts: NetworkPopulationBreakdown): number {
+  return (
+    counts.players +
+    counts.npcs +
+    counts.wildCreatures +
+    counts.companions +
+    counts.resourceNodes +
+    counts.lootContainers +
+    counts.scenery
+  );
+}
+
+function activeSpawnedActors(counts: NetworkPopulationBreakdown): number {
+  return counts.players + counts.npcs + counts.wildCreatures + counts.companions;
+}
+
+function finalizeChunkPopulation(state: NetworkChunkPopulationState): void {
+  state.activeEntityCount = totalPopulationBreakdown(state.counts);
+  const activeActors = activeSpawnedActors(state.counts);
+  state.spawnBudgetRemaining = Math.max(0, state.ambientPopulationCap - activeActors);
+  state.populationPressure =
+    state.ambientPopulationCap <= 0 ? 0 : activeActors / state.ambientPopulationCap;
+}
+
+function finalizeRegionPopulation(state: NetworkRegionPopulationState): void {
+  state.activeEntityCount = totalPopulationBreakdown(state.counts);
+  const activeActors = activeSpawnedActors(state.counts);
+  state.spawnBudgetRemaining = Math.max(0, state.ambientPopulationCap - activeActors);
+  state.populationPressure =
+    state.ambientPopulationCap <= 0 ? 0 : activeActors / state.ambientPopulationCap;
+}
+
+function summarizePopulationState(
+  tick: number,
+  entities: NetworkEntitySnapshot[],
+  regions: Map<string, LocalRegionState>,
+  encounterTables: Map<string, LocalEncounterTableState>
+): NetworkWorldPopulationState {
+  const chunks = new Map<string, NetworkChunkPopulationState>();
+
+  for (const region of regions.values()) {
+    for (const chunkKey of region.chunkKeys) {
+      const ambientPopulationCap = region.encounterTableIds.reduce(
+        (total, tableId) => total + (encounterTables.get(tableId)?.ambientCap ?? 0),
+        0
+      );
+      chunks.set(chunkKey, {
+        chunkKey,
+        regionId: region.regionId,
+        regionName: region.displayName,
+        biomeId: region.primaryBiomeId,
+        questGraphIds: [...region.activeQuestGraphIds],
+        factionTrackId: region.dominantFactionTrackId || null,
+        encounterTableIds: [...region.encounterTableIds],
+        counts: emptyPopulationBreakdown(),
+        activeEntityCount: 0,
+        ambientPopulationCap,
+        spawnBudgetRemaining: ambientPopulationCap,
+        populationPressure: 0
+      });
+    }
+  }
+
+  for (const entity of entities) {
+    const chunkKey = entity.metadata.chunkKey ?? chunkKeyFromPosition(entity.position);
+    const region = entity.metadata.regionId
+      ? regions.get(entity.metadata.regionId)
+      : regionForChunkKey(chunkKey, regions);
+    const chunkState =
+      chunks.get(chunkKey) ??
+      {
+        chunkKey,
+        regionId: entity.metadata.regionId ?? region?.regionId ?? null,
+        regionName: entity.metadata.regionName ?? region?.displayName ?? null,
+        biomeId: region?.primaryBiomeId ?? entity.metadata.spawnProfile?.biomeId ?? null,
+        questGraphIds: entity.metadata.questGraphIds.slice(),
+        factionTrackId:
+          entity.metadata.factionTrackId ?? region?.dominantFactionTrackId ?? null,
+        encounterTableIds: entity.metadata.encounterTableId
+          ? [entity.metadata.encounterTableId]
+          : [...(region?.encounterTableIds ?? [])],
+        counts: emptyPopulationBreakdown(),
+        activeEntityCount: 0,
+        ambientPopulationCap: 0,
+        spawnBudgetRemaining: 0,
+        populationPressure: 0
+      };
+
+    if (chunkState.ambientPopulationCap === 0) {
+      chunkState.ambientPopulationCap = chunkState.encounterTableIds.reduce(
+        (total, tableId) => total + (encounterTables.get(tableId)?.ambientCap ?? 0),
+        0
+      );
+    }
+    incrementPopulationBreakdown(chunkState.counts, entity);
+    finalizeChunkPopulation(chunkState);
+    chunks.set(chunkKey, chunkState);
+  }
+
+  const chunkList = Array.from(chunks.values()).sort((left, right) =>
+    left.chunkKey.localeCompare(right.chunkKey)
+  );
+  const regionList: NetworkRegionPopulationState[] = Array.from(regions.values())
+    .map((region) => {
+      const counts = emptyPopulationBreakdown();
+      const matchingChunks = chunkList.filter(
+        (chunk) => chunk.regionId === region.regionId
+      );
+      for (const chunk of matchingChunks) {
+        counts.players += chunk.counts.players;
+        counts.npcs += chunk.counts.npcs;
+        counts.wildCreatures += chunk.counts.wildCreatures;
+        counts.companions += chunk.counts.companions;
+        counts.resourceNodes += chunk.counts.resourceNodes;
+        counts.lootContainers += chunk.counts.lootContainers;
+        counts.scenery += chunk.counts.scenery;
+      }
+      const ambientPopulationCap = region.encounterTableIds.reduce(
+        (total, tableId) => total + (encounterTables.get(tableId)?.ambientCap ?? 0),
+        0
+      );
+      const regionState: NetworkRegionPopulationState = {
+        regionId: region.regionId,
+        regionName: region.displayName,
+        primaryBiomeId: region.primaryBiomeId,
+        chunkKeys: [...region.chunkKeys],
+        activeQuestGraphIds: [...region.activeQuestGraphIds],
+        dominantFactionTrackId: region.dominantFactionTrackId || null,
+        encounterTableIds: [...region.encounterTableIds],
+        activeChunkCount: matchingChunks.filter((chunk) => chunk.activeEntityCount > 0).length,
+        counts,
+        activeEntityCount: 0,
+        ambientPopulationCap,
+        spawnBudgetRemaining: ambientPopulationCap,
+        populationPressure: 0
+      };
+      finalizeRegionPopulation(regionState);
+      return regionState;
+    })
+    .sort((left, right) => left.regionId.localeCompare(right.regionId));
+
+  return {
+    tick,
+    chunks: chunkList,
+    regions: regionList
+  };
 }
 
 function chunkKeyFromPosition(position: Vec2Tuple): string {

--- a/apps/pod-web/src/main.ts
+++ b/apps/pod-web/src/main.ts
@@ -71,6 +71,7 @@ const backendLabel = document.querySelector<HTMLElement>("#backend-label");
 const frameSourceLabel = document.querySelector<HTMLElement>("#frame-source");
 const connectionLabel = document.querySelector<HTMLElement>("#connection-label");
 const worldLabel = document.querySelector<HTMLElement>("#world-label");
+const populationLabel = document.querySelector<HTMLElement>("#population-label");
 const targetLabel = document.querySelector<HTMLElement>("#target-label");
 const affordanceLabel = document.querySelector<HTMLElement>("#affordance-label");
 const actionStatusLabel = document.querySelector<HTMLElement>("#action-status-label");
@@ -108,6 +109,7 @@ if (
   !frameSourceLabel ||
   !connectionLabel ||
   !worldLabel ||
+  !populationLabel ||
   !targetLabel ||
   !affordanceLabel ||
   !actionStatusLabel ||
@@ -140,6 +142,7 @@ const renderCanvas = canvas;
 const frameSourceNode = frameSourceLabel;
 const connectionNode = connectionLabel;
 const worldNode = worldLabel;
+const populationNode = populationLabel;
 const targetNode = targetLabel;
 const affordanceNode = affordanceLabel;
 const actionStatusNode = actionStatusLabel;
@@ -259,6 +262,36 @@ function controlledEntity(): NetworkEntitySnapshot | null {
   }
 
   return latestSnapshot.entities.find((entity) => entity.id === controlledId) ?? null;
+}
+
+function currentPopulationSummary(): string {
+  if (!latestSnapshot) {
+    return "No authoritative population state yet";
+  }
+
+  const controlled = controlledEntity();
+  const regionId = controlled?.metadata.regionId ?? null;
+  const chunkKey = controlled?.metadata.chunkKey ?? null;
+  const region = regionId
+    ? latestSnapshot.population.regions.find((entry) => entry.regionId === regionId) ?? null
+    : null;
+  const chunk = chunkKey
+    ? latestSnapshot.population.chunks.find((entry) => entry.chunkKey === chunkKey) ?? null
+    : null;
+
+  if (!region && !chunk) {
+    return `${latestSnapshot.population.regions.length} regions · ${latestSnapshot.population.chunks.length} chunks`;
+  }
+
+  const chunkSummary = chunk
+    ? `${chunk.chunkKey} ${chunk.activeEntityCount} active · cap ${chunk.ambientPopulationCap} · budget ${chunk.spawnBudgetRemaining}`
+    : "unassigned chunk";
+  const regionSummary = region
+    ? `${region.regionName} ${region.activeEntityCount} active · ${region.activeChunkCount}/${region.chunkKeys.length} chunks hot · pressure ${region.populationPressure.toFixed(
+        2
+      )}`
+    : "unassigned region";
+  return `${regionSummary} · ${chunkSummary}`;
 }
 
 function targetableEntities(): NetworkEntitySnapshot[] {
@@ -791,6 +824,7 @@ function renderTelemetryHud(): void {
             : `controlled E(${liveConnectionStatus.controlledEntity})`
         }`
     : "demo scene";
+  populationNode.textContent = currentPopulationSummary();
   targetNode.textContent = formatTargetSummary(target, controlled);
   affordanceNode.textContent = describeTargetAffordances(target);
   actionStatusNode.textContent = formatActionStatus();

--- a/crates/pod-core/src/lib.rs
+++ b/crates/pod-core/src/lib.rs
@@ -94,7 +94,10 @@ pub use toon::{
     decode_toon_document, decode_toon_string, decode_toon_value, encode_toon_document,
     encode_toon_string,
 };
-pub use world::{ResolvedWorldChunkMetadata, World, WorldStreamingMetadata};
+pub use world::{
+    ChunkPopulationState, PopulationBreakdown, RegionPopulationState, ResolvedWorldChunkMetadata,
+    World, WorldPopulationState, WorldStreamingMetadata,
+};
 
 /// Fixed tick rate — all agents operate on the same clock
 pub const TICKS_PER_SECOND: u32 = 60;

--- a/crates/pod-core/src/world.rs
+++ b/crates/pod-core/src/world.rs
@@ -1,14 +1,19 @@
 use crate::action::{Action, AgentAction};
 use crate::agent::{Agent, AgentSlot};
 use crate::component::*;
-use crate::contract::{WorldChunkDefinition, WorldRegionDefinition};
+use crate::contract::{
+    EncounterSpawnEntry, RegionEncounterTable, WorldChunkDefinition, WorldRegionDefinition,
+};
 use crate::event::EventBus;
 use crate::id::AgentId;
 use crate::telemetry::TickTelemetryFrame;
 use crate::tick::{execute_tick, TickResult};
+use crate::toon::encode_toon_document;
 use glam::Vec2;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
 
 /// The complete game world.
 ///
@@ -42,6 +47,7 @@ pub struct WorldStreamingMetadata {
     pub chunk_size: f32,
     pub chunks: Vec<WorldChunkDefinition>,
     pub regions: Vec<WorldRegionDefinition>,
+    pub encounter_tables: Vec<RegionEncounterTable>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -49,9 +55,161 @@ pub struct ResolvedWorldChunkMetadata {
     pub chunk_key: String,
     pub region_id: Option<String>,
     pub region_name: Option<String>,
+    pub biome_id: Option<String>,
     pub quest_graph_ids: Vec<String>,
     pub faction_track_id: Option<String>,
     pub encounter_table_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct PopulationBreakdown {
+    pub players: u32,
+    pub npcs: u32,
+    pub wild_creatures: u32,
+    pub companions: u32,
+    pub resource_nodes: u32,
+    pub loot_containers: u32,
+    pub scenery: u32,
+}
+
+impl PopulationBreakdown {
+    fn increment(&mut self, kind: PopulationKind) {
+        match kind {
+            PopulationKind::Player => self.players += 1,
+            PopulationKind::Npc => self.npcs += 1,
+            PopulationKind::WildCreature => self.wild_creatures += 1,
+            PopulationKind::Companion => self.companions += 1,
+            PopulationKind::ResourceNode => self.resource_nodes += 1,
+            PopulationKind::LootContainer => self.loot_containers += 1,
+            PopulationKind::Scenery => self.scenery += 1,
+        }
+    }
+
+    fn total(self) -> u32 {
+        self.players
+            + self.npcs
+            + self.wild_creatures
+            + self.companions
+            + self.resource_nodes
+            + self.loot_containers
+            + self.scenery
+    }
+
+    fn active_spawned_actors(self) -> u32 {
+        self.players + self.npcs + self.wild_creatures + self.companions
+    }
+
+    fn merge(&mut self, other: Self) {
+        self.players += other.players;
+        self.npcs += other.npcs;
+        self.wild_creatures += other.wild_creatures;
+        self.companions += other.companions;
+        self.resource_nodes += other.resource_nodes;
+        self.loot_containers += other.loot_containers;
+        self.scenery += other.scenery;
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct ChunkPopulationState {
+    pub chunk_key: String,
+    pub region_id: Option<String>,
+    pub region_name: Option<String>,
+    pub biome_id: Option<String>,
+    pub quest_graph_ids: Vec<String>,
+    pub faction_track_id: Option<String>,
+    pub encounter_table_ids: Vec<String>,
+    pub counts: PopulationBreakdown,
+    pub active_entity_count: u32,
+    pub ambient_population_cap: u32,
+    pub spawn_budget_remaining: u32,
+    pub population_pressure: f32,
+}
+
+impl ChunkPopulationState {
+    fn refresh_metrics(&mut self) {
+        self.active_entity_count = self.counts.total();
+        let active_spawned = self.counts.active_spawned_actors();
+        self.spawn_budget_remaining = self.ambient_population_cap.saturating_sub(active_spawned);
+        self.population_pressure = if self.ambient_population_cap == 0 {
+            0.0
+        } else {
+            active_spawned as f32 / self.ambient_population_cap as f32
+        };
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct RegionPopulationState {
+    pub region_id: String,
+    pub region_name: String,
+    pub primary_biome_id: String,
+    pub chunk_keys: Vec<String>,
+    pub active_quest_graph_ids: Vec<String>,
+    pub dominant_faction_track_id: Option<String>,
+    pub encounter_table_ids: Vec<String>,
+    pub active_chunk_count: u32,
+    pub counts: PopulationBreakdown,
+    pub active_entity_count: u32,
+    pub ambient_population_cap: u32,
+    pub spawn_budget_remaining: u32,
+    pub population_pressure: f32,
+}
+
+impl RegionPopulationState {
+    fn refresh_metrics(&mut self) {
+        self.active_entity_count = self.counts.total();
+        let active_spawned = self.counts.active_spawned_actors();
+        self.spawn_budget_remaining = self.ambient_population_cap.saturating_sub(active_spawned);
+        self.population_pressure = if self.ambient_population_cap == 0 {
+            0.0
+        } else {
+            active_spawned as f32 / self.ambient_population_cap as f32
+        };
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct WorldPopulationState {
+    pub tick: u64,
+    pub chunks: Vec<ChunkPopulationState>,
+    pub regions: Vec<RegionPopulationState>,
+}
+
+impl WorldPopulationState {
+    pub fn to_toon_document(&self) -> String {
+        encode_toon_document("world_population_state", self)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PopulationKind {
+    Player,
+    Npc,
+    WildCreature,
+    Companion,
+    ResourceNode,
+    LootContainer,
+    Scenery,
+}
+
+#[derive(Debug, Clone)]
+struct StreamingSpawnRequest {
+    chunk_key: String,
+    biome_id: String,
+    faction_track_id: Option<String>,
+    encounter_table_id: String,
+    spawn_group: String,
+    archetype_id: String,
+    slot_index: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StreamingArchetypeKind {
+    WildCreature,
+    ResourceNode,
+    LootContainer,
+    Npc,
 }
 
 impl WorldStreamingMetadata {
@@ -60,6 +218,7 @@ impl WorldStreamingMetadata {
             chunk_size: chunk_size.max(0.001),
             chunks: Vec::new(),
             regions: Vec::new(),
+            encounter_tables: Vec::new(),
         }
     }
 
@@ -112,10 +271,87 @@ impl WorldStreamingMetadata {
             chunk_key,
             region_id: region.map(|region| region.region_id.clone()),
             region_name: region.map(|region| region.display_name.clone()),
+            biome_id: chunk
+                .map(|chunk| chunk.biome_id.clone())
+                .or_else(|| region.map(|region| region.primary_biome_id.clone())),
             quest_graph_ids,
             faction_track_id,
             encounter_table_id,
         }
+    }
+
+    fn chunk_definition(&self, chunk_key: &str) -> Option<&WorldChunkDefinition> {
+        self.chunks.iter().find(|chunk| chunk.chunk_key == chunk_key)
+    }
+
+    fn region_definition(&self, region_id: &str) -> Option<&WorldRegionDefinition> {
+        self.regions.iter().find(|region| region.region_id == region_id)
+    }
+
+    fn encounter_table(&self, table_id: &str) -> Option<&RegionEncounterTable> {
+        self.encounter_tables
+            .iter()
+            .find(|table| table.table_id == table_id)
+    }
+
+    fn encounter_table_cap(&self, table_id: &str) -> u32 {
+        self.encounter_tables
+            .iter()
+            .find(|table| table.table_id == table_id)
+            .map(|table| table.ambient_cap as u32)
+            .unwrap_or_default()
+    }
+
+    fn ambient_cap_for_tables(&self, table_ids: &[String]) -> u32 {
+        table_ids
+            .iter()
+            .map(|table_id| self.encounter_table_cap(table_id))
+            .sum()
+    }
+
+    fn chunk_population_seed(&self, chunk_key: &str) -> ChunkPopulationState {
+        let chunk = self.chunk_definition(chunk_key);
+        let region = chunk
+            .and_then(|chunk| self.region_definition(&chunk.region_id))
+            .or_else(|| {
+                self.regions
+                    .iter()
+                    .find(|region| region.chunk_keys.iter().any(|value| value == chunk_key))
+            });
+
+        let encounter_table_ids = chunk
+            .map(|chunk| chunk.encounter_table_ids.clone())
+            .filter(|table_ids| !table_ids.is_empty())
+            .or_else(|| region.map(|region| region.encounter_table_ids.clone()))
+            .unwrap_or_default();
+        let quest_graph_ids = chunk
+            .map(|chunk| chunk.quest_graph_ids.clone())
+            .filter(|quest_ids| !quest_ids.is_empty())
+            .or_else(|| region.map(|region| region.active_quest_graph_ids.clone()))
+            .unwrap_or_default();
+        let faction_track_id = chunk
+            .and_then(|chunk| chunk.faction_track_ids.first().cloned())
+            .or_else(|| {
+                region.and_then(|region| {
+                    (!region.dominant_faction_track_id.is_empty())
+                        .then(|| region.dominant_faction_track_id.clone())
+                })
+            });
+        let mut state = ChunkPopulationState {
+            chunk_key: chunk_key.to_string(),
+            region_id: region.map(|region| region.region_id.clone()),
+            region_name: region.map(|region| region.display_name.clone()),
+            biome_id: chunk
+                .map(|chunk| chunk.biome_id.clone())
+                .or_else(|| region.map(|region| region.primary_biome_id.clone())),
+            quest_graph_ids,
+            faction_track_id,
+            ambient_population_cap: self.ambient_cap_for_tables(&encounter_table_ids),
+            encounter_table_ids,
+            ..Default::default()
+        };
+        state.refresh_metrics();
+        state
     }
 
     fn chunk_key_for_position(&self, position: Vec2) -> String {
@@ -147,16 +383,186 @@ impl World {
         chunk_size: f32,
         chunks: Vec<WorldChunkDefinition>,
         regions: Vec<WorldRegionDefinition>,
+        encounter_tables: Vec<RegionEncounterTable>,
     ) {
         self.streaming = WorldStreamingMetadata {
             chunk_size: chunk_size.max(0.001),
             chunks,
             regions,
+            encounter_tables,
         };
     }
 
     pub fn resolve_streaming_metadata(&self, position: Vec2) -> ResolvedWorldChunkMetadata {
         self.streaming.resolve_position(position)
+    }
+
+    pub fn population_state(&self) -> WorldPopulationState {
+        let controlled_entities = self
+            .agents
+            .iter()
+            .filter_map(|slot| slot.entity_id.map(|entity| entity.id() as u64))
+            .collect::<HashSet<_>>();
+        let mut chunk_states = HashMap::<String, ChunkPopulationState>::new();
+
+        for chunk in &self.streaming.chunks {
+            chunk_states.insert(
+                chunk.chunk_key.clone(),
+                self.streaming.chunk_population_seed(&chunk.chunk_key),
+            );
+        }
+        for region in &self.streaming.regions {
+            for chunk_key in &region.chunk_keys {
+                chunk_states
+                    .entry(chunk_key.clone())
+                    .or_insert_with(|| self.streaming.chunk_population_seed(chunk_key));
+            }
+        }
+
+        for (entity, (transform,)) in self.ecs.query::<(&Transform,)>().iter() {
+            let streaming = self.resolve_streaming_metadata(transform.position);
+            let kind = classify_population_kind(self, entity, &controlled_entities);
+            let chunk_state = chunk_states
+                .entry(streaming.chunk_key.clone())
+                .or_insert_with(|| self.streaming.chunk_population_seed(&streaming.chunk_key));
+
+            chunk_state.region_id = streaming.region_id.clone();
+            chunk_state.region_name = streaming.region_name.clone();
+            if chunk_state.biome_id.is_none() {
+                chunk_state.biome_id = streaming.biome_id.clone();
+            }
+            if chunk_state.quest_graph_ids.is_empty() {
+                chunk_state.quest_graph_ids = streaming.quest_graph_ids.clone();
+            }
+            if chunk_state.faction_track_id.is_none() {
+                chunk_state.faction_track_id = streaming.faction_track_id.clone();
+            }
+            if chunk_state.encounter_table_ids.is_empty() {
+                if let Some(encounter_table_id) = streaming.encounter_table_id.clone() {
+                    chunk_state.encounter_table_ids.push(encounter_table_id);
+                    chunk_state.ambient_population_cap =
+                        self.streaming.ambient_cap_for_tables(&chunk_state.encounter_table_ids);
+                }
+            }
+            chunk_state.counts.increment(kind);
+            chunk_state.refresh_metrics();
+        }
+
+        let mut chunks = chunk_states.into_values().collect::<Vec<_>>();
+        chunks.sort_by(|left, right| left.chunk_key.cmp(&right.chunk_key));
+
+        let mut regions = self
+            .streaming
+            .regions
+            .iter()
+            .map(|region| {
+                let mut state = RegionPopulationState {
+                    region_id: region.region_id.clone(),
+                    region_name: region.display_name.clone(),
+                    primary_biome_id: region.primary_biome_id.clone(),
+                    chunk_keys: region.chunk_keys.clone(),
+                    active_quest_graph_ids: region.active_quest_graph_ids.clone(),
+                    dominant_faction_track_id: (!region.dominant_faction_track_id.is_empty())
+                        .then(|| region.dominant_faction_track_id.clone()),
+                    encounter_table_ids: region.encounter_table_ids.clone(),
+                    ambient_population_cap: self
+                        .streaming
+                        .ambient_cap_for_tables(&region.encounter_table_ids),
+                    ..Default::default()
+                };
+                for chunk in chunks
+                    .iter()
+                    .filter(|chunk| chunk.region_id.as_deref() == Some(region.region_id.as_str()))
+                {
+                    if chunk.active_entity_count > 0 {
+                        state.active_chunk_count += 1;
+                    }
+                    state.counts.merge(chunk.counts);
+                }
+                state.refresh_metrics();
+                state
+            })
+            .collect::<Vec<_>>();
+        regions.sort_by(|left, right| left.region_id.cmp(&right.region_id));
+
+        WorldPopulationState {
+            tick: self.tick,
+            chunks,
+            regions,
+        }
+    }
+
+    pub fn reconcile_streaming_population(&mut self) {
+        if self.streaming.chunks.is_empty() && self.streaming.regions.is_empty() {
+            return;
+        }
+
+        let active_chunks = self.active_streaming_chunk_keys();
+        if active_chunks.is_empty() {
+            return;
+        }
+
+        let mut live_counts = HashMap::<(String, String), u32>::new();
+        let mut stale_entities = Vec::new();
+        for (entity, (transform, spawn_profile)) in self.ecs.query::<(&Transform, &SpawnProfile)>().iter()
+        {
+            let chunk_key = self.streaming.chunk_key_for_position(transform.position);
+            if !active_chunks.contains(&chunk_key) {
+                stale_entities.push(entity);
+                continue;
+            }
+
+            let Some(table_id) = streaming_profile_table_id(spawn_profile) else {
+                continue;
+            };
+            *live_counts
+                .entry((chunk_key, table_id.to_string()))
+                .or_default() += 1;
+        }
+
+        for entity in stale_entities {
+            let _ = self.ecs.despawn(entity);
+        }
+
+        let mut requests = Vec::new();
+        for chunk_key in &active_chunks {
+            let seed = self.streaming.chunk_population_seed(chunk_key);
+            for table_id in &seed.encounter_table_ids {
+                let Some(table) = self.streaming.encounter_table(table_id) else {
+                    continue;
+                };
+                if table.entries.is_empty() {
+                    continue;
+                }
+
+                let current = live_counts
+                    .get(&(chunk_key.clone(), table_id.clone()))
+                    .copied()
+                    .unwrap_or_default();
+                let desired = table.ambient_cap as u32;
+                for slot_index in current..desired {
+                    let Some(entry) = choose_streaming_entry(table, chunk_key, slot_index) else {
+                        continue;
+                    };
+                    requests.push(StreamingSpawnRequest {
+                        chunk_key: chunk_key.clone(),
+                        biome_id: seed
+                            .biome_id
+                            .clone()
+                            .unwrap_or_else(|| table.biome_id.clone()),
+                        faction_track_id: seed.faction_track_id.clone(),
+                        encounter_table_id: table.table_id.clone(),
+                        spawn_group: table.spawn_group.clone(),
+                        archetype_id: entry.archetype_id.clone(),
+                        slot_index,
+                    });
+                }
+            }
+        }
+
+        for request in requests {
+            self.spawn_streaming_request(request);
+        }
     }
 
     /// Advance the simulation by one tick
@@ -171,6 +577,8 @@ impl World {
                 telemetry: TickTelemetryFrame::empty(self.tick),
             };
         }
+
+        self.reconcile_streaming_population();
 
         let result = execute_tick(
             &mut self.ecs,
@@ -203,6 +611,7 @@ impl World {
         slot.agent.on_join();
         slot.agent.on_spawn(entity_id);
         self.agents.push(slot);
+        self.reconcile_streaming_population();
         (slot_index, entity)
     }
 
@@ -273,6 +682,352 @@ impl World {
             action,
         });
     }
+
+    fn active_streaming_chunk_keys(&self) -> HashSet<String> {
+        let mut active = HashSet::new();
+
+        for entity in self.agents.iter().filter_map(|slot| slot.entity_id) {
+            let Ok(transform) = self.ecs.get::<&Transform>(entity) else {
+                continue;
+            };
+            let chunk_key = self.streaming.chunk_key_for_position(transform.position);
+            active.insert(chunk_key.clone());
+            if let Some(chunk) = self.streaming.chunk_definition(&chunk_key) {
+                for neighbor in &chunk.neighbor_chunk_keys {
+                    active.insert(neighbor.clone());
+                }
+            }
+        }
+
+        if active.is_empty() {
+            for chunk in &self.streaming.chunks {
+                active.insert(chunk.chunk_key.clone());
+            }
+        }
+
+        active
+    }
+
+    fn spawn_streaming_request(&mut self, request: StreamingSpawnRequest) {
+        let position = streaming_spawn_position(
+            &request.chunk_key,
+            self.streaming.chunk_size,
+            request.slot_index,
+            &request.encounter_table_id,
+        );
+        let display_name = archetype_display_name(&request.archetype_id);
+        let spawn_profile = SpawnProfile {
+            profile_id: format!("{}::{}", request.encounter_table_id, request.slot_index),
+            biome_id: request.biome_id.clone(),
+            spawn_group: request.spawn_group.clone(),
+            respawn_ticks: 60 * 30,
+            leash_radius: self.streaming.chunk_size * 0.45,
+        };
+        let faction = request
+            .faction_track_id
+            .as_ref()
+            .map(|faction_id| FactionAffiliation {
+                faction_id: faction_id.clone(),
+                ..FactionAffiliation::default()
+            });
+
+        match classify_streaming_archetype(&request.archetype_id, &request.spawn_group) {
+            StreamingArchetypeKind::WildCreature => {
+                let level = streaming_creature_level(&request.archetype_id);
+                let mut builder = self
+                    .spawn_at(position.x, position.y)
+                    .with_label(&display_name, Team::Team(2))
+                    .with_health(20.0 + level as f32 * 10.0)
+                    .with_combat_loadout(CombatLoadout {
+                        max_hit: 2.0 + level as f32 * 0.75,
+                        attack_speed_ticks: 4,
+                        attack_range: 24.0,
+                        ..CombatLoadout::default()
+                    })
+                    .with_creature_identity(CreatureIdentity {
+                        species_id: request.archetype_id.clone(),
+                        species_name: display_name.clone(),
+                        elemental_affinity: request.biome_id.clone(),
+                        level,
+                        temperament: CreatureTemperament::Neutral,
+                        capture_difficulty: 0.4 + level as f32 * 0.05,
+                        is_wild: true,
+                    })
+                    .with_encounter_profile(EncounterProfile {
+                        table_id: request.encounter_table_id.clone(),
+                        respawn_ticks: 60 * 30,
+                        ..EncounterProfile::default()
+                    })
+                    .with_spawn_profile(spawn_profile)
+                    .with_movement(42.0)
+                    .with_perception(280.0)
+                    .with_color(26.0, 26.0, [0.38, 0.76, 0.42, 1.0]);
+                if let Some(faction) = faction {
+                    builder = builder.with_faction_affiliation(faction);
+                }
+                builder.build();
+            }
+            StreamingArchetypeKind::ResourceNode => {
+                let mut builder = self
+                    .spawn_at(position.x, position.y)
+                    .with_label(&display_name, Team::None)
+                    .with_resource_node(streaming_resource_node(&request.archetype_id))
+                    .with_spawn_profile(spawn_profile)
+                    .with_color(24.0, 24.0, [0.72, 0.58, 0.32, 1.0]);
+                if let Some(faction) = faction {
+                    builder = builder.with_faction_affiliation(faction);
+                }
+                builder.build();
+            }
+            StreamingArchetypeKind::LootContainer => {
+                self.spawn_at(position.x, position.y)
+                    .with_label(&display_name, Team::None)
+                    .with_loot_container(streaming_loot_container(&request.archetype_id))
+                    .with_spawn_profile(spawn_profile)
+                    .with_color(24.0, 20.0, [0.74, 0.66, 0.32, 1.0])
+                    .build();
+            }
+            StreamingArchetypeKind::Npc => {
+                let mut builder = self
+                    .spawn_at(position.x, position.y)
+                    .with_label(&display_name, Team::Team(1))
+                    .with_health(40.0)
+                    .with_combat_loadout(CombatLoadout::default())
+                    .with_spawn_profile(spawn_profile)
+                    .with_movement(36.0)
+                    .with_perception(240.0)
+                    .with_color(28.0, 28.0, [0.30, 0.56, 0.84, 1.0]);
+                if let Some(faction) = faction {
+                    builder = builder.with_faction_affiliation(faction);
+                }
+                builder.build();
+            }
+        }
+    }
+}
+
+fn classify_population_kind(
+    world: &World,
+    entity: hecs::Entity,
+    controlled_entities: &HashSet<u64>,
+) -> PopulationKind {
+    let entity_id = entity.id() as u64;
+    let has_resource = world.ecs.get::<&ResourceNode>(entity).is_ok();
+    let has_loot = world.ecs.get::<&LootContainer>(entity).is_ok();
+    let creature = world.ecs.get::<&CreatureIdentity>(entity).ok();
+    let has_combat = world.ecs.get::<&CombatLoadout>(entity).is_ok();
+    let has_health = world.ecs.get::<&Health>(entity).is_ok();
+
+    if controlled_entities.contains(&entity_id) {
+        return PopulationKind::Player;
+    }
+    if has_resource {
+        return PopulationKind::ResourceNode;
+    }
+    if has_loot {
+        return PopulationKind::LootContainer;
+    }
+    if let Some(creature) = creature {
+        if creature.level > 0 {
+            return PopulationKind::WildCreature;
+        }
+    }
+    if world.ecs.get::<&CompanionRoster>(entity).is_ok() {
+        return PopulationKind::Companion;
+    }
+    if has_combat || has_health {
+        return PopulationKind::Npc;
+    }
+    PopulationKind::Scenery
+}
+
+fn streaming_profile_table_id(profile: &SpawnProfile) -> Option<&str> {
+    profile.profile_id.split_once("::").map(|(table_id, _)| table_id)
+}
+
+fn choose_streaming_entry<'a>(
+    table: &'a RegionEncounterTable,
+    chunk_key: &str,
+    slot_index: u32,
+) -> Option<&'a EncounterSpawnEntry> {
+    let candidates = table
+        .entries
+        .iter()
+        .filter(|entry| {
+            entry.required_stage_tags.is_empty() && entry.required_reputation_tiers.is_empty()
+        })
+        .collect::<Vec<_>>();
+    let candidates = if candidates.is_empty() {
+        table.entries.iter().collect::<Vec<_>>()
+    } else {
+        candidates
+    };
+    let total_weight = candidates
+        .iter()
+        .map(|entry| entry.weight.max(1) as u64)
+        .sum::<u64>();
+    if total_weight == 0 {
+        return None;
+    }
+
+    let mut cursor = stable_streaming_hash(chunk_key, &table.table_id)
+        .wrapping_add(slot_index as u64)
+        % total_weight;
+    for entry in candidates {
+        let weight = entry.weight.max(1) as u64;
+        if cursor < weight {
+            return Some(entry);
+        }
+        cursor -= weight;
+    }
+    table.entries.first()
+}
+
+fn stable_streaming_hash(left: &str, right: &str) -> u64 {
+    let mut hash = 1469598103934665603_u64;
+    for byte in left.bytes().chain([0xff]).chain(right.bytes()) {
+        hash ^= byte as u64;
+        hash = hash.wrapping_mul(1099511628211);
+    }
+    hash
+}
+
+fn parse_chunk_key(chunk_key: &str) -> Option<(i32, i32)> {
+    let (x, y) = chunk_key.split_once(':')?;
+    Some((x.parse().ok()?, y.parse().ok()?))
+}
+
+fn streaming_spawn_position(
+    chunk_key: &str,
+    chunk_size: f32,
+    slot_index: u32,
+    encounter_table_id: &str,
+) -> Vec2 {
+    let (chunk_x, chunk_y) = parse_chunk_key(chunk_key).unwrap_or((0, 0));
+    let center = Vec2::new(
+        (chunk_x as f32 + 0.5) * chunk_size,
+        (chunk_y as f32 + 0.5) * chunk_size,
+    );
+    let pattern = [
+        Vec2::new(-0.24, -0.18),
+        Vec2::new(0.21, -0.22),
+        Vec2::new(-0.18, 0.16),
+        Vec2::new(0.24, 0.14),
+        Vec2::new(0.00, -0.04),
+        Vec2::new(-0.31, 0.02),
+        Vec2::new(0.32, -0.01),
+        Vec2::new(0.06, 0.28),
+    ];
+    let salt = stable_streaming_hash(chunk_key, encounter_table_id) as usize;
+    let offset = pattern[(slot_index as usize + salt) % pattern.len()] * chunk_size;
+    center + offset
+}
+
+fn classify_streaming_archetype(archetype_id: &str, spawn_group: &str) -> StreamingArchetypeKind {
+    let normalized = format!(
+        "{}:{}",
+        archetype_id.to_ascii_lowercase(),
+        spawn_group.to_ascii_lowercase()
+    );
+    if normalized.contains("resource")
+        || normalized.contains("vein")
+        || normalized.contains("outcrop")
+        || normalized.contains("tree")
+        || normalized.contains("ore")
+    {
+        StreamingArchetypeKind::ResourceNode
+    } else if normalized.contains("chest")
+        || normalized.contains("cache")
+        || normalized.contains("crate")
+        || normalized.contains("loot")
+    {
+        StreamingArchetypeKind::LootContainer
+    } else if normalized.contains("npc")
+        || normalized.contains("warden")
+        || normalized.contains("merchant")
+    {
+        StreamingArchetypeKind::Npc
+    } else {
+        StreamingArchetypeKind::WildCreature
+    }
+}
+
+fn archetype_display_name(archetype_id: &str) -> String {
+    archetype_id
+        .split(['-', '_'])
+        .filter(|segment| !segment.is_empty())
+        .map(|segment| {
+            let mut chars = segment.chars();
+            match chars.next() {
+                Some(first) => {
+                    first.to_ascii_uppercase().to_string() + &chars.as_str().to_ascii_lowercase()
+                }
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn streaming_creature_level(archetype_id: &str) -> u16 {
+    if archetype_id.contains("alpha") || archetype_id.contains("beast") {
+        8
+    } else if archetype_id.contains("spirit") || archetype_id.contains("guardian") {
+        6
+    } else {
+        3
+    }
+}
+
+fn streaming_resource_node(archetype_id: &str) -> ResourceNode {
+    let normalized = archetype_id.to_ascii_lowercase();
+    if normalized.contains("tree") || normalized.contains("wood") {
+        ResourceNode {
+            skill: SkillKind::Woodcutting,
+            yield_item: ItemStack {
+                item_id: "verdant-log".to_string(),
+                display_name: "Verdant Log".to_string(),
+                quantity: 1,
+                stackable: true,
+            },
+            ..ResourceNode::default()
+        }
+    } else if normalized.contains("moonstone") {
+        ResourceNode {
+            tier: 2,
+            experience: 42,
+            yield_item: ItemStack {
+                item_id: "moonstone-shard".to_string(),
+                display_name: "Moonstone Shard".to_string(),
+                quantity: 1,
+                stackable: true,
+            },
+            ..ResourceNode::default()
+        }
+    } else {
+        ResourceNode {
+            yield_item: ItemStack {
+                item_id: "copper-ore".to_string(),
+                display_name: "Copper Ore".to_string(),
+                quantity: 1,
+                stackable: true,
+            },
+            ..ResourceNode::default()
+        }
+    }
+}
+
+fn streaming_loot_container(archetype_id: &str) -> LootContainer {
+    LootContainer {
+        coins: if archetype_id.contains("expedition") { 64 } else { 18 },
+        items: vec![ItemStack {
+            item_id: format!("{archetype_id}-salvage"),
+            display_name: format!("{} Salvage", archetype_display_name(archetype_id)),
+            quantity: 1,
+            stackable: true,
+        }],
+        ..LootContainer::default()
+    }
 }
 
 #[cfg(test)]
@@ -320,6 +1075,20 @@ mod tests {
             8.0,
             vec![heart_chunk, spire_chunk],
             vec![heart_region, spire_region],
+            vec![
+                RegionEncounterTable::new(
+                    "verdant-heart-wildlife",
+                    "verdant-hollow",
+                    "wildlife",
+                    vec![],
+                ),
+                RegionEncounterTable::new(
+                    "spirewatch-encounters",
+                    "spirewatch",
+                    "spire",
+                    vec![],
+                ),
+            ],
         );
 
         let heart = world.resolve_streaming_metadata(Vec2::new(2.0, 3.0));
@@ -345,6 +1114,252 @@ mod tests {
             spire.faction_track_id.as_deref(),
             Some("ancient-spirekeepers")
         );
+        assert_eq!(spire.biome_id.as_deref(), Some("spirewatch"));
+    }
+
+    #[test]
+    fn world_population_state_tracks_region_and_chunk_density() {
+        let mut world = World::new(42);
+
+        let mut heart_chunk = WorldChunkDefinition::new("0:0", "verdant-heart", "verdant-hollow");
+        heart_chunk.quest_graph_ids.push("verdant-intro".into());
+        heart_chunk.faction_track_ids.push("verdant-wardens".into());
+        heart_chunk
+            .encounter_table_ids
+            .push("verdant-heart-wildlife".into());
+
+        let mut spire_chunk = WorldChunkDefinition::new("0:1", "spirewatch", "spirewatch");
+        spire_chunk
+            .encounter_table_ids
+            .push("spirewatch-encounters".into());
+
+        let mut heart_region =
+            WorldRegionDefinition::new("verdant-heart", "Verdant Heart", "verdant-hollow");
+        heart_region.chunk_keys.push("0:0".into());
+        heart_region
+            .active_quest_graph_ids
+            .push("verdant-intro".into());
+        heart_region.dominant_faction_track_id = "verdant-wardens".into();
+        heart_region
+            .encounter_table_ids
+            .push("verdant-heart-wildlife".into());
+
+        let mut spire_region =
+            WorldRegionDefinition::new("spirewatch", "Spirewatch", "spirewatch");
+        spire_region.chunk_keys.push("0:1".into());
+        spire_region.dominant_faction_track_id = "ancient-spirekeepers".into();
+        spire_region
+            .encounter_table_ids
+            .push("spirewatch-encounters".into());
+
+        world.set_streaming_metadata(
+            8.0,
+            vec![heart_chunk, spire_chunk],
+            vec![heart_region, spire_region],
+            vec![
+                RegionEncounterTable {
+                    ambient_cap: 6,
+                    ..RegionEncounterTable::new(
+                        "verdant-heart-wildlife",
+                        "verdant-hollow",
+                        "wildlife",
+                        vec![],
+                    )
+                },
+                RegionEncounterTable {
+                    ambient_cap: 4,
+                    ..RegionEncounterTable::new(
+                        "spirewatch-encounters",
+                        "spirewatch",
+                        "spire",
+                        vec![],
+                    )
+                },
+            ],
+        );
+
+        let _tree = world.spawn_at(1.0, 1.0).with_label("Tree", Team::None).build();
+        let _ore = world
+            .spawn_at(2.0, 1.0)
+            .with_label("Ore Vein", Team::None)
+            .with_resource_node(ResourceNode {
+                skill: SkillKind::Mining,
+                tier: 2,
+                remaining_uses: 6,
+                respawn_ticks: 120,
+                experience: 45,
+                yield_item: ItemStack {
+                    item_id: "iron-ore".into(),
+                    display_name: "Iron Ore".into(),
+                    quantity: 1,
+                    stackable: true,
+                },
+            })
+            .build();
+        let _creature = world
+            .spawn_at(3.0, 1.0)
+            .with_label("Ember Lynx", Team::Team(2))
+            .with_health(30.0)
+            .with_combat_loadout(CombatLoadout::default())
+            .with_creature_identity(CreatureIdentity {
+                species_id: "ember-lynx".into(),
+                species_name: "Ember Lynx".into(),
+                elemental_affinity: "fire".into(),
+                temperament: CreatureTemperament::Aggressive,
+                level: 7,
+                capture_difficulty: 0.72,
+                is_wild: true,
+            })
+            .build();
+        let _loot = world
+            .spawn_at(2.0, 9.0)
+            .with_label("Spire Chest", Team::None)
+            .with_loot_container(LootContainer {
+                coins: 28,
+                items: vec![ItemStack {
+                    item_id: "spire-relic".into(),
+                    display_name: "Spire Relic".into(),
+                    quantity: 1,
+                    stackable: false,
+                }],
+                owner: None,
+                claimed: false,
+            })
+            .build();
+        let _ = world.add_agent(Box::new(crate::agent::HumanAgent::new()));
+
+        let population = world.population_state();
+        assert_eq!(population.tick, 0);
+        assert_eq!(population.regions.len(), 2);
+        assert_eq!(population.chunks.len(), 2);
+
+        let heart = population
+            .regions
+            .iter()
+            .find(|region| region.region_id == "verdant-heart")
+            .expect("heart region should exist");
+        assert_eq!(heart.active_chunk_count, 1);
+        assert_eq!(heart.counts.players, 1);
+        assert_eq!(heart.counts.wild_creatures, 1);
+        assert_eq!(heart.counts.resource_nodes, 1);
+        assert_eq!(heart.ambient_population_cap, 6);
+        assert_eq!(heart.spawn_budget_remaining, 4);
+        assert!(heart.population_pressure > 0.3);
+
+        let spire = population
+            .chunks
+            .iter()
+            .find(|chunk| chunk.chunk_key == "0:1")
+            .expect("spire chunk should exist");
+        assert_eq!(spire.region_id.as_deref(), Some("spirewatch"));
+        assert_eq!(spire.counts.loot_containers, 1);
+        assert_eq!(spire.ambient_population_cap, 4);
+        assert_eq!(spire.spawn_budget_remaining, 4);
+    }
+
+    #[test]
+    fn reconcile_streaming_population_spawns_and_rehomes_chunk_density() {
+        let mut world = World::new(99);
+
+        let mut heart_chunk = WorldChunkDefinition::new("0:0", "verdant-heart", "verdant-hollow");
+        heart_chunk
+            .encounter_table_ids
+            .push("verdant-heart-wildlife".into());
+        let mut steppe_chunk = WorldChunkDefinition::new("1:0", "ashen-steppe", "ashen-steppe");
+        steppe_chunk
+            .encounter_table_ids
+            .push("ashen-steppe-wildlife".into());
+
+        let mut heart_region =
+            WorldRegionDefinition::new("verdant-heart", "Verdant Heart", "verdant-hollow");
+        heart_region.chunk_keys.push("0:0".into());
+        heart_region
+            .encounter_table_ids
+            .push("verdant-heart-wildlife".into());
+
+        let mut steppe_region =
+            WorldRegionDefinition::new("ashen-steppe", "Ashen Steppe", "ashen-steppe");
+        steppe_region.chunk_keys.push("1:0".into());
+        steppe_region
+            .encounter_table_ids
+            .push("ashen-steppe-wildlife".into());
+
+        world.set_streaming_metadata(
+            8.0,
+            vec![heart_chunk, steppe_chunk],
+            vec![heart_region, steppe_region],
+            vec![
+                RegionEncounterTable {
+                    ambient_cap: 2,
+                    ..RegionEncounterTable::new(
+                        "verdant-heart-wildlife",
+                        "verdant-hollow",
+                        "wildlife",
+                        vec![EncounterSpawnEntry {
+                            archetype_id: "verdant-lynx".into(),
+                            weight: 1,
+                            min_count: 1,
+                            max_count: 2,
+                            required_stage_tags: Vec::new(),
+                            required_reputation_tiers: Vec::new(),
+                        }],
+                    )
+                },
+                RegionEncounterTable {
+                    ambient_cap: 1,
+                    ..RegionEncounterTable::new(
+                        "ashen-steppe-wildlife",
+                        "ashen-steppe",
+                        "wildlife",
+                        vec![EncounterSpawnEntry {
+                            archetype_id: "ashen-jackal".into(),
+                            weight: 1,
+                            min_count: 1,
+                            max_count: 1,
+                            required_stage_tags: Vec::new(),
+                            required_reputation_tiers: Vec::new(),
+                        }],
+                    )
+                },
+            ],
+        );
+
+        let (_, player) = world.add_agent(Box::new(crate::agent::IdleAgent::new()));
+        world
+            .ecs
+            .get::<&mut Transform>(player)
+            .expect("player should exist")
+            .position = Vec2::new(1.0, 1.0);
+        world.reconcile_streaming_population();
+
+        let population = world.population_state();
+        let heart = population
+            .chunks
+            .iter()
+            .find(|chunk| chunk.chunk_key == "0:0")
+            .expect("heart chunk should exist");
+        assert_eq!(heart.counts.wild_creatures, 2);
+
+        world
+            .ecs
+            .get::<&mut Transform>(player)
+            .expect("player should still exist")
+            .position = Vec2::new(9.0, 1.0);
+        world.reconcile_streaming_population();
+
+        let moved = world.population_state();
+        let heart_after = moved
+            .chunks
+            .iter()
+            .find(|chunk| chunk.chunk_key == "0:0")
+            .expect("heart chunk should still exist");
+        let steppe_after = moved
+            .chunks
+            .iter()
+            .find(|chunk| chunk.chunk_key == "1:0")
+            .expect("steppe chunk should exist");
+        assert_eq!(heart_after.counts.wild_creatures, 0);
+        assert_eq!(steppe_after.counts.wild_creatures, 1);
     }
 }
 

--- a/crates/pod-editor/src/lib.rs
+++ b/crates/pod-editor/src/lib.rs
@@ -13,11 +13,12 @@ use eframe::{App, Frame};
 use egui::{CentralPanel, Context, SidePanel, TopBottomPanel, Ui};
 use pod_core::{
     decode_toon_document, decode_toon_value, encode_toon_document, Action, ActionLifecycleStage,
-    AgentTelemetryFrame, AgentTickRollup, AgentToolCallEvent, AgentType, CreatureIdentity,
-    CreatureTemperament, EncounterSpawnEntry, FactionReputationTier, FactionReputationTrack,
-    QuestStageDefinition, QuestStateGraph, RegionEncounterTable, ReplayFile, ShardIncidentSummary,
+    AgentTelemetryFrame, AgentTickRollup, AgentToolCallEvent, AgentType, ChunkPopulationState,
+    CreatureIdentity, CreatureTemperament, EncounterSpawnEntry, FactionReputationTier,
+    FactionReputationTrack, PopulationBreakdown, QuestStageDefinition, QuestStateGraph,
+    RegionEncounterTable, RegionPopulationState, ReplayFile, ShardIncidentSummary,
     TelemetryConfig, TickTelemetryFrame, ToolCallStatus, TrajectorySample, VersionedTickTelemetry,
-    WorldChunkDefinition, WorldRegionDefinition,
+    WorldChunkDefinition, WorldPopulationState, WorldRegionDefinition,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
@@ -573,6 +574,8 @@ pub struct SpacetimeDashboardState {
     pub recent_tool_call_events: VecDeque<AgentToolCallEvent>,
     #[serde(default)]
     pub recent_tick_rollups: VecDeque<AgentTickRollup>,
+    #[serde(default)]
+    pub population_state: WorldPopulationState,
     pub last_reducer_call: String,
     pub reducer_calls: u32,
 }
@@ -597,6 +600,7 @@ impl Default for SpacetimeDashboardState {
             latest_incident_summary: None,
             recent_tool_call_events: VecDeque::new(),
             recent_tick_rollups: VecDeque::new(),
+            population_state: WorldPopulationState::default(),
             last_reducer_call: "none".to_string(),
             reducer_calls: 0,
         }
@@ -857,6 +861,11 @@ impl SpacetimeDashboardState {
                 tool_errors: rollup.tool_error_count as usize,
             }),
         }
+    }
+
+    pub fn apply_population_state(&mut self, population_state: WorldPopulationState) {
+        self.latest_tick = self.latest_tick.max(population_state.tick);
+        self.population_state = population_state;
     }
 
     pub fn to_toon_document(&self) -> String {
@@ -2542,6 +2551,22 @@ impl PodEditorApp {
         Ok(())
     }
 
+    pub fn import_world_population_toon_document(
+        &mut self,
+        document: &str,
+    ) -> Result<(), String> {
+        let population: WorldPopulationState =
+            decode_toon_document(document, "world_population_state")?;
+        let tick = population.tick;
+
+        self.history.remember(self.state.clone());
+        self.state
+            .spacetime_dashboard
+            .apply_population_state(population);
+        self.push_console(format!("Imported world population state @ tick {tick}"));
+        Ok(())
+    }
+
     pub fn import_live_debug_toon_document(&mut self, document: &str) -> Result<(), String> {
         let document_type = decode_toon_value(document)?
             .get("document_type")
@@ -2568,6 +2593,7 @@ impl PodEditorApp {
             }
             "agent_tool_call_event" => self.import_agent_tool_call_toon_document(document),
             "agent_tick_rollup" => self.import_agent_tick_rollup_toon_document(document),
+            "world_population_state" => self.import_world_population_toon_document(document),
             "replay_file" => {
                 let replay: ReplayFile = decode_toon_document(document, "replay_file")?;
                 let replay_name = replay.header.name.clone();
@@ -3340,6 +3366,52 @@ impl PodEditorApp {
             self.state.world_graph.faction_tracks.len(),
             self.state.world_graph.encounter_tables.len()
         ));
+        ui.label(format!(
+            "Authoritative population: {} regions · {} chunks",
+            self.state.spacetime_dashboard.population_state.regions.len(),
+            self.state.spacetime_dashboard.population_state.chunks.len()
+        ));
+        ui.separator();
+        if let Some(entity_id) = self.state.selected_entity {
+            if let Some(binding) = self.state.world_graph.binding_for_entity(entity_id) {
+                if let Some(region_id) = binding.region_id.as_deref() {
+                    if let Some(region) = self
+                        .state
+                        .spacetime_dashboard
+                        .population_state
+                        .regions
+                        .iter()
+                        .find(|region| region.region_id == region_id)
+                    {
+                        ui.label(format!(
+                            "Selected region pop: {} active · {}/{} chunks hot · cap {} · budget {}",
+                            region.active_entity_count,
+                            region.active_chunk_count,
+                            region.chunk_keys.len(),
+                            region.ambient_population_cap,
+                            region.spawn_budget_remaining
+                        ));
+                    }
+                }
+                if let Some(chunk_key) = binding.chunk_key.as_deref() {
+                    if let Some(chunk) = self
+                        .state
+                        .spacetime_dashboard
+                        .population_state
+                        .chunks
+                        .iter()
+                        .find(|chunk| chunk.chunk_key == chunk_key)
+                    {
+                        ui.label(format!(
+                            "Selected chunk pop: {} active · pressure {:.2} · cap {}",
+                            chunk.active_entity_count,
+                            chunk.population_pressure,
+                            chunk.ambient_population_cap
+                        ));
+                    }
+                }
+            }
+        }
         ui.separator();
         ui.label("Per-agent trajectory distance");
         if self.state.spacetime_dashboard.agent_summaries.is_empty() {
@@ -4511,6 +4583,67 @@ mod tests {
             15
         );
         assert_eq!(app.state.spacetime_dashboard.latest_tick, 15);
+    }
+
+    #[test]
+    fn editor_imports_world_population_toon_into_dashboard_state() {
+        let mut app = PodEditorApp::default();
+        let population = WorldPopulationState {
+            tick: 22,
+            chunks: vec![ChunkPopulationState {
+                chunk_key: "0:0".to_string(),
+                region_id: Some("verdant-heart".to_string()),
+                region_name: Some("Verdant Heart".to_string()),
+                biome_id: Some("verdant-hollow".to_string()),
+                quest_graph_ids: vec!["verdant-intro".to_string()],
+                faction_track_id: Some("verdant-wardens".to_string()),
+                encounter_table_ids: vec!["verdant-heart-wildlife".to_string()],
+                counts: PopulationBreakdown {
+                    players: 1,
+                    wild_creatures: 2,
+                    scenery: 3,
+                    ..PopulationBreakdown::default()
+                },
+                active_entity_count: 6,
+                ambient_population_cap: 8,
+                spawn_budget_remaining: 2,
+                population_pressure: 0.75,
+            }],
+            regions: vec![RegionPopulationState {
+                region_id: "verdant-heart".to_string(),
+                region_name: "Verdant Heart".to_string(),
+                primary_biome_id: "verdant-hollow".to_string(),
+                chunk_keys: vec!["0:0".to_string()],
+                active_quest_graph_ids: vec!["verdant-intro".to_string()],
+                dominant_faction_track_id: Some("verdant-wardens".to_string()),
+                encounter_table_ids: vec!["verdant-heart-wildlife".to_string()],
+                active_chunk_count: 1,
+                counts: PopulationBreakdown {
+                    players: 1,
+                    wild_creatures: 2,
+                    scenery: 3,
+                    ..PopulationBreakdown::default()
+                },
+                active_entity_count: 6,
+                ambient_population_cap: 8,
+                spawn_budget_remaining: 2,
+                population_pressure: 0.75,
+            }],
+        };
+
+        app.import_world_population_toon_document(&population.to_toon_document())
+            .expect("population TOON should import");
+
+        assert_eq!(app.state.spacetime_dashboard.latest_tick, 22);
+        assert_eq!(app.state.spacetime_dashboard.population_state.tick, 22);
+        assert_eq!(
+            app.state.spacetime_dashboard.population_state.regions[0].region_id,
+            "verdant-heart"
+        );
+        assert_eq!(
+            app.state.spacetime_dashboard.population_state.chunks[0].spawn_budget_remaining,
+            2
+        );
     }
 
     #[test]

--- a/crates/pod-net/src/client_native.rs
+++ b/crates/pod-net/src/client_native.rs
@@ -887,6 +887,10 @@ mod tests {
                 label: Some("player".into()),
                 metadata: crate::snapshot::EntityMetadataSnapshot::default(),
             }],
+            population: pod_core::WorldPopulationState {
+                tick: 20,
+                ..Default::default()
+            },
         };
         let predicted = WorldSnapshot {
             tick: 21,
@@ -901,6 +905,10 @@ mod tests {
                 label: Some("player".into()),
                 metadata: crate::snapshot::EntityMetadataSnapshot::default(),
             }],
+            population: pod_core::WorldPopulationState {
+                tick: 21,
+                ..Default::default()
+            },
         };
         let mut render_buffer = SnapshotInterpolationBuffer::default();
         render_buffer.push(authoritative.clone());

--- a/crates/pod-net/src/client_stdb.rs
+++ b/crates/pod-net/src/client_stdb.rs
@@ -577,6 +577,10 @@ impl SpacetimeDBClient {
                                 tick,
                                 updated: vec![snap],
                                 destroyed: vec![],
+                                population: pod_core::WorldPopulationState {
+                                    tick,
+                                    ..Default::default()
+                                },
                             },
                         });
                     }
@@ -607,6 +611,10 @@ impl SpacetimeDBClient {
                             tick,
                             updated: vec![],
                             destroyed: vec![entity_id],
+                            population: pod_core::WorldPopulationState {
+                                tick,
+                                ..Default::default()
+                            },
                         },
                     });
                 }
@@ -971,6 +979,10 @@ impl SpacetimeDBClient {
         WorldSnapshot {
             tick: self.current_tick_or_zero(),
             entities,
+            population: pod_core::WorldPopulationState {
+                tick: self.current_tick_or_zero(),
+                ..Default::default()
+            },
         }
     }
 
@@ -1533,6 +1545,10 @@ mod tests {
                 label: Some("player".into()),
                 metadata: EntityMetadataSnapshot::default(),
             }],
+            population: pod_core::WorldPopulationState {
+                tick: 10,
+                ..Default::default()
+            },
         });
         client.ingest_local_snapshot();
 
@@ -1559,6 +1575,10 @@ mod tests {
                 label: Some("npc".into()),
                 metadata: EntityMetadataSnapshot::default(),
             }],
+            population: pod_core::WorldPopulationState {
+                tick: 10,
+                ..Default::default()
+            },
         });
         client.ingest_local_snapshot();
         client.render_clock.advance(10, 1.0 / 60.0);

--- a/crates/pod-net/src/server.rs
+++ b/crates/pod-net/src/server.rs
@@ -679,6 +679,7 @@ impl GameServer {
                 tick: self.tick,
                 updated: current_snapshot.entities.clone(),
                 destroyed: vec![],
+                population: current_snapshot.population.clone(),
             }
         } else {
             StateDelta::diff(
@@ -810,6 +811,7 @@ impl GameServer {
                 tick: self.tick,
                 updated: snapshot.entities,
                 destroyed: vec![],
+                population: snapshot.population,
             },
         }
     }
@@ -1073,6 +1075,7 @@ impl std::error::Error for ServerError {}
                 let snapshot = WorldSnapshot {
                     tick,
                     entities: delta.updated,
+                    population: delta.population,
                 };
                 assert_eq!(snapshot.digest(), authoritative_digest);
             }

--- a/crates/pod-net/src/snapshot.rs
+++ b/crates/pod-net/src/snapshot.rs
@@ -12,7 +12,8 @@ use pod_core::{
     Action, ActorPresentation, AtmosphereProfile, AtmosphereVolume, CombatLoadout,
     CombatPresentation, CombatStyle, CreatureIdentity, EncounterKind, EncounterProfile,
     EncounterState, FactionAffiliation, FactionDisposition, Health, Label, LootContainer, Movement,
-    QuestAnchor, ResourceNode, SkillKind, SpawnProfile, Team, Transform, Velocity,
+    QuestAnchor, ResourceNode, SkillKind, SpawnProfile, Team, Transform,
+    Velocity, WorldPopulationState,
 };
 
 const FIXED_TICK_DURATION_SECS: f32 = 1.0 / 60.0;
@@ -30,6 +31,8 @@ pub struct WorldSnapshot {
     pub tick: u64,
     /// All entity states
     pub entities: Vec<EntitySnapshot>,
+    /// Authoritative streamed-world population state derived by the shard.
+    pub population: WorldPopulationState,
 }
 
 /// A serialized entity state
@@ -119,6 +122,8 @@ pub struct StateDelta {
     pub updated: Vec<EntitySnapshot>,
     /// Destroyed entity IDs
     pub destroyed: Vec<u64>,
+    /// Authoritative region/chunk population summary for the target tick.
+    pub population: WorldPopulationState,
 }
 
 /// Tick-aligned locally predicted actions that have been sent to the server but
@@ -487,6 +492,7 @@ impl WorldSnapshot {
     /// Capture current world state into a snapshot
     pub fn capture(world: &pod_core::World) -> Self {
         let mut entities = Vec::new();
+        let population = world.population_state();
         let controlled_entities = world
             .agents
             .iter()
@@ -599,6 +605,7 @@ impl WorldSnapshot {
         Self {
             tick: world.tick,
             entities,
+            population,
         }
     }
 
@@ -639,6 +646,8 @@ impl WorldSnapshot {
             hash_option_str(&mut hash, entity.label.as_deref());
             hash_entity_metadata(&mut hash, &entity.metadata);
         }
+
+        hash_population_state(&mut hash, &self.population);
 
         hash
     }
@@ -715,6 +724,7 @@ impl StateDelta {
             tick: new.tick,
             updated,
             destroyed,
+            population: new.population.clone(),
         }
     }
 
@@ -737,6 +747,7 @@ impl StateDelta {
         WorldSnapshot {
             tick: self.tick,
             entities,
+            population: self.population.clone(),
         }
     }
 
@@ -773,6 +784,7 @@ pub fn apply_authoritative_update(
         WorldSnapshot {
             tick,
             entities: delta.updated.clone(),
+            population: delta.population.clone(),
         }
     } else {
         let previous = previous.ok_or(SnapshotUpdateError::MissingBaseline { tick })?;
@@ -931,6 +943,11 @@ fn interpolate_snapshots(
     WorldSnapshot {
         tick: target_tick.floor().max(0.0) as u64,
         entities,
+        population: if factor < 0.5 {
+            lower.population.clone()
+        } else {
+            upper.population.clone()
+        },
     }
 }
 
@@ -1244,6 +1261,51 @@ fn hash_option_u8(hash: &mut u64, value: Option<u8>) {
     }
 }
 
+fn hash_population_breakdown(hash: &mut u64, counts: &pod_core::PopulationBreakdown) {
+    hash_u64(hash, counts.players as u64);
+    hash_u64(hash, counts.npcs as u64);
+    hash_u64(hash, counts.wild_creatures as u64);
+    hash_u64(hash, counts.companions as u64);
+    hash_u64(hash, counts.resource_nodes as u64);
+    hash_u64(hash, counts.loot_containers as u64);
+    hash_u64(hash, counts.scenery as u64);
+}
+
+fn hash_population_state(hash: &mut u64, population: &WorldPopulationState) {
+    hash_u64(hash, population.tick);
+    hash_u64(hash, population.chunks.len() as u64);
+    for chunk in &population.chunks {
+        hash_option_str(hash, Some(chunk.chunk_key.as_str()));
+        hash_option_str(hash, chunk.region_id.as_deref());
+        hash_option_str(hash, chunk.region_name.as_deref());
+        hash_option_str(hash, chunk.biome_id.as_deref());
+        hash_string_list(hash, &chunk.quest_graph_ids);
+        hash_option_str(hash, chunk.faction_track_id.as_deref());
+        hash_string_list(hash, &chunk.encounter_table_ids);
+        hash_population_breakdown(hash, &chunk.counts);
+        hash_u64(hash, chunk.active_entity_count as u64);
+        hash_u64(hash, chunk.ambient_population_cap as u64);
+        hash_u64(hash, chunk.spawn_budget_remaining as u64);
+        hash_f32(hash, chunk.population_pressure);
+    }
+    hash_u64(hash, population.regions.len() as u64);
+    for region in &population.regions {
+        hash_option_str(hash, Some(region.region_id.as_str()));
+        hash_option_str(hash, Some(region.region_name.as_str()));
+        hash_option_str(hash, Some(region.primary_biome_id.as_str()));
+        hash_string_list(hash, &region.chunk_keys);
+        hash_string_list(hash, &region.active_quest_graph_ids);
+        hash_option_str(hash, region.dominant_faction_track_id.as_deref());
+        hash_string_list(hash, &region.encounter_table_ids);
+        hash_u64(hash, region.active_chunk_count as u64);
+        hash_population_breakdown(hash, &region.counts);
+        hash_u64(hash, region.active_entity_count as u64);
+        hash_u64(hash, region.ambient_population_cap as u64);
+        hash_u64(hash, region.spawn_budget_remaining as u64);
+        hash_f32(hash, region.population_pressure);
+    }
+}
+
 fn hash_entity_metadata(hash: &mut u64, metadata: &EntityMetadataSnapshot) {
     hash_option_str(hash, Some(entity_kind_name(metadata.kind)));
     hash_option_str(hash, metadata.chunk_key.as_deref());
@@ -1403,9 +1465,37 @@ mod tests {
     use pod_core::{
         ActorPresentation, AtmosphereProfile, AtmosphereVolume, CombatLoadout, CombatPresentation,
         CreatureIdentity, EncounterProfile, FactionAffiliation, FactionDisposition, IdleAgent,
-        LootContainer, QuestAnchor, ResourceNode, SpawnProfile, WorldChunkDefinition,
-        WorldRegionDefinition,
+        LootContainer, QuestAnchor, RegionEncounterTable, ResourceNode, SpawnProfile,
+        WorldChunkDefinition, WorldRegionDefinition,
     };
+
+    fn empty_population(tick: u64) -> WorldPopulationState {
+        WorldPopulationState {
+            tick,
+            ..Default::default()
+        }
+    }
+
+    fn snapshot_with_entities(tick: u64, entities: Vec<EntitySnapshot>) -> WorldSnapshot {
+        WorldSnapshot {
+            tick,
+            entities,
+            population: empty_population(tick),
+        }
+    }
+
+    fn delta_with_updates(
+        tick: u64,
+        updated: Vec<EntitySnapshot>,
+        destroyed: Vec<u64>,
+    ) -> StateDelta {
+        StateDelta {
+            tick,
+            updated,
+            destroyed,
+            population: empty_population(tick),
+        }
+    }
 
     #[test]
     fn test_snapshot_default() {
@@ -1642,7 +1732,17 @@ mod tests {
             .encounter_table_ids
             .push("verdant-heart-wildlife".into());
 
-        world.set_streaming_metadata(8.0, vec![heart_chunk], vec![heart_region]);
+        world.set_streaming_metadata(
+            8.0,
+            vec![heart_chunk],
+            vec![heart_region],
+            vec![RegionEncounterTable::new(
+                "verdant-heart-wildlife",
+                "verdant-hollow",
+                "wildlife",
+                vec![],
+            )],
+        );
 
         world
             .spawn_at(2.0, 2.0)
@@ -1761,9 +1861,9 @@ mod tests {
             metadata: EntityMetadataSnapshot::default(),
         });
 
-        let delta = StateDelta {
-            tick: 1,
-            updated: vec![EntitySnapshot {
+        let delta = delta_with_updates(
+            1,
+            vec![EntitySnapshot {
                 id: 2,
                 position: Vec2::new(5.0, 5.0),
                 velocity: Vec2::ZERO,
@@ -1774,8 +1874,8 @@ mod tests {
                 label: None,
                 metadata: EntityMetadataSnapshot::default(),
             }],
-            destroyed: vec![],
-        };
+            vec![],
+        );
 
         let snap2 = delta.apply_to(&snap1);
         assert_eq!(snap2.entities.len(), 2);
@@ -1846,11 +1946,7 @@ mod tests {
         assert_eq!(delta.updated.len(), 1);
         assert_eq!(delta.updated[0].label.as_deref(), Some("sprite3d"));
 
-        let delta_with_destroy = StateDelta {
-            tick: 2,
-            updated: delta.updated.clone(),
-            destroyed: vec![12],
-        };
+        let delta_with_destroy = delta_with_updates(2, delta.updated.clone(), vec![12]);
 
         let applied = delta_with_destroy.apply_to(&base);
         assert_eq!(applied.entities.len(), 1);
@@ -1885,9 +1981,9 @@ mod tests {
             metadata: EntityMetadataSnapshot::default(),
         });
 
-        let delta = StateDelta {
-            tick: 10,
-            updated: vec![EntitySnapshot {
+        let delta = delta_with_updates(
+            10,
+            vec![EntitySnapshot {
                 id: 10,
                 position: Vec2::new(5.0, 5.0),
                 velocity: Vec2::ZERO,
@@ -1898,8 +1994,8 @@ mod tests {
                 label: Some("updated".into()),
                 metadata: EntityMetadataSnapshot::default(),
             }],
-            destroyed: vec![11, 99_999],
-        };
+            vec![11, 99_999],
+        );
 
         let applied = delta.apply_to(&base);
         assert_eq!(applied.entities.len(), 1);
@@ -1942,23 +2038,17 @@ mod tests {
             metadata: EntityMetadataSnapshot::default(),
         };
 
-        let snapshot_a = WorldSnapshot {
-            tick: 4,
-            entities: vec![entity_a.clone(), entity_b.clone()],
-        };
-        let snapshot_b = WorldSnapshot {
-            tick: 4,
-            entities: vec![entity_b, entity_a],
-        };
+        let snapshot_a = snapshot_with_entities(4, vec![entity_a.clone(), entity_b.clone()]);
+        let snapshot_b = snapshot_with_entities(4, vec![entity_b, entity_a]);
 
         assert_eq!(snapshot_a.digest(), snapshot_b.digest());
     }
 
     #[test]
     fn test_replay_predicted_actions_replays_move_and_stop() {
-        let snapshot = WorldSnapshot {
-            tick: 10,
-            entities: vec![EntitySnapshot {
+        let snapshot = snapshot_with_entities(
+            10,
+            vec![EntitySnapshot {
                 id: 7,
                 position: Vec2::ZERO,
                 velocity: Vec2::ZERO,
@@ -1969,7 +2059,7 @@ mod tests {
                 label: Some("player".into()),
                 metadata: EntityMetadataSnapshot::default(),
             }],
-        };
+        );
 
         let predicted = snapshot.replay_predicted_actions(
             Some(7),
@@ -1995,9 +2085,9 @@ mod tests {
     fn test_interpolation_buffer_replaces_same_tick_snapshot() {
         let mut buffer = SnapshotInterpolationBuffer::default();
 
-        buffer.push(WorldSnapshot {
-            tick: 10,
-            entities: vec![EntitySnapshot {
+        buffer.push(snapshot_with_entities(
+            10,
+            vec![EntitySnapshot {
                 id: 1,
                 position: Vec2::ZERO,
                 velocity: Vec2::ZERO,
@@ -2008,10 +2098,10 @@ mod tests {
                 label: Some("old".into()),
                 metadata: EntityMetadataSnapshot::default(),
             }],
-        });
-        buffer.push(WorldSnapshot {
-            tick: 10,
-            entities: vec![EntitySnapshot {
+        ));
+        buffer.push(snapshot_with_entities(
+            10,
+            vec![EntitySnapshot {
                 id: 1,
                 position: Vec2::new(5.0, 0.0),
                 velocity: Vec2::ZERO,
@@ -2022,7 +2112,7 @@ mod tests {
                 label: Some("new".into()),
                 metadata: EntityMetadataSnapshot::default(),
             }],
-        });
+        ));
 
         let sampled = buffer.sample(10.0).unwrap();
         assert_eq!(sampled.mode, SnapshotSampleMode::Exact);
@@ -2034,9 +2124,9 @@ mod tests {
     #[test]
     fn test_interpolation_buffer_lerps_shared_entities() {
         let mut buffer = SnapshotInterpolationBuffer::default();
-        buffer.push(WorldSnapshot {
-            tick: 10,
-            entities: vec![EntitySnapshot {
+        buffer.push(snapshot_with_entities(
+            10,
+            vec![EntitySnapshot {
                 id: 1,
                 position: Vec2::new(0.0, 0.0),
                 velocity: Vec2::new(10.0, 0.0),
@@ -2047,10 +2137,10 @@ mod tests {
                 label: Some("player".into()),
                 metadata: EntityMetadataSnapshot::default(),
             }],
-        });
-        buffer.push(WorldSnapshot {
-            tick: 12,
-            entities: vec![EntitySnapshot {
+        ));
+        buffer.push(snapshot_with_entities(
+            12,
+            vec![EntitySnapshot {
                 id: 1,
                 position: Vec2::new(12.0, 0.0),
                 velocity: Vec2::new(14.0, 0.0),
@@ -2061,7 +2151,7 @@ mod tests {
                 label: Some("player".into()),
                 metadata: EntityMetadataSnapshot::default(),
             }],
-        });
+        ));
 
         let sampled = buffer.sample(11.0).unwrap();
         let entity = &sampled.snapshot.entities[0];
@@ -2077,9 +2167,9 @@ mod tests {
     #[test]
     fn test_interpolation_buffer_extrapolates_latest_snapshot() {
         let mut buffer = SnapshotInterpolationBuffer::default();
-        buffer.push(WorldSnapshot {
-            tick: 5,
-            entities: vec![EntitySnapshot {
+        buffer.push(snapshot_with_entities(
+            5,
+            vec![EntitySnapshot {
                 id: 9,
                 position: Vec2::new(1.0, 2.0),
                 velocity: Vec2::new(60.0, 0.0),
@@ -2090,7 +2180,7 @@ mod tests {
                 label: Some("npc".into()),
                 metadata: EntityMetadataSnapshot::default(),
             }],
-        });
+        ));
 
         let sampled = buffer.sample(6.0).unwrap();
         let entity = &sampled.snapshot.entities[0];
@@ -2106,9 +2196,9 @@ mod tests {
             max_extrapolation_ticks: 1.0,
             ..InterpolationConfig::default()
         });
-        buffer.push(WorldSnapshot {
-            tick: 10,
-            entities: vec![EntitySnapshot {
+        buffer.push(snapshot_with_entities(
+            10,
+            vec![EntitySnapshot {
                 id: 1,
                 position: Vec2::new(5.0, 0.0),
                 velocity: Vec2::new(30.0, 0.0),
@@ -2119,7 +2209,7 @@ mod tests {
                 label: None,
                 metadata: EntityMetadataSnapshot::default(),
             }],
-        });
+        ));
 
         let past = buffer.sample(9.0).unwrap();
         assert_eq!(past.mode, SnapshotSampleMode::ClampedPast);
@@ -2145,18 +2235,9 @@ mod tests {
     #[test]
     fn test_interpolation_buffer_rewind_returns_latest_snapshot_before_tick() {
         let mut buffer = SnapshotInterpolationBuffer::default();
-        buffer.push(WorldSnapshot {
-            tick: 10,
-            entities: vec![],
-        });
-        buffer.push(WorldSnapshot {
-            tick: 15,
-            entities: vec![],
-        });
-        buffer.push(WorldSnapshot {
-            tick: 20,
-            entities: vec![],
-        });
+        buffer.push(snapshot_with_entities(10, vec![]));
+        buffer.push(snapshot_with_entities(15, vec![]));
+        buffer.push(snapshot_with_entities(20, vec![]));
 
         assert_eq!(buffer.rewind_to(16).unwrap().tick, 15);
         assert_eq!(buffer.rewind_to(8).unwrap().tick, 10);
@@ -2165,9 +2246,9 @@ mod tests {
     #[test]
     fn test_build_rollback_preview_replays_batches_after_rewind_tick() {
         let mut buffer = SnapshotInterpolationBuffer::default();
-        buffer.push(WorldSnapshot {
-            tick: 10,
-            entities: vec![EntitySnapshot {
+        buffer.push(snapshot_with_entities(
+            10,
+            vec![EntitySnapshot {
                 id: 7,
                 position: Vec2::ZERO,
                 velocity: Vec2::ZERO,
@@ -2178,10 +2259,10 @@ mod tests {
                 label: Some("player".into()),
                 metadata: EntityMetadataSnapshot::default(),
             }],
-        });
-        buffer.push(WorldSnapshot {
-            tick: 12,
-            entities: vec![EntitySnapshot {
+        ));
+        buffer.push(snapshot_with_entities(
+            12,
+            vec![EntitySnapshot {
                 id: 7,
                 position: Vec2::new(2.0, 0.0),
                 velocity: Vec2::ZERO,
@@ -2192,7 +2273,7 @@ mod tests {
                 label: Some("player".into()),
                 metadata: EntityMetadataSnapshot::default(),
             }],
-        });
+        ));
 
         let preview = build_rollback_preview(
             &buffer,
@@ -2241,9 +2322,9 @@ mod tests {
 
     #[test]
     fn test_build_catch_up_diagnostics_reports_drift_and_history_window() {
-        let authoritative = WorldSnapshot {
-            tick: 12,
-            entities: vec![EntitySnapshot {
+        let authoritative = snapshot_with_entities(
+            12,
+            vec![EntitySnapshot {
                 id: 1,
                 position: Vec2::new(6.0, 0.0),
                 velocity: Vec2::ZERO,
@@ -2254,10 +2335,10 @@ mod tests {
                 label: Some("player".into()),
                 metadata: EntityMetadataSnapshot::default(),
             }],
-        };
-        let predicted = WorldSnapshot {
-            tick: 13,
-            entities: vec![EntitySnapshot {
+        );
+        let predicted = snapshot_with_entities(
+            13,
+            vec![EntitySnapshot {
                 id: 1,
                 position: Vec2::new(8.0, 0.0),
                 velocity: Vec2::new(120.0, 0.0),
@@ -2268,16 +2349,10 @@ mod tests {
                 label: Some("player".into()),
                 metadata: EntityMetadataSnapshot::default(),
             }],
-        };
+        );
         let mut buffer = SnapshotInterpolationBuffer::default();
-        buffer.push(WorldSnapshot {
-            tick: 10,
-            entities: authoritative.entities.clone(),
-        });
-        buffer.push(WorldSnapshot {
-            tick: 11,
-            entities: authoritative.entities.clone(),
-        });
+        buffer.push(snapshot_with_entities(10, authoritative.entities.clone()));
+        buffer.push(snapshot_with_entities(11, authoritative.entities.clone()));
         buffer.push(authoritative.clone());
 
         let mut clock = RenderClock::default();
@@ -2342,9 +2417,9 @@ mod tests {
         let sampled = InterpolatedSnapshot {
             target_tick: 12.0,
             mode: SnapshotSampleMode::Interpolated,
-            snapshot: WorldSnapshot {
-                tick: 12,
-                entities: vec![
+            snapshot: snapshot_with_entities(
+                12,
+                vec![
                     EntitySnapshot {
                         id: 1,
                         position: Vec2::new(5.0, 0.0),
@@ -2368,11 +2443,11 @@ mod tests {
                         metadata: EntityMetadataSnapshot::default(),
                     },
                 ],
-            },
+            ),
         };
-        let predicted_local = WorldSnapshot {
-            tick: 13,
-            entities: vec![EntitySnapshot {
+        let predicted_local = snapshot_with_entities(
+            13,
+            vec![EntitySnapshot {
                 id: 1,
                 position: Vec2::new(8.0, 1.0),
                 velocity: Vec2::new(3.0, 0.0),
@@ -2383,7 +2458,7 @@ mod tests {
                 label: Some("player".into()),
                 metadata: EntityMetadataSnapshot::default(),
             }],
-        };
+        );
 
         let composed = compose_presentation_snapshot(sampled, Some(&predicted_local), Some(1));
 
@@ -2400,11 +2475,7 @@ mod tests {
 
     #[test]
     fn test_apply_authoritative_update_requires_baseline_for_delta() {
-        let delta = StateDelta {
-            tick: 5,
-            updated: vec![],
-            destroyed: vec![],
-        };
+        let delta = delta_with_updates(5, vec![], vec![]);
 
         let error = apply_authoritative_update(None, 5, false, &delta, 0).unwrap_err();
         assert_eq!(error, SnapshotUpdateError::MissingBaseline { tick: 5 });
@@ -2412,9 +2483,9 @@ mod tests {
 
     #[test]
     fn test_apply_authoritative_update_accepts_full_snapshot() {
-        let full = StateDelta {
-            tick: 5,
-            updated: vec![EntitySnapshot {
+        let full = delta_with_updates(
+            5,
+            vec![EntitySnapshot {
                 id: 1,
                 position: Vec2::new(2.0, 3.0),
                 velocity: Vec2::X,
@@ -2425,12 +2496,13 @@ mod tests {
                 label: Some("player".into()),
                 metadata: EntityMetadataSnapshot::default(),
             }],
-            destroyed: vec![],
-        };
+            vec![],
+        );
 
         let expected_snapshot = WorldSnapshot {
             tick: 5,
             entities: full.updated.clone(),
+            population: full.population.clone(),
         };
 
         let applied =


### PR DESCRIPTION
## Summary
- add deterministic shard-side streamed population reconciliation and TOON-exportable chunk/region population state in pod-core
- carry authoritative population state through pod-net and surface it in pod-web and pod-editor debug HUDs
- replace the old default server map with a streamed Verdant Hollow shard so authoritative worlds seed live population instead of relying on local-only browser density

## Validation
- cargo test -p pod-core --lib
- cargo test -p pod-net --lib
- cargo test -p pod-editor --lib
- cargo test -p pod-server --bin pod-server
- cd apps/pod-web && bun test ./src/contracts.test.ts ./src/local-world.test.ts ./src/affordances.test.ts
- cd apps/pod-web && bun run typecheck
- cd apps/pod-web && bun run build
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Authoritative population state tracking now visible in browser and editor—displays active entity counts, population caps, spawn budgets, and regional pressure metrics.
  * Default world map replaced with Verdant Hollow shard layout featuring multiple regions and biome-based encounters.
  * Dashboard now renders world population summaries with per-region and per-chunk population details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->