### PR TITLE
Add streamed population respawn pacing

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -846,5 +846,20 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cd apps/pod-web && bun run build`
   - `git diff --check`
 
-**Last updated**: Iteration 86
-**Current focus**: Iteration 87 authoritative streamed respawn tuning and richer shard-backed flagship biome authoring, followed by browser/editor heatmaps and creator controls for live regional population balancing
+### Iteration 87
+- [x] Reworked streamed shard population reconciliation into slot-based authoritative runtime state, including remembered live slots, per-slot respawn deadlines, and deterministic refill timing so streamed encounters no longer respawn immediately after despawn.
+- [x] Extended `WorldPopulationState` with pending-respawn and next-respawn timing at both chunk and region level, then propagated those new fields through `pod-net` hashing/transport and the browser/editor population contract surfaces.
+- [x] Updated `apps/pod-web` HUD summaries and `pod-editor` Spacetime dashboard summaries to show pending respawns and next respawn tick, so creators can tune live density pacing instead of only reading active counts and budget.
+- [x] Added deterministic regression coverage for respawn deadline behavior in `pod-core`, updated browser parsing tests for the new population timing fields, and kept the server flagship shard map green under the new authoritative pacing rules.
+- [x] Validated touched targets:
+  - `cargo test -p pod-core --lib`
+  - `cargo test -p pod-net --lib`
+  - `cargo test -p pod-editor --lib`
+  - `cargo test -p pod-server --bin pod-server`
+  - `cd apps/pod-web && bun test ./src/contracts.test.ts ./src/local-world.test.ts ./src/affordances.test.ts`
+  - `cd apps/pod-web && bun run typecheck`
+  - `cd apps/pod-web && bun run build`
+  - `git diff --check`
+
+**Last updated**: Iteration 87
+**Current focus**: Iteration 88 browser/editor population heatmaps and creator balancing controls on top of authoritative shard respawn state, followed by richer flagship biome authoring and denser multi-region shard content

--- a/apps/pod-web/src/contracts.test.ts
+++ b/apps/pod-web/src/contracts.test.ts
@@ -559,6 +559,8 @@ describe("TOON contract parsing", () => {
               activeEntityCount: 4,
               ambientPopulationCap: 6,
               spawnBudgetRemaining: 4,
+              pendingRespawns: 1,
+              nextRespawnTick: 36,
               populationPressure: 0.33
             }
           ],
@@ -584,6 +586,8 @@ describe("TOON contract parsing", () => {
               activeEntityCount: 4,
               ambientPopulationCap: 6,
               spawnBudgetRemaining: 4,
+              pendingRespawns: 1,
+              nextRespawnTick: 36,
               populationPressure: 0.33
             }
           ]
@@ -887,6 +891,8 @@ describe("TOON contract parsing", () => {
                   active_entity_count: 15,
                   ambient_population_cap: 8,
                   spawn_budget_remaining: 1,
+                  pending_respawns: 2,
+                  next_respawn_tick: 42,
                   population_pressure: 0.875
                 }
               ],
@@ -912,6 +918,8 @@ describe("TOON contract parsing", () => {
                   active_entity_count: 15,
                   ambient_population_cap: 8,
                   spawn_budget_remaining: 1,
+                  pending_respawns: 2,
+                  next_respawn_tick: 42,
                   population_pressure: 0.875
                 }
               ]
@@ -929,6 +937,7 @@ describe("TOON contract parsing", () => {
     expect(message.snapshot.population.tick).toBe(24);
     expect(message.snapshot.population.chunks[0]?.chunkKey).toBe("0:0");
     expect(message.snapshot.population.chunks[0]?.counts.wildCreatures).toBe(3);
+    expect(message.snapshot.population.chunks[0]?.nextRespawnTick).toBe(42);
     expect(message.snapshot.population.regions[0]?.populationPressure).toBe(0.875);
   });
 });

--- a/apps/pod-web/src/contracts.ts
+++ b/apps/pod-web/src/contracts.ts
@@ -566,6 +566,8 @@ export interface NetworkChunkPopulationState {
   activeEntityCount: number;
   ambientPopulationCap: number;
   spawnBudgetRemaining: number;
+  pendingRespawns: number;
+  nextRespawnTick: number | null;
   populationPressure: number;
 }
 
@@ -582,6 +584,8 @@ export interface NetworkRegionPopulationState {
   activeEntityCount: number;
   ambientPopulationCap: number;
   spawnBudgetRemaining: number;
+  pendingRespawns: number;
+  nextRespawnTick: number | null;
   populationPressure: number;
 }
 
@@ -1244,6 +1248,10 @@ function parseChunkPopulationState(value: unknown): NetworkChunkPopulationState 
       asNumber(value.ambient_population_cap ?? value.ambientPopulationCap) ?? 0,
     spawnBudgetRemaining:
       asNumber(value.spawn_budget_remaining ?? value.spawnBudgetRemaining) ?? 0,
+    pendingRespawns:
+      asNumber(value.pending_respawns ?? value.pendingRespawns) ?? 0,
+    nextRespawnTick:
+      asNumber(value.next_respawn_tick ?? value.nextRespawnTick) ?? null,
     populationPressure:
       asNumber(value.population_pressure ?? value.populationPressure) ?? 0
   };
@@ -1285,6 +1293,10 @@ function parseRegionPopulationState(value: unknown): NetworkRegionPopulationStat
       asNumber(value.ambient_population_cap ?? value.ambientPopulationCap) ?? 0,
     spawnBudgetRemaining:
       asNumber(value.spawn_budget_remaining ?? value.spawnBudgetRemaining) ?? 0,
+    pendingRespawns:
+      asNumber(value.pending_respawns ?? value.pendingRespawns) ?? 0,
+    nextRespawnTick:
+      asNumber(value.next_respawn_tick ?? value.nextRespawnTick) ?? null,
     populationPressure:
       asNumber(value.population_pressure ?? value.populationPressure) ?? 0
   };

--- a/apps/pod-web/src/local-world.ts
+++ b/apps/pod-web/src/local-world.ts
@@ -2499,6 +2499,8 @@ function summarizePopulationState(
         activeEntityCount: 0,
         ambientPopulationCap,
         spawnBudgetRemaining: ambientPopulationCap,
+        pendingRespawns: 0,
+        nextRespawnTick: null,
         populationPressure: 0
       });
     }
@@ -2526,6 +2528,8 @@ function summarizePopulationState(
         activeEntityCount: 0,
         ambientPopulationCap: 0,
         spawnBudgetRemaining: 0,
+        pendingRespawns: 0,
+        nextRespawnTick: null,
         populationPressure: 0
       };
 
@@ -2575,6 +2579,8 @@ function summarizePopulationState(
         activeEntityCount: 0,
         ambientPopulationCap,
         spawnBudgetRemaining: ambientPopulationCap,
+        pendingRespawns: 0,
+        nextRespawnTick: null,
         populationPressure: 0
       };
       finalizeRegionPopulation(regionState);

--- a/apps/pod-web/src/main.ts
+++ b/apps/pod-web/src/main.ts
@@ -284,12 +284,12 @@ function currentPopulationSummary(): string {
   }
 
   const chunkSummary = chunk
-    ? `${chunk.chunkKey} ${chunk.activeEntityCount} active · cap ${chunk.ambientPopulationCap} · budget ${chunk.spawnBudgetRemaining}`
+    ? `${chunk.chunkKey} ${chunk.activeEntityCount} active · cap ${chunk.ambientPopulationCap} · budget ${chunk.spawnBudgetRemaining} · respawns ${chunk.pendingRespawns}${chunk.nextRespawnTick != null ? ` @${chunk.nextRespawnTick}` : ""}`
     : "unassigned chunk";
   const regionSummary = region
     ? `${region.regionName} ${region.activeEntityCount} active · ${region.activeChunkCount}/${region.chunkKeys.length} chunks hot · pressure ${region.populationPressure.toFixed(
         2
-      )}`
+      )} · respawns ${region.pendingRespawns}${region.nextRespawnTick != null ? ` @${region.nextRespawnTick}` : ""}`
     : "unassigned region";
   return `${regionSummary} · ${chunkSummary}`;
 }

--- a/crates/pod-core/src/world.rs
+++ b/crates/pod-core/src/world.rs
@@ -38,6 +38,12 @@ pub struct World {
     /// Authored streamed-world metadata used by authoritative snapshot and
     /// tooling surfaces.
     pub streaming: WorldStreamingMetadata,
+    /// Previously live authored streaming slots, tracked so despawns can be
+    /// converted into deterministic respawn deadlines instead of immediate
+    /// refills.
+    streaming_live_slots: HashSet<String>,
+    /// Per-slot respawn gates for streamed authored populations.
+    streaming_respawn_deadlines: HashMap<String, u64>,
     /// Externally submitted actions (e.g., from network clients).
     external_actions: Vec<AgentAction>,
 }
@@ -123,6 +129,8 @@ pub struct ChunkPopulationState {
     pub active_entity_count: u32,
     pub ambient_population_cap: u32,
     pub spawn_budget_remaining: u32,
+    pub pending_respawns: u32,
+    pub next_respawn_tick: Option<u64>,
     pub population_pressure: f32,
 }
 
@@ -153,6 +161,8 @@ pub struct RegionPopulationState {
     pub active_entity_count: u32,
     pub ambient_population_cap: u32,
     pub spawn_budget_remaining: u32,
+    pub pending_respawns: u32,
+    pub next_respawn_tick: Option<u64>,
     pub population_pressure: f32,
 }
 
@@ -195,6 +205,7 @@ enum PopulationKind {
 
 #[derive(Debug, Clone)]
 struct StreamingSpawnRequest {
+    slot_key: String,
     chunk_key: String,
     biome_id: String,
     faction_track_id: Option<String>,
@@ -202,6 +213,7 @@ struct StreamingSpawnRequest {
     spawn_group: String,
     archetype_id: String,
     slot_index: u32,
+    respawn_ticks: u32,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -374,6 +386,8 @@ impl World {
             next_entity_id: 1,
             paused: false,
             streaming: WorldStreamingMetadata::new(8.0),
+            streaming_live_slots: HashSet::new(),
+            streaming_respawn_deadlines: HashMap::new(),
             external_actions: Vec::new(),
         }
     }
@@ -448,6 +462,24 @@ impl World {
             chunk_state.refresh_metrics();
         }
 
+        for (slot_key, deadline) in &self.streaming_respawn_deadlines {
+            if *deadline <= self.tick {
+                continue;
+            }
+            let Some((chunk_key, _, _)) = parse_streaming_slot_key(slot_key) else {
+                continue;
+            };
+            let chunk_state = chunk_states
+                .entry(chunk_key.to_string())
+                .or_insert_with(|| self.streaming.chunk_population_seed(chunk_key));
+            chunk_state.pending_respawns += 1;
+            chunk_state.next_respawn_tick = Some(
+                chunk_state
+                    .next_respawn_tick
+                    .map_or(*deadline, |current| current.min(*deadline)),
+            );
+        }
+
         let mut chunks = chunk_states.into_values().collect::<Vec<_>>();
         chunks.sort_by(|left, right| left.chunk_key.cmp(&right.chunk_key));
 
@@ -478,6 +510,13 @@ impl World {
                         state.active_chunk_count += 1;
                     }
                     state.counts.merge(chunk.counts);
+                    state.pending_respawns += chunk.pending_respawns;
+                    state.next_respawn_tick = match (state.next_respawn_tick, chunk.next_respawn_tick)
+                    {
+                        (Some(current), Some(next)) => Some(current.min(next)),
+                        (None, Some(next)) => Some(next),
+                        (current, None) => current,
+                    };
                 }
                 state.refresh_metrics();
                 state
@@ -502,67 +541,70 @@ impl World {
             return;
         }
 
-        let mut live_counts = HashMap::<(String, String), u32>::new();
+        let slot_specs = self.streaming_slot_specs(&active_chunks);
+        let active_slot_keys = slot_specs
+            .iter()
+            .map(|spec| spec.slot_key.clone())
+            .collect::<HashSet<_>>();
+
+        self.streaming_live_slots
+            .retain(|slot_key| active_slot_keys.contains(slot_key));
+        self.streaming_respawn_deadlines
+            .retain(|slot_key, _| active_slot_keys.contains(slot_key));
+
+        let mut live_slot_keys = HashSet::new();
         let mut stale_entities = Vec::new();
-        for (entity, (transform, spawn_profile)) in self.ecs.query::<(&Transform, &SpawnProfile)>().iter()
+        for (entity, (transform, spawn_profile)) in
+            self.ecs.query::<(&Transform, &SpawnProfile)>().iter()
         {
             let chunk_key = self.streaming.chunk_key_for_position(transform.position);
             if !active_chunks.contains(&chunk_key) {
                 stale_entities.push(entity);
                 continue;
             }
-
-            let Some(table_id) = streaming_profile_table_id(spawn_profile) else {
-                continue;
-            };
-            *live_counts
-                .entry((chunk_key, table_id.to_string()))
-                .or_default() += 1;
+            live_slot_keys.insert(spawn_profile.profile_id.clone());
         }
 
         for entity in stale_entities {
             let _ = self.ecs.despawn(entity);
         }
 
-        let mut requests = Vec::new();
-        for chunk_key in &active_chunks {
-            let seed = self.streaming.chunk_population_seed(chunk_key);
-            for table_id in &seed.encounter_table_ids {
-                let Some(table) = self.streaming.encounter_table(table_id) else {
-                    continue;
-                };
-                if table.entries.is_empty() {
-                    continue;
-                }
-
-                let current = live_counts
-                    .get(&(chunk_key.clone(), table_id.clone()))
-                    .copied()
-                    .unwrap_or_default();
-                let desired = table.ambient_cap as u32;
-                for slot_index in current..desired {
-                    let Some(entry) = choose_streaming_entry(table, chunk_key, slot_index) else {
-                        continue;
-                    };
-                    requests.push(StreamingSpawnRequest {
-                        chunk_key: chunk_key.clone(),
-                        biome_id: seed
-                            .biome_id
-                            .clone()
-                            .unwrap_or_else(|| table.biome_id.clone()),
-                        faction_track_id: seed.faction_track_id.clone(),
-                        encounter_table_id: table.table_id.clone(),
-                        spawn_group: table.spawn_group.clone(),
-                        archetype_id: entry.archetype_id.clone(),
-                        slot_index,
-                    });
-                }
+        let previous_live_slots = self.streaming_live_slots.clone();
+        for slot_key in previous_live_slots.difference(&live_slot_keys) {
+            if self.streaming_respawn_deadlines.contains_key(slot_key) {
+                continue;
             }
+            let Some(spec) = slot_specs.iter().find(|spec| spec.slot_key == *slot_key) else {
+                continue;
+            };
+            self.streaming_respawn_deadlines
+                .insert(slot_key.clone(), self.tick + spec.respawn_ticks as u64);
         }
 
+        let mut requests = Vec::new();
+        for spec in slot_specs {
+            if live_slot_keys.contains(&spec.slot_key) {
+                self.streaming_respawn_deadlines.remove(&spec.slot_key);
+                continue;
+            }
+
+            if self
+                .streaming_respawn_deadlines
+                .get(&spec.slot_key)
+                .is_some_and(|deadline| *deadline > self.tick)
+            {
+                continue;
+            }
+            self.streaming_respawn_deadlines.remove(&spec.slot_key);
+            requests.push(spec);
+        }
+
+        let mut next_live_slots = live_slot_keys;
         for request in requests {
+            next_live_slots.insert(request.slot_key.clone());
             self.spawn_streaming_request(request);
         }
+        self.streaming_live_slots = next_live_slots;
     }
 
     /// Advance the simulation by one tick
@@ -708,6 +750,50 @@ impl World {
         active
     }
 
+    fn streaming_slot_specs(&self, active_chunks: &HashSet<String>) -> Vec<StreamingSpawnRequest> {
+        let mut specs = Vec::new();
+
+        for chunk_key in active_chunks {
+            let seed = self.streaming.chunk_population_seed(chunk_key);
+            for table_id in &seed.encounter_table_ids {
+                let Some(table) = self.streaming.encounter_table(table_id) else {
+                    continue;
+                };
+                if table.entries.is_empty() {
+                    continue;
+                }
+
+                let biome_id = seed
+                    .biome_id
+                    .clone()
+                    .unwrap_or_else(|| table.biome_id.clone());
+                for slot_index in 0..table.ambient_cap as u32 {
+                    let Some(entry) = choose_streaming_entry(table, chunk_key, slot_index) else {
+                        continue;
+                    };
+                    let respawn_ticks = streaming_respawn_ticks(
+                        &entry.archetype_id,
+                        &table.spawn_group,
+                        entry.max_count,
+                    );
+                    specs.push(StreamingSpawnRequest {
+                        slot_key: encode_streaming_slot_key(chunk_key, &table.table_id, slot_index),
+                        chunk_key: chunk_key.clone(),
+                        biome_id: biome_id.clone(),
+                        faction_track_id: seed.faction_track_id.clone(),
+                        encounter_table_id: table.table_id.clone(),
+                        spawn_group: table.spawn_group.clone(),
+                        archetype_id: entry.archetype_id.clone(),
+                        slot_index,
+                        respawn_ticks,
+                    });
+                }
+            }
+        }
+
+        specs
+    }
+
     fn spawn_streaming_request(&mut self, request: StreamingSpawnRequest) {
         let position = streaming_spawn_position(
             &request.chunk_key,
@@ -717,10 +803,10 @@ impl World {
         );
         let display_name = archetype_display_name(&request.archetype_id);
         let spawn_profile = SpawnProfile {
-            profile_id: format!("{}::{}", request.encounter_table_id, request.slot_index),
+            profile_id: request.slot_key.clone(),
             biome_id: request.biome_id.clone(),
             spawn_group: request.spawn_group.clone(),
-            respawn_ticks: 60 * 30,
+            respawn_ticks: request.respawn_ticks,
             leash_radius: self.streaming.chunk_size * 0.45,
         };
         let faction = request
@@ -755,7 +841,7 @@ impl World {
                     })
                     .with_encounter_profile(EncounterProfile {
                         table_id: request.encounter_table_id.clone(),
-                        respawn_ticks: 60 * 30,
+                        respawn_ticks: request.respawn_ticks,
                         ..EncounterProfile::default()
                     })
                     .with_spawn_profile(spawn_profile)
@@ -841,8 +927,14 @@ fn classify_population_kind(
     PopulationKind::Scenery
 }
 
-fn streaming_profile_table_id(profile: &SpawnProfile) -> Option<&str> {
-    profile.profile_id.split_once("::").map(|(table_id, _)| table_id)
+fn encode_streaming_slot_key(chunk_key: &str, table_id: &str, slot_index: u32) -> String {
+    format!("{chunk_key}|{table_id}|{slot_index}")
+}
+
+fn parse_streaming_slot_key(slot_key: &str) -> Option<(&str, &str, u32)> {
+    let (chunk_key, remainder) = slot_key.split_once('|')?;
+    let (table_id, slot_index) = remainder.rsplit_once('|')?;
+    Some((chunk_key, table_id, slot_index.parse().ok()?))
 }
 
 fn choose_streaming_entry<'a>(
@@ -921,6 +1013,26 @@ fn streaming_spawn_position(
     let salt = stable_streaming_hash(chunk_key, encounter_table_id) as usize;
     let offset = pattern[(slot_index as usize + salt) % pattern.len()] * chunk_size;
     center + offset
+}
+
+fn streaming_respawn_ticks(archetype_id: &str, spawn_group: &str, entry_max_count: u8) -> u32 {
+    let normalized = format!(
+        "{}:{}",
+        archetype_id.to_ascii_lowercase(),
+        spawn_group.to_ascii_lowercase()
+    );
+    if normalized.contains("resource")
+        || normalized.contains("vein")
+        || normalized.contains("outcrop")
+        || normalized.contains("tree")
+    {
+        60 * 12
+    } else if normalized.contains("boss") || normalized.contains("beast") {
+        60 * 20
+    } else {
+        let density_factor = entry_max_count.max(1) as u32;
+        60 * (6 + density_factor * 2)
+    }
 }
 
 fn classify_streaming_archetype(archetype_id: &str, spawn_group: &str) -> StreamingArchetypeKind {
@@ -1360,6 +1472,83 @@ mod tests {
             .expect("steppe chunk should exist");
         assert_eq!(heart_after.counts.wild_creatures, 0);
         assert_eq!(steppe_after.counts.wild_creatures, 1);
+    }
+
+    #[test]
+    fn reconcile_streaming_population_respects_respawn_deadlines() {
+        let mut world = World::new(7);
+
+        let mut chunk = WorldChunkDefinition::new("0:0", "verdant-heart", "verdant-hollow");
+        chunk.encounter_table_ids.push("verdant-heart-wildlife".into());
+        let mut region =
+            WorldRegionDefinition::new("verdant-heart", "Verdant Heart", "verdant-hollow");
+        region.chunk_keys.push("0:0".into());
+        region
+            .encounter_table_ids
+            .push("verdant-heart-wildlife".into());
+
+        world.set_streaming_metadata(
+            8.0,
+            vec![chunk],
+            vec![region],
+            vec![RegionEncounterTable {
+                ambient_cap: 1,
+                ..RegionEncounterTable::new(
+                    "verdant-heart-wildlife",
+                    "verdant-hollow",
+                    "wildlife",
+                    vec![EncounterSpawnEntry {
+                        archetype_id: "verdant-lynx".into(),
+                        weight: 1,
+                        min_count: 1,
+                        max_count: 1,
+                        required_stage_tags: Vec::new(),
+                        required_reputation_tiers: Vec::new(),
+                    }],
+                )
+            }],
+        );
+
+        world.add_agent(Box::new(crate::agent::IdleAgent::new()));
+        world.reconcile_streaming_population();
+        let spawned_entity = world
+            .ecs
+            .query::<&SpawnProfile>()
+            .iter()
+            .map(|(entity, _)| entity)
+            .next()
+            .expect("streamed entity should spawn");
+        let respawn_ticks = world
+            .ecs
+            .get::<&SpawnProfile>(spawned_entity)
+            .expect("spawn profile exists")
+            .respawn_ticks as u64;
+
+        assert!(world.ecs.despawn(spawned_entity).is_ok());
+        world.reconcile_streaming_population();
+
+        let during_cooldown = world.population_state();
+        let chunk_state = during_cooldown
+            .chunks
+            .iter()
+            .find(|chunk| chunk.chunk_key == "0:0")
+            .expect("chunk should exist");
+        assert_eq!(chunk_state.counts.wild_creatures, 0);
+        assert_eq!(chunk_state.pending_respawns, 1);
+        assert_eq!(chunk_state.next_respawn_tick, Some(respawn_ticks));
+
+        world.tick = respawn_ticks;
+        world.reconcile_streaming_population();
+
+        let after_respawn = world.population_state();
+        let chunk_state = after_respawn
+            .chunks
+            .iter()
+            .find(|chunk| chunk.chunk_key == "0:0")
+            .expect("chunk should still exist");
+        assert_eq!(chunk_state.counts.wild_creatures, 1);
+        assert_eq!(chunk_state.pending_respawns, 0);
+        assert_eq!(chunk_state.next_respawn_tick, None);
     }
 }
 

--- a/crates/pod-editor/src/lib.rs
+++ b/crates/pod-editor/src/lib.rs
@@ -3384,12 +3384,17 @@ impl PodEditorApp {
                         .find(|region| region.region_id == region_id)
                     {
                         ui.label(format!(
-                            "Selected region pop: {} active · {}/{} chunks hot · cap {} · budget {}",
+                            "Selected region pop: {} active · {}/{} chunks hot · cap {} · budget {} · respawns {}{}",
                             region.active_entity_count,
                             region.active_chunk_count,
                             region.chunk_keys.len(),
                             region.ambient_population_cap,
-                            region.spawn_budget_remaining
+                            region.spawn_budget_remaining,
+                            region.pending_respawns,
+                            region
+                                .next_respawn_tick
+                                .map(|tick| format!(" @ {tick}"))
+                                .unwrap_or_default()
                         ));
                     }
                 }
@@ -3403,10 +3408,15 @@ impl PodEditorApp {
                         .find(|chunk| chunk.chunk_key == chunk_key)
                     {
                         ui.label(format!(
-                            "Selected chunk pop: {} active · pressure {:.2} · cap {}",
+                            "Selected chunk pop: {} active · pressure {:.2} · cap {} · respawns {}{}",
                             chunk.active_entity_count,
                             chunk.population_pressure,
-                            chunk.ambient_population_cap
+                            chunk.ambient_population_cap,
+                            chunk.pending_respawns,
+                            chunk
+                                .next_respawn_tick
+                                .map(|tick| format!(" @ {tick}"))
+                                .unwrap_or_default()
                         ));
                     }
                 }
@@ -4607,6 +4617,8 @@ mod tests {
                 active_entity_count: 6,
                 ambient_population_cap: 8,
                 spawn_budget_remaining: 2,
+                pending_respawns: 1,
+                next_respawn_tick: Some(48),
                 population_pressure: 0.75,
             }],
             regions: vec![RegionPopulationState {
@@ -4627,6 +4639,8 @@ mod tests {
                 active_entity_count: 6,
                 ambient_population_cap: 8,
                 spawn_budget_remaining: 2,
+                pending_respawns: 1,
+                next_respawn_tick: Some(48),
                 population_pressure: 0.75,
             }],
         };
@@ -4643,6 +4657,10 @@ mod tests {
         assert_eq!(
             app.state.spacetime_dashboard.population_state.chunks[0].spawn_budget_remaining,
             2
+        );
+        assert_eq!(
+            app.state.spacetime_dashboard.population_state.chunks[0].next_respawn_tick,
+            Some(48)
         );
     }
 

--- a/crates/pod-net/src/snapshot.rs
+++ b/crates/pod-net/src/snapshot.rs
@@ -1261,6 +1261,16 @@ fn hash_option_u8(hash: &mut u64, value: Option<u8>) {
     }
 }
 
+fn hash_option_u64(hash: &mut u64, value: Option<u64>) {
+    match value {
+        Some(value) => {
+            hash_u64(hash, 1);
+            hash_u64(hash, value);
+        }
+        None => hash_u64(hash, 0),
+    }
+}
+
 fn hash_population_breakdown(hash: &mut u64, counts: &pod_core::PopulationBreakdown) {
     hash_u64(hash, counts.players as u64);
     hash_u64(hash, counts.npcs as u64);
@@ -1286,6 +1296,8 @@ fn hash_population_state(hash: &mut u64, population: &WorldPopulationState) {
         hash_u64(hash, chunk.active_entity_count as u64);
         hash_u64(hash, chunk.ambient_population_cap as u64);
         hash_u64(hash, chunk.spawn_budget_remaining as u64);
+        hash_u64(hash, chunk.pending_respawns as u64);
+        hash_option_u64(hash, chunk.next_respawn_tick);
         hash_f32(hash, chunk.population_pressure);
     }
     hash_u64(hash, population.regions.len() as u64);
@@ -1302,6 +1314,8 @@ fn hash_population_state(hash: &mut u64, population: &WorldPopulationState) {
         hash_u64(hash, region.active_entity_count as u64);
         hash_u64(hash, region.ambient_population_cap as u64);
         hash_u64(hash, region.spawn_budget_remaining as u64);
+        hash_u64(hash, region.pending_respawns as u64);
+        hash_option_u64(hash, region.next_respawn_tick);
         hash_f32(hash, region.population_pressure);
     }
 }


### PR DESCRIPTION
## Summary
- add slot-based streamed population respawn pacing in pod-core so authored shard populations refill deterministically instead of instantly
- propagate pending respawn and next respawn tick through pod-net into browser/editor population surfaces
- expose respawn timing in the browser HUD and editor dashboard for creator-side balancing

## Validation
- cargo test -p pod-core --lib
- cargo test -p pod-net --lib
- cargo test -p pod-editor --lib
- cargo test -p pod-server --bin pod-server
- cd apps/pod-web && bun test ./src/contracts.test.ts ./src/local-world.test.ts ./src/affordances.test.ts
- cd apps/pod-web && bun run typecheck
- cd apps/pod-web && bun run build
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added respawn tracking and scheduling to population states, enabling visibility into pending respawns across chunks and regions.
  * UI dashboard now displays pending respawn counts and next respawn tick timing.
  * Implemented deterministic respawn deadlines for streamed populations instead of immediate respawning.

* **Tests**
  * Updated population state tests to validate new respawn tracking fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->