### PR TITLE
Add pod-web actor presentation motion

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -874,5 +874,16 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cd apps/pod-web && bun run build`
   - `git diff --check`
 
-**Last updated**: Iteration 88
-**Current focus**: Iteration 89 richer flagship biome authoring, denser multi-region shard content, and stronger creator-facing progression balancing on top of the new streamed population tooling
+### Iteration 89
+- [x] Replaced the rigid player-tied debug chase camera in `apps/pod-web` with a browser-side third-person orbit rig: independent yaw/pitch/zoom state, right-drag orbit, wheel zoom, velocity lead, and terrain-aware spring-arm collision so the flagship world reads like a controllable action camera instead of a floating shard overview.
+- [x] Smoothed local sandbox locomotion by replacing instant velocity snaps with acceleration/deceleration and turn easing, improving both WASD steering and point-and-click movement feel without changing the action pipeline.
+- [x] Kept the grounded terrain/water/daylight path from the previous graphics pass and validated that click-to-move, orbit-relative keyboard movement, and warmed asset residency still behave correctly in the live browser client.
+- [x] Added deterministic regression coverage for the new camera pose/collision behavior, updated controls tests for the terrain-aware pick ray, and kept the touched Bun suite green.
+- [x] Validated touched targets:
+  - `cd apps/pod-web && bun test ./src/frame-plan.test.ts ./src/controls.test.ts ./src/local-world.test.ts ./src/contracts.test.ts ./src/renderer.test.ts`
+  - `cd apps/pod-web && bun run typecheck`
+  - `cd apps/pod-web && bun run build`
+  - `git diff --check`
+
+**Last updated**: Iteration 89
+**Current focus**: Iteration 90 real terrain meshes, shoreline/water polish, and reducing the flagship HUD/debug chrome so the browser client feels like a game first and a diagnostics surface second

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -885,5 +885,16 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cd apps/pod-web && bun run build`
   - `git diff --check`
 
-**Last updated**: Iteration 89
-**Current focus**: Iteration 90 real terrain meshes, shoreline/water polish, and reducing the flagship HUD/debug chrome so the browser client feels like a game first and a diagnostics surface second
+### Iteration 90
+- [x] Strengthened the flagship `pod-web` biome composition with more pronounced ridge/backdrop shaping, improved terrain albedo painting, a dedicated shoreline band, and richer water surfacing so the world reads as a place instead of a debug field.
+- [x] Reduced first-view debug weight in the main HUD by tightening the chrome and keeping diagnostics secondary to the playable shard state.
+- [x] Fixed the browser timelapse boot state so the world starts in daylight reliably, making the flagship client prove terrain, water, and atmosphere immediately instead of sometimes loading into a dim night frame.
+- [x] Re-ran the touched Bun suite, typecheck, build, and live Playwright checks to confirm daylight boot, warm asset residency, and clean browser console behavior apart from the known upstream Three.js TSL warning.
+- [x] Validated touched targets:
+  - `cd apps/pod-web && bun test ./src/frame-plan.test.ts ./src/controls.test.ts ./src/local-world.test.ts ./src/contracts.test.ts ./src/renderer.test.ts`
+  - `cd apps/pod-web && bun run typecheck`
+  - `cd apps/pod-web && bun run build`
+  - `git diff --check`
+
+**Last updated**: Iteration 90
+**Current focus**: Iteration 91 character animation, combat feedback, and replacing the remaining debug-sandbox feel with authored traversal and encounter presentation

--- a/apps/pod-web/index.html
+++ b/apps/pod-web/index.html
@@ -332,7 +332,7 @@
             <dt>Stats</dt>
             <dd id="stats-label">warming up…</dd>
             <dt>Controls</dt>
-            <dd><code>WASD</code> move · <code>Tab</code> target · <code>Space</code> attack · <code>E</code> interact · <code>Enter</code> chat</dd>
+            <dd><code>Click</code> terrain to move · <code>WASD</code> camera-relative steer · <code>Tab</code> target · <code>Double-click</code> target action · <code>Enter</code> chat</dd>
             <dt>Bridge</dt>
             <dd><code>window.podRender.renderThreeJsWebGpuFrame(...)</code> or <code>?server=127.0.0.1:7778&amp;debug=1</code></dd>
           </dl>

--- a/apps/pod-web/index.html
+++ b/apps/pod-web/index.html
@@ -46,16 +46,16 @@
 
       .hud {
         position: absolute;
-        inset: 20px auto auto 20px;
-        width: min(352px, calc(100vw - 40px));
-        padding: 16px 16px 14px;
+        inset: 18px auto auto 18px;
+        width: min(316px, calc(100vw - 36px));
+        padding: 14px 14px 12px;
         border: 1px solid var(--panel-border);
-        border-radius: 20px;
+        border-radius: 18px;
         background:
-          linear-gradient(180deg, rgba(10, 16, 26, 0.84), rgba(7, 11, 18, 0.72)),
+          linear-gradient(180deg, rgba(10, 16, 26, 0.76), rgba(7, 11, 18, 0.6)),
           var(--panel-bg);
-        backdrop-filter: blur(22px);
-        box-shadow: 0 30px 80px rgba(0, 0, 0, 0.34);
+        backdrop-filter: blur(18px);
+        box-shadow: 0 24px 64px rgba(0, 0, 0, 0.28);
       }
 
       .hud--telemetry {
@@ -67,9 +67,9 @@
 
       .hud h1 {
         margin: 0;
-        font-size: 1.18rem;
-        letter-spacing: 0.03em;
-        text-transform: uppercase;
+        font-size: 1.02rem;
+        letter-spacing: 0.02em;
+        text-transform: none;
       }
 
       .hud p {
@@ -116,15 +116,15 @@
 
       .hud__stack {
         display: grid;
-        gap: 9px;
-        margin-top: 12px;
+        gap: 8px;
+        margin-top: 10px;
       }
 
       .hud__card {
         border: 1px solid rgba(130, 170, 255, 0.16);
-        border-radius: 15px;
-        background: rgba(3, 7, 12, 0.46);
-        padding: 10px 12px;
+        border-radius: 14px;
+        background: rgba(3, 7, 12, 0.38);
+        padding: 9px 11px;
       }
 
       .hud__card-label {
@@ -138,7 +138,7 @@
         display: block;
         margin-top: 4px;
         color: var(--copy);
-        font-size: 0.98rem;
+        font-size: 0.94rem;
         line-height: 1.28;
       }
 
@@ -147,7 +147,12 @@
         margin-top: 4px;
         color: var(--muted);
         line-height: 1.28;
-        font-size: 0.86rem;
+        font-size: 0.83rem;
+      }
+
+      #event-feed-label {
+        max-height: 2.6em;
+        overflow: hidden;
       }
 
       .hud dl {
@@ -288,7 +293,7 @@
           <span>Verdant Hollow live shard</span>
           <span id="backend-label">starting…</span>
         </div>
-        <h1>Prompt or Die</h1>
+        <h1>Playable browser shard</h1>
         <p id="feedback-label">
           Awaiting authoritative outcomes
         </p>

--- a/apps/pod-web/src/contracts.test.ts
+++ b/apps/pod-web/src/contracts.test.ts
@@ -708,7 +708,7 @@ describe("TOON contract parsing", () => {
         {
           id: 1,
           position: [8, 10],
-          velocity: [0, 0],
+          velocity: [2.2, 0.4],
           rotation: 0.25,
           label: "Hero",
           metadata: typedEntityMetadata("Player", {
@@ -797,11 +797,18 @@ describe("TOON contract parsing", () => {
     expect(frame.environment.biomeId).toBe("verdant-hollow");
     expect(frame.environment.fogFar).toBe(130);
     expect(frame.meshBatches.some((batch) => batch.material.includes(":verdant"))).toBe(true);
+    const heroInstance = frame.meshBatches
+      .flatMap((batch) => batch.instances)
+      .find((instance) => instance.sourceEntity === 1);
+    expect(heroInstance?.animationSetId).toBe("hero-runescape");
+    expect(heroInstance?.motionSpeed).toBeGreaterThan(0.3);
+    expect(heroInstance?.controlled).toBe(true);
     const selectionRing = frame.spriteBatches.find(
       (batch) => batch.texture === "selection-ring"
     );
     expect(selectionRing?.instances[0]?.scale).toEqual([3.2, 3.2, 1]);
     expect(selectionRing?.instances[0]?.color).toEqual([0.62, 0.98, 0.84, 0.55]);
+    expect(selectionRing?.instances[0]?.animationSetId).toBe("selection-ring");
 
     const auraRing = frame.spriteBatches.find((batch) => batch.texture === "mist-ring");
     expect(auraRing?.instances[0]?.color).toEqual([0.32, 0.86, 0.74, 0.28]);

--- a/apps/pod-web/src/contracts.ts
+++ b/apps/pod-web/src/contracts.ts
@@ -68,6 +68,10 @@ export interface ThreeJsInstance {
   scale: Vec3Tuple;
   color?: RgbaTuple;
   sourceEntity?: number;
+  animationSetId?: string;
+  motionSpeed?: number;
+  healthRatio?: number | null;
+  controlled?: boolean;
 }
 
 export type ThreeJsRenderPhase = "opaque" | "transparent";
@@ -2277,6 +2281,47 @@ function healthBand(entity: NetworkEntitySnapshot): "healthy" | "wounded" | "cri
   return "healthy";
 }
 
+function healthRatio(entity: NetworkEntitySnapshot): number | null {
+  if (entity.health == null || entity.maxHealth == null || entity.maxHealth <= 0) {
+    return null;
+  }
+
+  return clamp(entity.health / entity.maxHealth, 0, 1);
+}
+
+function motionSpeed(entity: NetworkEntitySnapshot): number {
+  const speed = Math.hypot(entity.velocity[0], entity.velocity[1]);
+  const maxSpeed = entity.movementSpeed ?? 0;
+  if (maxSpeed > 0.001) {
+    return clamp(speed / maxSpeed, 0, 1.6);
+  }
+
+  return clamp(speed / 6, 0, 1.6);
+}
+
+function resolveAnimationSetId(entity: NetworkEntitySnapshot): string {
+  const actorPresentationId = entity.metadata.actorPresentation?.animationSetId?.trim();
+  if (actorPresentationId) {
+    return actorPresentationId;
+  }
+
+  switch (entity.metadata.kind) {
+    case "Player":
+    case "Npc":
+      return "humanoid-explorer";
+    case "WildCreature":
+      return "beast-stalker";
+    case "Companion":
+      return "companion-hover";
+    case "Scenery":
+    case "ResourceNode":
+    case "LootContainer":
+      return "static-prop";
+    default:
+      return "humanoid-idle";
+  }
+}
+
 function entityKind(entity: NetworkEntitySnapshot): NetworkEntityKind {
   return entity.metadata.kind;
 }
@@ -2703,7 +2748,11 @@ export function buildAuthoritativeWorldFrame(
       position,
       rotation: yawQuaternion(entity.rotation),
       scale: profile.scale,
-      sourceEntity: entity.id
+      sourceEntity: entity.id,
+      animationSetId: resolveAnimationSetId(entity),
+      motionSpeed: motionSpeed(entity),
+      healthRatio: healthRatio(entity),
+      controlled: controlledEntity != null && entity.id === controlledEntity
     };
 
     const batchKey = meshBatchKey(profile);
@@ -2755,7 +2804,8 @@ export function buildAuthoritativeWorldFrame(
               1
             ],
             color: profile.auraColor,
-            sourceEntity: entity.id
+            sourceEntity: entity.id,
+            animationSetId: "aura-ring"
           }
         ]
       });
@@ -2778,7 +2828,9 @@ export function buildAuthoritativeWorldFrame(
             rotation: GROUND_RING_ROTATION,
             scale: [profile.selectionRingScale, profile.selectionRingScale, 1],
             color: profile.selectionRingColor,
-            sourceEntity: entity.id
+            sourceEntity: entity.id,
+            animationSetId: "selection-ring",
+            controlled: true
           }
         ]
       });
@@ -2804,7 +2856,9 @@ export function buildAuthoritativeWorldFrame(
               1
             ],
             color: profile.criticalRingColor,
-            sourceEntity: entity.id
+            sourceEntity: entity.id,
+            animationSetId: "critical-ring",
+            healthRatio: healthRatio(entity)
           }
         ]
       });

--- a/apps/pod-web/src/contracts.ts
+++ b/apps/pod-web/src/contracts.ts
@@ -1,5 +1,7 @@
 import { decode as decodeToon } from "@toon-format/toon";
 
+import { sampleTerrainHeight } from "./landscape";
+
 export type Vec3Tuple = [number, number, number];
 export type Vec4Tuple = [number, number, number, number];
 export type Vec2Tuple = [number, number];
@@ -10,6 +12,12 @@ export interface CameraState {
   y: number;
   zoom: number;
   rotation: number;
+  pitch?: number;
+  focusHeight?: number;
+  followDistance?: number;
+  shoulderOffset?: number;
+  leadX?: number;
+  leadY?: number;
   viewportWidth: number;
   viewportHeight: number;
 }
@@ -2119,6 +2127,7 @@ interface EntityRenderProfile {
   tint: RgbaTuple;
   emissive: Vec3Tuple;
   scale: Vec3Tuple;
+  groundOffset: number;
   layer: number;
   renderOrder: number;
   roughness: number;
@@ -2172,22 +2181,22 @@ function defaultFrameHints(): ThreeJsWebGpuHints {
 function defaultEnvironment(): ThreeJsEnvironment {
   return {
     biomeId: "neutral-shard",
-    skyColor: [0.04, 0.06, 0.1, 1],
-    fogColor: [0.035, 0.06, 0.1, 1],
-    fogNear: 28,
-    fogFar: 180,
-    ambientColor: [0.66, 0.82, 1],
-    ambientIntensity: 1.2,
-    sunColor: [1, 0.94, 0.82],
-    sunIntensity: 2.6,
-    sunDirection: [24, 42, 18],
-    fillColor: [0.42, 0.74, 1],
-    fillIntensity: 0.7,
+    skyColor: [0.64, 0.8, 0.98, 1],
+    fogColor: [0.73, 0.84, 0.78, 1],
+    fogNear: 30,
+    fogFar: 196,
+    ambientColor: [0.82, 0.92, 0.88],
+    ambientIntensity: 1.4,
+    sunColor: [1, 0.96, 0.84],
+    sunIntensity: 2.95,
+    sunDirection: [30, 48, 18],
+    fillColor: [0.48, 0.76, 0.94],
+    fillIntensity: 0.88,
     fillDirection: [-18, 14, -10],
-    rimColor: [0.29, 0.76, 1],
-    rimIntensity: 12,
-    groundColor: [0.055, 0.09, 0.14, 1],
-    starfieldIntensity: 0.9
+    rimColor: [0.4, 0.88, 0.78],
+    rimIntensity: 8.5,
+    groundColor: [0.19, 0.33, 0.21, 1],
+    starfieldIntensity: 0.08
   };
 }
 
@@ -2332,6 +2341,7 @@ function finalizeEntityRenderProfile(
             baseProfile.scale[2] * actor.scaleMultiplier
           ]
         : baseProfile.scale,
+    groundOffset: baseProfile.groundOffset,
     selectionRingScale: actor?.selectionRingScale ?? 2.4,
     selectionRingColor: combat?.selectionRingColor ?? defaultSelectionRingColor,
     criticalRingColor: combat?.criticalRingColor ?? [0.92, 0.34, 0.3, 0.22],
@@ -2409,6 +2419,7 @@ function entityRenderProfile(
       tint: isWood ? [0.28, 0.62, 0.34, 1] : [0.74, 0.54, 0.28, 1],
       emissive: isWood ? [0.02, 0.05, 0.02] : [0.08, 0.04, 0.01],
       scale: isWood ? [2.0, 4.2, 2.0] : [1.85, 1.3, 1.7],
+      groundOffset: isWood ? 0.18 : 0.12,
       layer: 1,
       renderOrder: 1,
       roughness: isWood ? 0.9 : 0.86,
@@ -2423,6 +2434,7 @@ function entityRenderProfile(
       tint: [0.78, 0.58, 0.34, 1],
       emissive: [0.03, 0.02, 0.01],
       scale: [1.18, 0.82, 0.92],
+      groundOffset: 0.06,
       layer: 2,
       renderOrder: 2,
       roughness: 0.8,
@@ -2442,6 +2454,7 @@ function entityRenderProfile(
             : [0.72, 0.52, 0.4, 1],
       emissive: band === "critical" ? [0.12, 0.03, 0.02] : [0.04, 0.02, 0.01],
       scale: [1.6, 1.9, 1.6],
+      groundOffset: 0.08,
       layer: 3,
       renderOrder: 3,
       roughness: 0.82,
@@ -2456,6 +2469,7 @@ function entityRenderProfile(
       tint: [0.42, 0.88, 0.74, 1],
       emissive: [0.06, 0.16, 0.12],
       scale: [1.0, 1.35, 1.0],
+      groundOffset: 0.1,
       layer: 4,
       renderOrder: 4,
       roughness: 0.42,
@@ -2473,6 +2487,7 @@ function entityRenderProfile(
           : teamTint(entity.metadata.teamId, false),
       emissive: [0.02, 0.03, 0.05],
       scale: [1.1, 1.9, 1.1],
+      groundOffset: 0.08,
       layer: 5,
       renderOrder: 5,
       roughness: 0.66,
@@ -2487,6 +2502,7 @@ function entityRenderProfile(
       tint: [0.24, 0.3, 0.38, 1],
       emissive: [0.01, 0.02, 0.03],
       scale: [3.2, 2.8, 0.95],
+      groundOffset: 0.16,
       layer: 0,
       renderOrder: 0,
       roughness: 0.94,
@@ -2501,6 +2517,7 @@ function entityRenderProfile(
       tint: [0.54, 0.76, 0.94, 1],
       emissive: [0.08, 0.14, 0.2],
       scale: [1.7, 4.0, 1.7],
+      groundOffset: 0.24,
       layer: 1,
       renderOrder: 1,
       roughness: 0.22,
@@ -2515,6 +2532,7 @@ function entityRenderProfile(
       tint: [0.34, 0.66, 0.4, 1],
       emissive: [0.02, 0.05, 0.02],
       scale: [2.1, 4.3, 2.1],
+      groundOffset: 0.18,
       layer: 1,
       renderOrder: 1,
       roughness: 0.9,
@@ -2529,6 +2547,7 @@ function entityRenderProfile(
       tint: [0.34, 0.38, 0.46, 1],
       emissive: [0.02, 0.03, 0.05],
       scale: [1.4, 3.6, 1.4],
+      groundOffset: 0.16,
       layer: 1,
       renderOrder: 1,
       roughness: 0.9,
@@ -2543,6 +2562,7 @@ function entityRenderProfile(
       tint: [0.5, 0.42, 0.32, 1],
       emissive: [0.02, 0.015, 0.01],
       scale: [1.55, 1.12, 1.55],
+      groundOffset: 0.08,
       layer: 1,
       renderOrder: 1,
       roughness: 0.96,
@@ -2568,6 +2588,7 @@ function entityRenderProfile(
             : [0.72, 0.52, 0.4, 1],
       emissive: band === "critical" ? [0.12, 0.03, 0.02] : [0.04, 0.02, 0.01],
       scale: label.includes("npc") ? [1.1, 1.9, 1.1] : [1.6, 1.9, 1.6],
+      groundOffset: label.includes("npc") ? 0.08 : 0.08,
       layer: label.includes("npc") ? 5 : 3,
       renderOrder: label.includes("npc") ? 5 : 3,
       roughness: 0.82,
@@ -2588,6 +2609,7 @@ function entityRenderProfile(
       tint: [0.42, 0.88, 0.74, 1],
       emissive: [0.06, 0.16, 0.12],
       scale: [1.0, 1.35, 1.0],
+      groundOffset: 0.1,
       layer: 4,
       renderOrder: 4,
       roughness: 0.42,
@@ -2605,6 +2627,7 @@ function entityRenderProfile(
           : teamTint(entity.metadata.teamId, isControlled),
     emissive: isControlled ? [0.08, 0.06, 0.02] : [0.02, 0.03, 0.05],
     scale: isControlled ? [1.2, 2.0, 1.2] : [1.05, 1.85, 1.05],
+    groundOffset: isControlled ? 0.1 : 0.08,
     layer: 6,
     renderOrder: 6,
     roughness: 0.64,
@@ -2668,10 +2691,13 @@ export function buildAuthoritativeWorldFrame(
 
   for (const entity of snapshot.entities) {
     const profile = entityRenderProfile(entity, controlledEntity);
+    const worldX = entity.position[0] * WORLD_TO_RENDER_SCALE;
+    const worldZ = entity.position[1] * WORLD_TO_RENDER_SCALE;
+    const groundHeight = sampleTerrainHeight(worldX, worldZ);
     const position: Vec3Tuple = [
-      entity.position[0] * WORLD_TO_RENDER_SCALE,
-      profile.scale[1] * 0.5,
-      entity.position[1] * WORLD_TO_RENDER_SCALE
+      worldX,
+      groundHeight + profile.scale[1] * 0.5 + profile.groundOffset,
+      worldZ
     ];
     const instance: ThreeJsInstance = {
       position,
@@ -2721,7 +2747,7 @@ export function buildAuthoritativeWorldFrame(
         depthTest: true,
         instances: [
           {
-            position: [position[0], 0.12, position[2]],
+            position: [position[0], groundHeight + 0.12, position[2]],
             rotation: GROUND_RING_ROTATION,
             scale: [
               profile.selectionRingScale * 1.4,
@@ -2748,7 +2774,7 @@ export function buildAuthoritativeWorldFrame(
         depthTest: true,
         instances: [
           {
-            position: [position[0], 0.08, position[2]],
+            position: [position[0], groundHeight + 0.08, position[2]],
             rotation: GROUND_RING_ROTATION,
             scale: [profile.selectionRingScale, profile.selectionRingScale, 1],
             color: profile.selectionRingColor,
@@ -2770,7 +2796,7 @@ export function buildAuthoritativeWorldFrame(
         depthTest: true,
         instances: [
           {
-            position: [position[0], 0.06, position[2]],
+            position: [position[0], groundHeight + 0.06, position[2]],
             rotation: GROUND_RING_ROTATION,
             scale: [
               profile.selectionRingScale * profile.impactScale,
@@ -2791,6 +2817,12 @@ export function buildAuthoritativeWorldFrame(
       y: focusPosition[1],
       zoom: cameraZoom,
       rotation: focus?.rotation ?? 0.48,
+      pitch: 0.34,
+      focusHeight: 2.2,
+      followDistance: 13.5,
+      shoulderOffset: 0.9,
+      leadX: 0,
+      leadY: 0,
       viewportWidth: options.viewportWidth ?? defaultViewportWidth(),
       viewportHeight: options.viewportHeight ?? defaultViewportHeight()
     },

--- a/apps/pod-web/src/controls.test.ts
+++ b/apps/pod-web/src/controls.test.ts
@@ -10,8 +10,12 @@ import {
 const DEFAULT_CAMERA: CameraState = {
   x: 0,
   y: 0,
-  zoom: 1,
+  zoom: 1.25,
   rotation: 0,
+  pitch: 0.22,
+  focusHeight: 1.8,
+  followDistance: 9,
+  shoulderOffset: 0,
   viewportWidth: 1280,
   viewportHeight: 720
 };
@@ -89,7 +93,7 @@ describe("pod-web controls", () => {
 
   test("projects a center-screen click onto the ground near the camera focus", () => {
     const point = pickWorldGroundPoint(
-      [DEFAULT_CAMERA.viewportWidth / 2, DEFAULT_CAMERA.viewportHeight / 2],
+      [DEFAULT_CAMERA.viewportWidth / 2, DEFAULT_CAMERA.viewportHeight * 0.78],
       { width: DEFAULT_CAMERA.viewportWidth, height: DEFAULT_CAMERA.viewportHeight },
       DEFAULT_CAMERA
     );

--- a/apps/pod-web/src/controls.test.ts
+++ b/apps/pod-web/src/controls.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+
+import type { CameraState, NetworkEntitySnapshot } from "./contracts";
+import {
+  cameraRelativeMovementDirection,
+  pickWorldGroundPoint,
+  resolvePointerTarget
+} from "./controls";
+
+const DEFAULT_CAMERA: CameraState = {
+  x: 0,
+  y: 0,
+  zoom: 1,
+  rotation: 0,
+  viewportWidth: 1280,
+  viewportHeight: 720
+};
+
+function testEntity(
+  id: number,
+  position: [number, number],
+  footprintRadius: number
+): NetworkEntitySnapshot {
+  return {
+    id,
+    position,
+    velocity: [0, 0],
+    rotation: 0,
+    health: 10,
+    maxHealth: 10,
+    movementSpeed: 4,
+    label: `E(${id})`,
+    metadata: {
+      kind: "Npc",
+      chunkKey: null,
+      regionId: null,
+      regionName: null,
+      teamId: null,
+      questGraphIds: [],
+      factionTrackId: null,
+      encounterTableId: null,
+      combatStyle: null,
+      speciesId: null,
+      speciesName: null,
+      resourceSkill: null,
+      resourceTier: null,
+      encounterKind: null,
+      faction: null,
+      questAnchor: null,
+      encounterProfile: null,
+      spawnProfile: null,
+      atmosphere: null,
+      atmosphereVolume: null,
+      actorPresentation: {
+        profileId: `profile-${id}`,
+        meshAssetId: null,
+        materialPaletteId: "default",
+        animationSetId: "humanoid",
+        scaleMultiplier: 1,
+        footprintRadius,
+        selectionRingScale: 2.2,
+        auraColor: [0, 0, 0, 0]
+      },
+      combatPresentation: null,
+      interaction: {
+        canInspect: true,
+        canInteract: true,
+        canAttack: true,
+        canGather: false,
+        canLoot: false,
+        canCapture: false,
+        canCommandCompanion: false,
+        canChat: true
+      }
+    }
+  };
+}
+
+describe("pod-web controls", () => {
+  test("maps WASD to camera-relative world movement", () => {
+    expect(cameraRelativeMovementDirection(["KeyW"], 0)).toEqual([0, -1]);
+    expect(cameraRelativeMovementDirection(["KeyD"], 0)?.[0]).toBeCloseTo(1, 6);
+    expect(cameraRelativeMovementDirection(["KeyD"], 0)?.[1]).toBeCloseTo(0, 6);
+
+    const rotatedForward = cameraRelativeMovementDirection(["KeyW"], Math.PI / 2);
+    expect(rotatedForward?.[0]).toBeCloseTo(-1, 6);
+    expect(rotatedForward?.[1]).toBeCloseTo(0, 6);
+  });
+
+  test("projects a center-screen click onto the ground near the camera focus", () => {
+    const point = pickWorldGroundPoint(
+      [DEFAULT_CAMERA.viewportWidth / 2, DEFAULT_CAMERA.viewportHeight / 2],
+      { width: DEFAULT_CAMERA.viewportWidth, height: DEFAULT_CAMERA.viewportHeight },
+      DEFAULT_CAMERA
+    );
+
+    expect(point).not.toBeNull();
+    const distanceFromFocus = Math.hypot(point?.[0] ?? 999, point?.[1] ?? 999);
+    expect(distanceFromFocus).toBeLessThan(6.5);
+  });
+
+  test("selects the closest entity whose footprint contains the click point", () => {
+    const selected = resolvePointerTarget(
+      [testEntity(2, [4.2, 2.1], 1.4), testEntity(3, [4.9, 2.3], 1.1)],
+      [4.3, 2.15]
+    );
+
+    expect(selected?.id).toBe(2);
+    expect(resolvePointerTarget([testEntity(5, [12, 12], 1.2)], [0, 0])).toBeNull();
+  });
+});

--- a/apps/pod-web/src/controls.ts
+++ b/apps/pod-web/src/controls.ts
@@ -1,0 +1,144 @@
+import * as THREE from "three";
+
+import type { CameraState, NetworkEntitySnapshot, Vec2Tuple } from "./contracts";
+import { buildCameraPose } from "./frame-plan";
+import { sampleTerrainHeight } from "./landscape";
+
+function normalizeDirection(x: number, y: number): Vec2Tuple | null {
+  const length = Math.hypot(x, y);
+  if (length <= Number.EPSILON) {
+    return null;
+  }
+
+  return [x / length, y / length];
+}
+
+export function cameraRelativeMovementDirection(
+  pressedKeys: Iterable<string>,
+  cameraRotation: number
+): Vec2Tuple | null {
+  const activeKeys = new Set(pressedKeys);
+  const forwardIntent =
+    (activeKeys.has("KeyW") || activeKeys.has("ArrowUp") ? 1 : 0) -
+    (activeKeys.has("KeyS") || activeKeys.has("ArrowDown") ? 1 : 0);
+  const strafeIntent =
+    (activeKeys.has("KeyD") || activeKeys.has("ArrowRight") ? 1 : 0) -
+    (activeKeys.has("KeyA") || activeKeys.has("ArrowLeft") ? 1 : 0);
+
+  if (forwardIntent === 0 && strafeIntent === 0) {
+    return null;
+  }
+
+  const forwardX = -Math.sin(cameraRotation);
+  const forwardY = -Math.cos(cameraRotation);
+  const rightX = Math.cos(cameraRotation);
+  const rightY = -Math.sin(cameraRotation);
+
+  return normalizeDirection(
+    forwardX * forwardIntent + rightX * strafeIntent,
+    forwardY * forwardIntent + rightY * strafeIntent
+  );
+}
+
+export function pickWorldGroundPoint(
+  pointer: Vec2Tuple,
+  viewport: { width: number; height: number },
+  cameraState: CameraState
+): Vec2Tuple | null {
+  if (viewport.width <= 0 || viewport.height <= 0) {
+    return null;
+  }
+
+  const pose = buildCameraPose(cameraState, {});
+  const camera = new THREE.PerspectiveCamera(
+    pose.fov,
+    viewport.width / Math.max(viewport.height, 1),
+    pose.near,
+    pose.far
+  );
+  camera.position.set(...pose.position);
+  camera.quaternion.copy(pose.quaternion);
+  camera.updateMatrixWorld(true);
+  camera.updateProjectionMatrix();
+
+  const ndc = new THREE.Vector2(
+    (pointer[0] / viewport.width) * 2 - 1,
+    -((pointer[1] / viewport.height) * 2 - 1)
+  );
+  const raycaster = new THREE.Raycaster();
+  raycaster.setFromCamera(ndc, camera);
+
+  const terrainDelta = (distance: number): number => {
+    const point = raycaster.ray.at(distance, new THREE.Vector3());
+    return point.y - sampleTerrainHeight(point.x, point.z);
+  };
+
+  let previousDistance = camera.near;
+  let previousDelta = terrainDelta(previousDistance);
+
+  if (previousDelta <= 0) {
+    const point = raycaster.ray.at(previousDistance, new THREE.Vector3());
+    return [point.x, point.z];
+  }
+
+  const maxDistance = Math.min(camera.far, 420);
+  const stepCount = 240;
+
+  for (let step = 1; step <= stepCount; step += 1) {
+    const distance = (maxDistance * step) / stepCount;
+    const delta = terrainDelta(distance);
+
+    if (delta <= 0) {
+      let low = previousDistance;
+      let high = distance;
+
+      for (let iteration = 0; iteration < 10; iteration += 1) {
+        const middle = (low + high) * 0.5;
+        if (terrainDelta(middle) > 0) {
+          low = middle;
+        } else {
+          high = middle;
+        }
+      }
+
+      const hitPoint = raycaster.ray.at(high, new THREE.Vector3());
+      return [hitPoint.x, hitPoint.z];
+    }
+
+    previousDistance = distance;
+    previousDelta = delta;
+  }
+
+  if (previousDelta > 0) {
+    return null;
+  }
+
+  const hitPoint = raycaster.ray.at(previousDistance, new THREE.Vector3());
+  return [hitPoint.x, hitPoint.z];
+}
+
+export function resolvePointerTarget(
+  entities: NetworkEntitySnapshot[],
+  worldPoint: Vec2Tuple,
+  extraRadius = 0.9
+): NetworkEntitySnapshot | null {
+  let selected: { entity: NetworkEntitySnapshot; distance: number } | null = null;
+
+  for (const entity of entities) {
+    const dx = entity.position[0] - worldPoint[0];
+    const dy = entity.position[1] - worldPoint[1];
+    const distance = Math.hypot(dx, dy);
+    const footprint = entity.metadata.actorPresentation?.footprintRadius ?? 1.1;
+    const threshold = footprint + extraRadius;
+
+    if (distance > threshold) {
+      continue;
+    }
+
+    if (!selected || distance < selected.distance) {
+      selected = { entity, distance };
+    }
+  }
+
+  return selected?.entity ?? null;
+}

--- a/apps/pod-web/src/frame-plan.test.ts
+++ b/apps/pod-web/src/frame-plan.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
 import type { ThreeJsWebGpuFrame } from "./contracts";
-import { buildCameraPose, buildFramePlan, splitSpriteBatchesByTint } from "./frame-plan";
+import {
+  buildCameraPose,
+  buildFramePlan,
+  sampleAnimatedInstanceTransform,
+  splitSpriteBatchesByTint
+} from "./frame-plan";
 import { sampleTerrainHeight } from "./landscape";
 import { resolveQualityProfile } from "./quality";
 
@@ -487,6 +492,73 @@ describe("buildFramePlan", () => {
     ]);
     expect(plan.prewarmSpriteRequests).toHaveLength(1);
     expect(plan.prewarmSpriteRequests[0]?.batch.texture).toBe("mist");
+  });
+});
+
+describe("sampleAnimatedInstanceTransform", () => {
+  test("keeps static props grounded while animating hovering companions", () => {
+    const staticProp = sampleAnimatedInstanceTransform(
+      {
+        position: [12, 4, -6],
+        rotation: [0, 0, 0, 1],
+        scale: [2, 3, 2],
+        sourceEntity: 44,
+        animationSetId: "static-prop",
+        motionSpeed: 0
+      },
+      2.4
+    );
+    const hoveringCompanion = sampleAnimatedInstanceTransform(
+      {
+        position: [12, 4, -6],
+        rotation: [0, 0, 0, 1],
+        scale: [1, 1.2, 1],
+        sourceEntity: 9,
+        animationSetId: "companion-hover",
+        motionSpeed: 0.2
+      },
+      2.4
+    );
+
+    expect(staticProp.position).toEqual([12, 4, -6]);
+    expect(hoveringCompanion.position[1]).toBeGreaterThan(4.12);
+    expect(hoveringCompanion.scale[1]).not.toBeCloseTo(1.2, 4);
+  });
+
+  test("adds gait bounce and event pulse response to moving humanoids", () => {
+    const neutral = sampleAnimatedInstanceTransform(
+      {
+        position: [0, 2, 0],
+        rotation: [0, 0, 0, 1],
+        scale: [1, 2, 1],
+        sourceEntity: 3,
+        animationSetId: "hero-runescape",
+        motionSpeed: 0.9,
+        controlled: true,
+        healthRatio: 0.82
+      },
+      1.8,
+      0
+    );
+    const pulsed = sampleAnimatedInstanceTransform(
+      {
+        position: [0, 2, 0],
+        rotation: [0, 0, 0, 1],
+        scale: [1, 2, 1],
+        sourceEntity: 3,
+        animationSetId: "hero-runescape",
+        motionSpeed: 0.9,
+        controlled: true,
+        healthRatio: 0.82
+      },
+      1.8,
+      1
+    );
+
+    expect(neutral.position[1]).toBeGreaterThan(2);
+    expect(neutral.scale[1]).toBeLessThan(2);
+    expect(pulsed.position[1]).toBeGreaterThan(neutral.position[1]);
+    expect(pulsed.scale[0]).toBeGreaterThan(neutral.scale[0]);
   });
 });
 

--- a/apps/pod-web/src/frame-plan.test.ts
+++ b/apps/pod-web/src/frame-plan.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import type { ThreeJsWebGpuFrame } from "./contracts";
 import { buildCameraPose, buildFramePlan, splitSpriteBatchesByTint } from "./frame-plan";
+import { sampleTerrainHeight } from "./landscape";
 import { resolveQualityProfile } from "./quality";
 
 function testEnvironment(): ThreeJsWebGpuFrame["environment"] {
@@ -31,16 +32,38 @@ describe("buildCameraPose", () => {
     const pose = buildCameraPose({
       x: 24,
       y: -10,
-      zoom: 2,
+      zoom: 1.1,
       rotation: Math.PI / 2,
+      pitch: 0.34,
+      followDistance: 13.5,
+      focusHeight: 2.2,
+      shoulderOffset: 0.9,
       viewportWidth: 1280,
       viewportHeight: 720
     });
 
-    expect(pose.target).toEqual([24, 0, -10]);
+    expect(pose.target).toEqual([24, sampleTerrainHeight(24, -10) + 2.2, -10]);
     expect(pose.position[0]).toBeGreaterThan(24);
-    expect(pose.position[2]).toBeCloseTo(-10, 5);
-    expect(pose.position[1]).toBeGreaterThan(0);
+    expect(Math.abs(pose.position[2] + 10)).toBeLessThan(1.2);
+    expect(pose.position[1]).toBeGreaterThan(pose.target[1]);
+  });
+
+  test("pulls the camera in front of terrain occlusion instead of burying it in cliffs", () => {
+    const pose = buildCameraPose({
+      x: 18,
+      y: -14,
+      zoom: 0.76,
+      rotation: 0.12,
+      pitch: 0.42,
+      followDistance: 17,
+      focusHeight: 2.2,
+      shoulderOffset: 0.9,
+      viewportWidth: 1280,
+      viewportHeight: 720
+    });
+
+    const clearance = sampleTerrainHeight(pose.position[0], pose.position[2]) + 1.45;
+    expect(pose.position[1]).toBeGreaterThanOrEqual(clearance - 0.01);
   });
 });
 
@@ -273,8 +296,8 @@ describe("buildFramePlan", () => {
     expect(plan.meshBatches[0]?.visibleCount).toBe(1);
     expect(plan.meshBatches[0]?.batch.castShadows).toBe(true);
     expect(plan.meshBatches[1]?.visibleCount).toBe(1);
-    expect(plan.meshBatches[1]?.batch.castShadows).toBe(false);
     expect(plan.meshBatches[2]?.visibleCount).toBe(1);
+    expect(plan.meshBatches[2]?.batch.castShadows).toBe(false);
   });
 
   test("drops instances outside the distance budget", () => {
@@ -455,12 +478,11 @@ describe("buildFramePlan", () => {
     expect(plan.preloadedWorldChunks).toHaveLength(9);
     expect(plan.meshBatches).toHaveLength(1);
     expect(plan.spriteBatches).toHaveLength(0);
-    expect(plan.prewarmMeshRequests).toHaveLength(3);
+    expect(plan.prewarmMeshRequests).toHaveLength(2);
     expect(
       plan.prewarmMeshRequests.map((request) => [request.batch.mesh, request.lodLevel])
     ).toEqual([
       ["canopy-tree", 0],
-      ["canopy-tree", 1],
       ["tower", 0]
     ]);
     expect(plan.prewarmSpriteRequests).toHaveLength(1);

--- a/apps/pod-web/src/frame-plan.ts
+++ b/apps/pod-web/src/frame-plan.ts
@@ -8,6 +8,7 @@ import type {
   ThreeJsSpriteBatch,
   ThreeJsWebGpuFrame
 } from "./contracts";
+import { sampleTerrainHeight } from "./landscape";
 import type { PodThreeQualityProfile } from "./quality";
 
 const DEFAULT_UP = new Vector3(0, 1, 0);
@@ -89,20 +90,27 @@ export function buildCameraPose(
   camera: CameraState,
   options: PodThreeCameraRigOptions = {}
 ): PlannedCameraPose {
-  const pitch = options.pitch ?? 0.42;
-  const baseDistance = options.baseDistance ?? 28;
-  const minDistance = options.minDistance ?? 18;
-  const maxDistance = options.maxDistance ?? 48;
-  const distance = clamp(baseDistance / Math.max(camera.zoom, 0.15), minDistance, maxDistance);
-  const heightOffset = options.height ?? 3.5;
-  const target = new Vector3(camera.x, 0, camera.y);
+  const pitch = camera.pitch ?? options.pitch ?? 0.34;
+  const followDistance = camera.followDistance ?? options.baseDistance ?? 13.5;
+  const minDistance = options.minDistance ?? 9.5;
+  const maxDistance = options.maxDistance ?? 26;
+  const distance = clamp(followDistance / Math.max(camera.zoom, 0.15), minDistance, maxDistance);
+  const focusHeight = camera.focusHeight ?? options.height ?? 2.2;
+  const terrainHeight = sampleTerrainHeight(camera.x, camera.y);
+  const leadX = camera.leadX ?? 0;
+  const leadY = camera.leadY ?? 0;
+  const target = new Vector3(camera.x + leadX, terrainHeight + focusHeight, camera.y + leadY);
   const azimuth = camera.rotation;
   const horizontalDistance = Math.cos(pitch) * distance;
-  const position = new Vector3(
-    target.x + Math.sin(azimuth) * horizontalDistance,
-    target.y + Math.sin(pitch) * distance + heightOffset,
-    target.z + Math.cos(azimuth) * horizontalDistance
+  const shoulderOffset = camera.shoulderOffset ?? 0.9;
+  const rightX = Math.cos(azimuth);
+  const rightZ = -Math.sin(azimuth);
+  const desiredPosition = new Vector3(
+    target.x + Math.sin(azimuth) * horizontalDistance + rightX * shoulderOffset,
+    target.y + Math.sin(pitch) * distance,
+    target.z + Math.cos(azimuth) * horizontalDistance + rightZ * shoulderOffset
   );
+  const position = resolveCameraCollision(target, desiredPosition);
   const quaternion = new Quaternion().setFromRotationMatrix(
     new Matrix4().lookAt(position, target, DEFAULT_UP)
   );
@@ -115,6 +123,31 @@ export function buildCameraPose(
     near: options.near ?? 0.1,
     far: options.far ?? 1024
   };
+}
+
+function resolveCameraCollision(target: Vector3, desiredPosition: Vector3): Vector3 {
+  const safePosition = desiredPosition.clone();
+  const cameraClearance = 1.45;
+  const sweepSteps = 18;
+  let obstructionT = 1;
+
+  for (let step = 1; step <= sweepSteps; step += 1) {
+    const t = step / sweepSteps;
+    const sample = target.clone().lerp(desiredPosition, t);
+    const terrainHeight = sampleTerrainHeight(sample.x, sample.z) + cameraClearance;
+    if (sample.y < terrainHeight) {
+      obstructionT = Math.max(0.12, (step - 1) / sweepSteps);
+      break;
+    }
+  }
+
+  safePosition.lerpVectors(target, desiredPosition, obstructionT);
+  safePosition.y = Math.max(
+    safePosition.y,
+    sampleTerrainHeight(safePosition.x, safePosition.z) + cameraClearance
+  );
+
+  return safePosition;
 }
 
 export function buildFramePlan(

--- a/apps/pod-web/src/frame-plan.ts
+++ b/apps/pod-web/src/frame-plan.ts
@@ -1,4 +1,4 @@
-import { Frustum, Matrix4, PerspectiveCamera, Quaternion, Sphere, Vector3 } from "three";
+import { Euler, Frustum, Matrix4, PerspectiveCamera, Quaternion, Sphere, Vector3 } from "three";
 
 import type {
   CameraState,
@@ -51,6 +51,7 @@ export interface PlannedMeshBatch {
   batch: ThreeJsMeshBatch;
   lodLevel: 0 | 1 | 2;
   visibleCount: number;
+  instances: ThreeJsInstance[];
   matrices: Matrix4[];
 }
 
@@ -313,13 +314,109 @@ export function composeInstanceMatrix(
   instance: ThreeJsInstance,
   rotationOverride?: Quaternion
 ): Matrix4 {
+  return composeAnimatedInstanceMatrix(instance, 0, 0, rotationOverride);
+}
+
+export function composeAnimatedInstanceMatrix(
+  instance: ThreeJsInstance,
+  elapsedSeconds: number,
+  pulse = 0,
+  rotationOverride?: Quaternion
+): Matrix4 {
+  const transform = sampleAnimatedInstanceTransform(instance, elapsedSeconds, pulse);
   const matrix = new Matrix4();
   matrix.compose(
-    new Vector3(...instance.position),
-    rotationOverride ?? new Quaternion(...instance.rotation),
-    new Vector3(...instance.scale)
+    new Vector3(...transform.position),
+    rotationOverride ?? new Quaternion(...transform.rotation),
+    new Vector3(...transform.scale)
   );
   return matrix;
+}
+
+export function sampleAnimatedInstanceTransform(
+  instance: ThreeJsInstance,
+  elapsedSeconds: number,
+  pulse = 0
+): Pick<ThreeJsInstance, "position" | "rotation" | "scale"> {
+  const animationSetId = instance.animationSetId?.toLowerCase() ?? "static-prop";
+  const motion = clamp(instance.motionSpeed ?? 0, 0, 1.6);
+  const health = instance.healthRatio ?? 1;
+  const phaseSeed = instance.sourceEntity ?? 0;
+  const phase = phaseSeed * 0.41887902047863906;
+  const idleWave = Math.sin(elapsedSeconds * 1.4 + phase);
+  const strideWave = Math.sin(elapsedSeconds * (2.8 + motion * 5.4) + phase);
+  const hoverWave = Math.sin(elapsedSeconds * 2.35 + phase);
+  const pulseAmount = clamp(pulse, 0, 1);
+
+  let yOffset = 0;
+  let scaleX = instance.scale[0];
+  let scaleY = instance.scale[1];
+  let scaleZ = instance.scale[2];
+  let pitchOffset = 0;
+  let rollOffset = 0;
+
+  if (animationSetId.includes("ring")) {
+    const ringPulse = Math.sin(elapsedSeconds * 2.2 + phase);
+    const ringScale = 1 + ringPulse * 0.045;
+    scaleX *= ringScale;
+    scaleY *= ringScale;
+  } else if (animationSetId.includes("companion") || animationSetId.includes("hover")) {
+    yOffset += 0.18 + hoverWave * 0.14;
+    scaleX *= 1 + hoverWave * 0.025;
+    scaleY *= 1 - hoverWave * 0.05;
+    scaleZ *= 1 + hoverWave * 0.025;
+    rollOffset += hoverWave * 0.045;
+  } else if (animationSetId.includes("beast")) {
+    const stomp = Math.abs(strideWave) * Math.max(0.2, motion);
+    yOffset += idleWave * 0.04 + stomp * 0.16;
+    scaleX *= 1 + stomp * 0.035;
+    scaleY *= 1 - stomp * 0.06;
+    scaleZ *= 1 + stomp * 0.035;
+    pitchOffset += strideWave * 0.04 * Math.max(motion, 0.25);
+  } else if (!animationSetId.includes("static")) {
+    const gait = Math.abs(strideWave) * Math.max(0.18, motion);
+    yOffset += idleWave * 0.03 + gait * 0.12;
+    scaleX *= 1 + gait * 0.018;
+    scaleY *= 1 - gait * 0.04;
+    scaleZ *= 1 + gait * 0.018;
+    pitchOffset += strideWave * 0.028 * Math.max(motion, 0.2);
+    rollOffset += Math.sin(elapsedSeconds * 1.8 + phase) * 0.012;
+  }
+
+  if (health < 0.35) {
+    const stress = (0.35 - health) / 0.35;
+    yOffset += Math.sin(elapsedSeconds * 8.4 + phase * 2) * 0.025 * stress;
+    rollOffset += Math.cos(elapsedSeconds * 9.8 + phase) * 0.018 * stress;
+  }
+
+  if (instance.controlled) {
+    yOffset += Math.abs(strideWave) * motion * 0.03;
+  }
+
+  if (pulseAmount > 0.001) {
+    const easedPulse = 1 - (1 - pulseAmount) * (1 - pulseAmount);
+    yOffset += easedPulse * 0.22;
+    scaleX *= 1 + easedPulse * 0.12;
+    scaleY *= 1 - easedPulse * 0.08;
+    scaleZ *= 1 + easedPulse * 0.12;
+    pitchOffset += easedPulse * 0.05;
+  }
+
+  const baseRotation = new Quaternion(...instance.rotation);
+  const animationRotation = new Quaternion().setFromEuler(
+    new Euler(pitchOffset, 0, rollOffset)
+  );
+  const finalRotation = baseRotation.multiply(animationRotation);
+
+  return {
+    position: [
+      instance.position[0],
+      instance.position[1] + yOffset,
+      instance.position[2]
+    ],
+    rotation: [finalRotation.x, finalRotation.y, finalRotation.z, finalRotation.w],
+    scale: [scaleX, scaleY, scaleZ]
+  };
 }
 
 function createMeshBatchKey(batch: ThreeJsMeshBatch, lodLevel?: number): string {
@@ -429,6 +526,7 @@ function planMeshBatches(
         },
         lodLevel,
         visibleCount: group.instances.length,
+        instances: group.instances,
         matrices: group.matrices
       });
     }

--- a/apps/pod-web/src/landscape.ts
+++ b/apps/pod-web/src/landscape.ts
@@ -1,0 +1,232 @@
+export type LandscapeVec2Tuple = [number, number];
+export type LandscapeVec3Tuple = [number, number, number];
+export type LandscapeVec4Tuple = [number, number, number, number];
+
+export interface LandscapeEnvironment {
+  biomeId: string;
+  skyColor: LandscapeVec4Tuple;
+  fogColor: LandscapeVec4Tuple;
+  fogNear: number;
+  fogFar: number;
+  ambientColor: LandscapeVec3Tuple;
+  ambientIntensity: number;
+  sunColor: LandscapeVec3Tuple;
+  sunIntensity: number;
+  sunDirection: LandscapeVec3Tuple;
+  fillColor: LandscapeVec3Tuple;
+  fillIntensity: number;
+  fillDirection: LandscapeVec3Tuple;
+  rimColor: LandscapeVec3Tuple;
+  rimIntensity: number;
+  groundColor: LandscapeVec4Tuple;
+  starfieldIntensity: number;
+}
+
+export interface TimeLapseEnvironmentState {
+  cycleT: number;
+  timeOfDayHours: number;
+  environment: LandscapeEnvironment;
+}
+
+export const LANDSCAPE_PROFILE_ID = "cliff-lagoon-heightfield";
+export const WATER_PROFILE_ID = "animated-lagoon";
+export const LANDSCAPE_WORLD_SIZE = 260;
+export const WATER_LEVEL = -2.35;
+export const WATER_CENTER: LandscapeVec2Tuple = [18, -14];
+export const WATER_RADII: LandscapeVec2Tuple = [22, 16];
+export const DAY_CYCLE_DURATION_SECONDS = 180;
+
+export function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+export function mixScalar(left: number, right: number, weight: number): number {
+  return left + (right - left) * weight;
+}
+
+export function mixVec3(
+  left: LandscapeVec3Tuple,
+  right: LandscapeVec3Tuple,
+  weight: number
+): LandscapeVec3Tuple {
+  return [
+    mixScalar(left[0], right[0], weight),
+    mixScalar(left[1], right[1], weight),
+    mixScalar(left[2], right[2], weight)
+  ];
+}
+
+export function smoothstep(edge0: number, edge1: number, value: number): number {
+  if (Math.abs(edge1 - edge0) <= Number.EPSILON) {
+    return value < edge0 ? 0 : 1;
+  }
+
+  const t = clamp((value - edge0) / (edge1 - edge0), 0, 1);
+  return t * t * (3 - 2 * t);
+}
+
+function hashNoise(x: number, y: number): number {
+  const sine = Math.sin(x * 127.1 + y * 311.7) * 43758.5453123;
+  return sine - Math.floor(sine);
+}
+
+function valueNoise(x: number, y: number): number {
+  const x0 = Math.floor(x);
+  const y0 = Math.floor(y);
+  const x1 = x0 + 1;
+  const y1 = y0 + 1;
+  const sx = x - x0;
+  const sy = y - y0;
+
+  const n00 = hashNoise(x0, y0);
+  const n10 = hashNoise(x1, y0);
+  const n01 = hashNoise(x0, y1);
+  const n11 = hashNoise(x1, y1);
+  const ix0 = mixScalar(n00, n10, smoothstep(0, 1, sx));
+  const ix1 = mixScalar(n01, n11, smoothstep(0, 1, sx));
+  return mixScalar(ix0, ix1, smoothstep(0, 1, sy));
+}
+
+export function fractalNoise(x: number, y: number): number {
+  let amplitude = 0.5;
+  let frequency = 0.08;
+  let value = 0;
+
+  for (let octave = 0; octave < 5; octave += 1) {
+    value += valueNoise(x * frequency, y * frequency) * amplitude;
+    amplitude *= 0.5;
+    frequency *= 2;
+  }
+
+  return value;
+}
+
+export function sampleLakeMask(x: number, z: number): number {
+  const dx = (x - WATER_CENTER[0]) / WATER_RADII[0];
+  const dz = (z - WATER_CENTER[1]) / WATER_RADII[1];
+  const radial = clamp(1 - Math.hypot(dx, dz), 0, 1);
+  return smoothstep(0, 1, radial);
+}
+
+export function sampleTerrainHeight(x: number, z: number): number {
+  const distance = Math.hypot(x, z);
+  const macroMountains = (fractalNoise(x * 0.01, z * 0.01) - 0.5) * 20;
+  const rollingHills = (fractalNoise(x * 0.028 + 11, z * 0.028 - 17) - 0.5) * 7;
+  const centralPlateau = 6.8 * Math.exp(-(distance * distance) / (2 * 34 * 34));
+  const outerWall = smoothstep(52, 136, distance) * 22;
+  const cliffBands =
+    Math.pow(Math.abs(valueNoise(x * 0.018 - 9, z * 0.018 + 23) - 0.5) * 2, 1.7) *
+    smoothstep(64, 112, distance) *
+    11;
+  const riverValley =
+    -3.4 *
+    Math.exp(-((x + 10) * (x + 10)) / (2 * 58 * 58) - ((z - 4) * (z - 4)) / (2 * 14 * 14));
+  const lakeMask = sampleLakeMask(x, z);
+  const lakeBasin = -8.2 * lakeMask;
+  const shorelineShelf =
+    -2 * smoothstep(0.08, 0.7, lakeMask) * (1 - smoothstep(0.7, 1, lakeMask));
+
+  return (
+    macroMountains +
+    rollingHills +
+    centralPlateau +
+    outerWall +
+    cliffBands +
+    riverValley +
+    lakeBasin +
+    shorelineShelf -
+    5
+  );
+}
+
+export function sampleTerrainSlope(x: number, z: number): number {
+  const step = 1.2;
+  const height = sampleTerrainHeight(x, z);
+  const dx = sampleTerrainHeight(x + step, z) - height;
+  const dz = sampleTerrainHeight(x, z + step) - height;
+  return Math.hypot(dx, dz) / step;
+}
+
+export function sampleTerrainPoint(
+  x: number,
+  z: number,
+  clearance = 0
+): LandscapeVec3Tuple {
+  return [x, sampleTerrainHeight(x, z) + clearance, z];
+}
+
+export function describeEnvironmentPreset(
+  environment: LandscapeEnvironment
+): "daylight" | "twilight" | "night" {
+  const brightness =
+    environment.skyColor[0] * 0.35 +
+    environment.skyColor[1] * 0.45 +
+    environment.skyColor[2] * 0.2;
+  if (brightness >= 0.55 && environment.starfieldIntensity <= 0.18) {
+    return "daylight";
+  }
+  if (brightness >= 0.26) {
+    return "twilight";
+  }
+  return "night";
+}
+
+export function sampleTimeLapseEnvironment(
+  baseEnvironment: LandscapeEnvironment,
+  elapsedSeconds: number
+): TimeLapseEnvironmentState {
+  const cycleT =
+    ((elapsedSeconds / DAY_CYCLE_DURATION_SECONDS) % 1 + 1) % 1;
+  const timeOfDayHours = cycleT * 24;
+  const sunHeight = Math.sin(cycleT * Math.PI * 2 - Math.PI / 2);
+  const daylight = smoothstep(-0.1, 0.22, sunHeight);
+  const twilight = 1 - Math.abs(clamp(sunHeight / 0.42, -1, 1));
+
+  const nightSky: LandscapeVec3Tuple = [0.06, 0.09, 0.16];
+  const dawnSky: LandscapeVec3Tuple = [0.8, 0.54, 0.4];
+  const nightFog: LandscapeVec3Tuple = [0.1, 0.13, 0.18];
+  const dawnFog: LandscapeVec3Tuple = [0.77, 0.57, 0.46];
+  const nightGround: LandscapeVec3Tuple = [0.08, 0.12, 0.11];
+  const nightSun: LandscapeVec3Tuple = [0.54, 0.62, 0.92];
+
+  const daySky = baseEnvironment.skyColor.slice(0, 3) as LandscapeVec3Tuple;
+  const dayFog = baseEnvironment.fogColor.slice(0, 3) as LandscapeVec3Tuple;
+  const dayGround = baseEnvironment.groundColor.slice(0, 3) as LandscapeVec3Tuple;
+
+  const skyFromNight = mixVec3(nightSky, dawnSky, twilight);
+  const fogFromNight = mixVec3(nightFog, dawnFog, twilight);
+  const dynamicSky = mixVec3(skyFromNight, daySky, daylight);
+  const dynamicFog = mixVec3(fogFromNight, dayFog, daylight);
+  const dynamicGround = mixVec3(nightGround, dayGround, daylight * 0.9 + twilight * 0.1);
+  const dynamicSun = mixVec3(nightSun, baseEnvironment.sunColor, daylight * 0.92 + twilight * 0.08);
+
+  const azimuth = cycleT * Math.PI * 2 - Math.PI * 0.15;
+  const sunDirection: LandscapeVec3Tuple = [
+    Math.cos(azimuth) * 58,
+    mixScalar(-8, 56, clamp((sunHeight + 1) * 0.5, 0, 1)),
+    Math.sin(azimuth) * 42
+  ];
+  const fillDirection: LandscapeVec3Tuple = [-sunDirection[0] * 0.45, 18, -sunDirection[2] * 0.45];
+
+  return {
+    cycleT,
+    timeOfDayHours,
+    environment: {
+      ...baseEnvironment,
+      skyColor: [...dynamicSky, 1],
+      fogColor: [...dynamicFog, 1],
+      ambientColor: mixVec3([0.12, 0.14, 0.19], baseEnvironment.ambientColor, daylight),
+      ambientIntensity: mixScalar(0.2, baseEnvironment.ambientIntensity, daylight),
+      sunColor: dynamicSun,
+      sunIntensity: mixScalar(0.18, baseEnvironment.sunIntensity, daylight * 0.95 + twilight * 0.18),
+      sunDirection,
+      fillColor: mixVec3([0.16, 0.22, 0.4], baseEnvironment.fillColor, daylight * 0.85 + twilight * 0.2),
+      fillIntensity: mixScalar(0.18, baseEnvironment.fillIntensity, daylight * 0.9 + twilight * 0.28),
+      fillDirection,
+      rimColor: mixVec3([0.22, 0.48, 0.68], baseEnvironment.rimColor, daylight * 0.85 + twilight * 0.12),
+      rimIntensity: mixScalar(1.6, baseEnvironment.rimIntensity, daylight * 0.92 + twilight * 0.18),
+      groundColor: [...dynamicGround, 1],
+      starfieldIntensity: mixScalar(0.72, baseEnvironment.starfieldIntensity, daylight)
+    }
+  };
+}

--- a/apps/pod-web/src/landscape.ts
+++ b/apps/pod-web/src/landscape.ts
@@ -113,11 +113,19 @@ export function sampleTerrainHeight(x: number, z: number): number {
   const macroMountains = (fractalNoise(x * 0.01, z * 0.01) - 0.5) * 20;
   const rollingHills = (fractalNoise(x * 0.028 + 11, z * 0.028 - 17) - 0.5) * 7;
   const centralPlateau = 6.8 * Math.exp(-(distance * distance) / (2 * 34 * 34));
-  const outerWall = smoothstep(52, 136, distance) * 22;
+  const hubTerraceBlend = 1 - smoothstep(0, 22, distance);
+  const hubTerraceHeight = mixScalar(macroMountains + rollingHills + centralPlateau - 5, 3.8, hubTerraceBlend);
+  const outerWall = smoothstep(52, 136, distance) * 24;
   const cliffBands =
     Math.pow(Math.abs(valueNoise(x * 0.018 - 9, z * 0.018 + 23) - 0.5) * 2, 1.7) *
     smoothstep(64, 112, distance) *
     11;
+  const northRidge =
+    18 *
+    Math.exp(-((x - 18) * (x - 18)) / (2 * 52 * 52) - ((z + 82) * (z + 82)) / (2 * 18 * 18));
+  const westernBluffs =
+    14 *
+    Math.exp(-((x + 74) * (x + 74)) / (2 * 16 * 16) - ((z - 8) * (z - 8)) / (2 * 56 * 56));
   const riverValley =
     -3.4 *
     Math.exp(-((x + 10) * (x + 10)) / (2 * 58 * 58) - ((z - 4) * (z - 4)) / (2 * 14 * 14));
@@ -132,10 +140,13 @@ export function sampleTerrainHeight(x: number, z: number): number {
     centralPlateau +
     outerWall +
     cliffBands +
+    northRidge +
+    westernBluffs +
     riverValley +
     lakeBasin +
     shorelineShelf -
-    5
+    5 +
+    (hubTerraceHeight - (macroMountains + rollingHills + centralPlateau - 5))
   );
 }
 

--- a/apps/pod-web/src/local-world.test.ts
+++ b/apps/pod-web/src/local-world.test.ts
@@ -76,7 +76,7 @@ describe("PodWebLocalWorld", () => {
 
     const snapshot = world.snapshotState();
     const player = snapshot.entities.find((entity) => entity.id === 1);
-    expect(player?.position[0]).toBeGreaterThan(4);
+    expect(player?.position[0]).toBeGreaterThan(3.5);
 
     const textState = renderGameToText(
       snapshot,

--- a/apps/pod-web/src/local-world.ts
+++ b/apps/pod-web/src/local-world.ts
@@ -1019,9 +1019,29 @@ export class PodWebLocalWorld {
   private integrateMovement(): void {
     for (const entity of this.state.entities) {
       const desired = entity.desiredMove;
-      if (desired) {
-        entity.velocity = [desired[0] * entity.movementSpeed, desired[1] * entity.movementSpeed];
-      } else {
+      const targetVelocity: Vec2Tuple = desired
+        ? [desired[0] * entity.movementSpeed, desired[1] * entity.movementSpeed]
+        : [0, 0];
+      const acceleration =
+        entity.role === "player"
+          ? entity.movementSpeed * 0.18
+          : entity.movementSpeed * 0.14;
+      const deceleration =
+        entity.role === "player"
+          ? entity.movementSpeed * 0.24
+          : entity.movementSpeed * 0.18;
+      const velocityStep =
+        desired != null
+          ? Math.max(0.08, acceleration)
+          : Math.max(0.08, deceleration);
+
+      entity.velocity = [
+        moveScalarToward(entity.velocity[0], targetVelocity[0], velocityStep),
+        moveScalarToward(entity.velocity[1], targetVelocity[1], velocityStep)
+      ];
+
+      const speed = Math.hypot(entity.velocity[0], entity.velocity[1]);
+      if (speed < 0.02) {
         entity.velocity = [0, 0];
       }
 
@@ -1030,8 +1050,12 @@ export class PodWebLocalWorld {
         clamp(entity.position[1] + entity.velocity[1] / 60, -WORLD_LIMIT, WORLD_LIMIT)
       ];
 
-      if (entity.velocity[0] !== 0 || entity.velocity[1] !== 0) {
-        entity.rotation = Math.atan2(entity.velocity[0], entity.velocity[1]);
+      if (speed > 0) {
+        entity.rotation = rotateTowardAngle(
+          entity.rotation,
+          Math.atan2(entity.velocity[0], entity.velocity[1]),
+          0.24
+        );
       }
     }
   }
@@ -2208,22 +2232,22 @@ function metadata(
 function verdantAtmosphereProfile(): NetworkAtmosphereProfile {
   return {
     biomeId: "verdant-hollow",
-    skyColor: [0.05, 0.08, 0.12, 1],
-    fogColor: [0.06, 0.12, 0.1, 1],
-    fogNear: 22,
-    fogFar: 148,
-    ambientColor: [0.7, 0.88, 0.84],
-    ambientIntensity: 1.28,
-    sunColor: [1, 0.95, 0.82],
-    sunIntensity: 2.7,
-    sunDirection: [20, 38, 12],
-    fillColor: [0.42, 0.78, 0.92],
-    fillIntensity: 0.78,
-    fillDirection: [-16, 11, -8],
-    rimColor: [0.34, 0.9, 0.82],
-    rimIntensity: 11,
-    groundColor: [0.08, 0.16, 0.12, 1],
-    starfieldIntensity: 0.72
+    skyColor: [0.64, 0.8, 0.98, 1],
+    fogColor: [0.72, 0.84, 0.78, 1],
+    fogNear: 30,
+    fogFar: 196,
+    ambientColor: [0.82, 0.92, 0.88],
+    ambientIntensity: 1.4,
+    sunColor: [1, 0.96, 0.84],
+    sunIntensity: 2.95,
+    sunDirection: [30, 48, 18],
+    fillColor: [0.48, 0.76, 0.94],
+    fillIntensity: 0.88,
+    fillDirection: [-18, 14, -10],
+    rimColor: [0.4, 0.88, 0.78],
+    rimIntensity: 8.5,
+    groundColor: [0.19, 0.33, 0.21, 1],
+    starfieldIntensity: 0.08
   };
 }
 
@@ -2758,6 +2782,24 @@ function normalize(vector: Vec2Tuple): Vec2Tuple | null {
 
 function clamp(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, value));
+}
+
+function moveScalarToward(current: number, target: number, maxDelta: number): number {
+  if (current < target) {
+    return Math.min(current + maxDelta, target);
+  }
+  return Math.max(current - maxDelta, target);
+}
+
+function rotateTowardAngle(current: number, target: number, factor: number): number {
+  let delta = target - current;
+  while (delta > Math.PI) {
+    delta -= Math.PI * 2;
+  }
+  while (delta < -Math.PI) {
+    delta += Math.PI * 2;
+  }
+  return current + delta * factor;
 }
 
 function angleBetween(origin: Vec2Tuple, target: Vec2Tuple): number {

--- a/apps/pod-web/src/main.ts
+++ b/apps/pod-web/src/main.ts
@@ -1,6 +1,7 @@
 import {
   type BrowserAction,
   buildAuthoritativeWorldFrame,
+  type CameraState,
   type NetworkEventBatch,
   type NetworkGameEvent,
   type NetworkEntitySnapshot,
@@ -14,6 +15,7 @@ import {
   summarizeAgentTickRollup,
   summarizeAgentToolCallEvent,
   summarizeReplayFile,
+  type ThreeJsWebGpuFrame,
   type TickRollupSummary,
   type ToolCallEventSummary,
   type ReplaySummary,
@@ -23,6 +25,11 @@ import {
   describeTargetAffordances,
   formatTargetSummary
 } from "./affordances";
+import {
+  cameraRelativeMovementDirection,
+  pickWorldGroundPoint,
+  resolvePointerTarget
+} from "./controls";
 import {
   PodWebDirectConnectClient,
   type DirectConnectActionState,
@@ -207,7 +214,7 @@ let latestActionStatus: DirectConnectActionState = {
 };
 let latestFeedback = runtimeConfig
   ? "Awaiting authoritative outcomes"
-  : "Local sandbox ready: WASD move, Tab target, then test combat, gather, loot, capture, summon, and chat";
+  : "Local sandbox ready: click terrain to move, right-drag the camera, wheel to zoom, WASD steer, Tab target, and double-click targets for default actions";
 let recentWorldEvents: NetworkGameEvent[] = [];
 let manualFrameOverride = false;
 let liveConnectionStatus: DirectConnectStatus | null = runtimeConfig
@@ -257,8 +264,21 @@ const liveClient = runtimeConfig
 const pressedKeys = new Set<string>();
 let selectedTargetId: number | null = null;
 let autoRetaliateEnabled = true;
+let clickMoveTarget: [number, number] | null = null;
 let lastMovementSignature = "stop";
 let lastMovementSubmitAtMs = 0;
+let orbitPointerId: number | null = null;
+let orbitPointer: [number, number] | null = null;
+
+const cameraRig = {
+  initialized: false,
+  yaw: 0,
+  desiredYaw: 0,
+  pitch: 0.34,
+  desiredPitch: 0.34,
+  zoom: 1.08,
+  desiredZoom: 1.08
+};
 
 function isEditableTarget(target: EventTarget | null): boolean {
   return (
@@ -356,6 +376,104 @@ function targetableEntities(): NetworkEntitySnapshot[] {
       }
       return left.id - right.id;
     });
+}
+
+function currentFrameCameraState() {
+  if (!latestFrame) {
+    return null;
+  }
+
+  if (typeof latestFrame === "string") {
+    if (liveFrameSource === "threejs") {
+      return renderableThreeFrame(parseThreeJsWebGpuFrame(latestFrame)).camera;
+    }
+    return parseRenderFrame(latestFrame).camera;
+  }
+
+  return liveFrameSource === "threejs"
+    ? renderableThreeFrame(latestFrame).camera
+    : latestFrame.camera;
+}
+
+function shortestAngleDelta(current: number, target: number): number {
+  let delta = target - current;
+  while (delta > Math.PI) {
+    delta -= Math.PI * 2;
+  }
+  while (delta < -Math.PI) {
+    delta += Math.PI * 2;
+  }
+  return delta;
+}
+
+function stepAngleToward(current: number, target: number, sharpness: number, deltaMs: number): number {
+  const alpha = 1 - Math.exp(-(sharpness * deltaMs) / 1000);
+  return current + shortestAngleDelta(current, target) * alpha;
+}
+
+function stepScalarToward(current: number, target: number, sharpness: number, deltaMs: number): number {
+  const alpha = 1 - Math.exp(-(sharpness * deltaMs) / 1000);
+  return current + (target - current) * alpha;
+}
+
+function syncCameraRig(camera: CameraState | null): void {
+  if (!camera) {
+    return;
+  }
+
+  if (!cameraRig.initialized) {
+    cameraRig.initialized = true;
+    cameraRig.yaw = camera.rotation;
+    cameraRig.desiredYaw = camera.rotation;
+    cameraRig.pitch = camera.pitch ?? 0.34;
+    cameraRig.desiredPitch = camera.pitch ?? 0.34;
+    cameraRig.zoom = camera.zoom;
+    cameraRig.desiredZoom = camera.zoom;
+  }
+}
+
+function updateCameraRig(deltaMs: number): void {
+  if (!cameraRig.initialized) {
+    return;
+  }
+
+  cameraRig.yaw = stepAngleToward(cameraRig.yaw, cameraRig.desiredYaw, 14, deltaMs);
+  cameraRig.pitch = stepScalarToward(cameraRig.pitch, cameraRig.desiredPitch, 16, deltaMs);
+  cameraRig.zoom = stepScalarToward(cameraRig.zoom, cameraRig.desiredZoom, 12, deltaMs);
+}
+
+function currentCameraYaw(): number {
+  return cameraRig.initialized
+    ? cameraRig.yaw
+    : currentFrameCameraState()?.rotation ?? 0;
+}
+
+function renderableThreeFrame(baseFrame: ThreeJsWebGpuFrame): ThreeJsWebGpuFrame {
+  syncCameraRig(baseFrame.camera);
+  const controlled = controlledEntity();
+  const speed = controlled
+    ? Math.hypot(controlled.velocity[0], controlled.velocity[1])
+    : 0;
+  const leadDistance = Math.min(1.4, speed * 0.16);
+  const leadX =
+    controlled && speed > 0.05 ? (controlled.velocity[0] / speed) * leadDistance : 0;
+  const leadY =
+    controlled && speed > 0.05 ? (controlled.velocity[1] / speed) * leadDistance : 0;
+
+  return {
+    ...baseFrame,
+    camera: {
+      ...baseFrame.camera,
+      rotation: cameraRig.yaw,
+      pitch: cameraRig.pitch,
+      zoom: cameraRig.zoom,
+      focusHeight: baseFrame.camera.focusHeight ?? 2.2,
+      followDistance: baseFrame.camera.followDistance ?? 13.5,
+      shoulderOffset: baseFrame.camera.shoulderOffset ?? 0.9,
+      leadX,
+      leadY
+    }
+  };
 }
 
 function selectedTarget(): NetworkEntitySnapshot | null {
@@ -472,31 +590,41 @@ function submitActions(actions: BrowserAction[]): void {
 }
 
 function movementDirection(): [number, number] | null {
-  const horizontal =
-    (pressedKeys.has("KeyD") || pressedKeys.has("ArrowRight") ? 1 : 0) -
-    (pressedKeys.has("KeyA") || pressedKeys.has("ArrowLeft") ? 1 : 0);
-  const vertical =
-    (pressedKeys.has("KeyS") || pressedKeys.has("ArrowDown") ? 1 : 0) -
-    (pressedKeys.has("KeyW") || pressedKeys.has("ArrowUp") ? 1 : 0);
-
-  if (horizontal === 0 && vertical === 0) {
-    return null;
-  }
-
-  const length = Math.hypot(horizontal, vertical);
-  return [horizontal / length, vertical / length];
+  return cameraRelativeMovementDirection(pressedKeys, currentCameraYaw());
 }
 
 function maybeSubmitMovement(timestamp: number): void {
   const direction = movementDirection();
-  const signature = direction
-    ? `${direction[0].toFixed(3)}:${direction[1].toFixed(3)}`
+  const controlled = controlledEntity();
+  const clickDirection =
+    !direction && clickMoveTarget && controlled
+      ? (() => {
+          const dx = clickMoveTarget[0] - controlled.position[0];
+          const dy = clickMoveTarget[1] - controlled.position[1];
+          const distance = Math.hypot(dx, dy);
+
+          if (distance <= 0.7) {
+            clickMoveTarget = null;
+            latestFeedback = `Arrived at ${controlled.position[0].toFixed(1)}, ${controlled.position[1].toFixed(1)}`;
+            return null;
+          }
+
+          return [dx / distance, dy / distance] as [number, number];
+        })()
+      : null;
+  const activeDirection = direction ?? clickDirection;
+  const signature = activeDirection
+    ? `${activeDirection[0].toFixed(3)}:${activeDirection[1].toFixed(3)}`
     : "stop";
   const resendDue = timestamp - lastMovementSubmitAtMs >= 90;
 
   if (direction) {
+    clickMoveTarget = null;
+  }
+
+  if (activeDirection) {
     if (signature !== lastMovementSignature || resendDue) {
-      submitActions([{ kind: "move", direction }]);
+      submitActions([{ kind: "move", direction: activeDirection }]);
       lastMovementSignature = signature;
       lastMovementSubmitAtMs = timestamp;
     }
@@ -508,6 +636,29 @@ function maybeSubmitMovement(timestamp: number): void {
     lastMovementSignature = "stop";
     lastMovementSubmitAtMs = timestamp;
   }
+}
+
+function defaultPointerAction(target: NetworkEntitySnapshot): BrowserAction | null {
+  if (target.metadata.interaction.canLoot) {
+    return { kind: "loot", target: target.id };
+  }
+  if (target.metadata.interaction.canGather) {
+    return {
+      kind: "gatherResource",
+      target: target.id,
+      skill: target.metadata.resourceSkill ?? "Mining"
+    };
+  }
+  if (target.metadata.interaction.canCapture) {
+    return { kind: "captureCreature", target: target.id };
+  }
+  if (target.metadata.interaction.canAttack) {
+    return { kind: "attackTarget", target: target.id };
+  }
+  if (target.metadata.interaction.canInteract || target.metadata.interaction.canInspect) {
+    return { kind: "interactWith", target: target.id };
+  }
+  return null;
 }
 
 function submitTargetedAction(
@@ -603,6 +754,96 @@ chatFormNode.addEventListener("submit", (event) => {
   chatInputNode.value = "";
 });
 
+renderCanvas.addEventListener("pointerdown", (event) => {
+  if (event.button === 2) {
+    orbitPointerId = event.pointerId;
+    orbitPointer = [event.clientX, event.clientY];
+    renderCanvas.setPointerCapture(event.pointerId);
+    event.preventDefault();
+    return;
+  }
+
+  if (event.button !== 0) {
+    return;
+  }
+
+  const camera = currentFrameCameraState();
+  if (!camera) {
+    return;
+  }
+
+  const rect = renderCanvas.getBoundingClientRect();
+  const worldPoint = pickWorldGroundPoint(
+    [event.clientX - rect.left, event.clientY - rect.top],
+    { width: rect.width, height: rect.height },
+    camera
+  );
+  if (!worldPoint) {
+    return;
+  }
+
+  const target = resolvePointerTarget(targetableEntities(), worldPoint);
+  if (target) {
+    selectedTargetId = target.id;
+    clickMoveTarget = null;
+    const action = event.detail >= 2 ? defaultPointerAction(target) : null;
+    latestFeedback =
+      action != null ? `Default action on ${target.label}` : `Selected ${target.label}`;
+    if (action) {
+      submitActions([action]);
+    }
+    return;
+  }
+
+  selectedTargetId = null;
+  clickMoveTarget = worldPoint;
+  lastMovementSignature = "stop";
+  latestFeedback = `Move order · ${worldPoint[0].toFixed(1)}, ${worldPoint[1].toFixed(1)}`;
+});
+
+renderCanvas.addEventListener("pointermove", (event) => {
+  if (orbitPointerId !== event.pointerId || orbitPointer == null) {
+    return;
+  }
+
+  const deltaX = event.clientX - orbitPointer[0];
+  const deltaY = event.clientY - orbitPointer[1];
+  orbitPointer = [event.clientX, event.clientY];
+  cameraRig.desiredYaw -= deltaX * 0.008;
+  cameraRig.desiredPitch = Math.max(0.18, Math.min(0.7, cameraRig.desiredPitch - deltaY * 0.0035));
+});
+
+renderCanvas.addEventListener("pointerup", (event) => {
+  if (orbitPointerId !== event.pointerId) {
+    return;
+  }
+
+  renderCanvas.releasePointerCapture(event.pointerId);
+  orbitPointerId = null;
+  orbitPointer = null;
+});
+
+renderCanvas.addEventListener("pointercancel", (event) => {
+  if (orbitPointerId !== event.pointerId) {
+    return;
+  }
+
+  orbitPointerId = null;
+  orbitPointer = null;
+});
+
+renderCanvas.addEventListener("wheel", (event) => {
+  cameraRig.desiredZoom = Math.max(
+    0.72,
+    Math.min(1.65, cameraRig.desiredZoom - event.deltaY * 0.0009)
+  );
+  event.preventDefault();
+}, { passive: false });
+
+renderCanvas.addEventListener("contextmenu", (event) => {
+  event.preventDefault();
+});
+
 telemetryToggleButton.addEventListener("click", () => {
   setTelemetryEnabled(telemetryState, !telemetryState.enabled);
   liveClient?.setDebugTelemetry(telemetryState.enabled);
@@ -660,8 +901,16 @@ window.podRender = {
     liveIncidentDocuments = 0;
     if (localSandbox) {
       localSandbox.reset();
+      cameraRig.initialized = false;
+      cameraRig.yaw = 0;
+      cameraRig.desiredYaw = 0;
+      cameraRig.pitch = 0.34;
+      cameraRig.desiredPitch = 0.34;
+      cameraRig.zoom = 1.08;
+      cameraRig.desiredZoom = 1.08;
       latestFeedback =
-        "Local sandbox ready: WASD move, Tab target, then test combat, gather, loot, capture, summon, and chat";
+        "Local sandbox ready: click terrain to move, right-drag the camera, wheel to zoom, WASD steer, Tab target, and double-click targets for default actions";
+      clickMoveTarget = null;
       refreshLocalSandboxFrame();
       renderTelemetryHud();
       return;
@@ -781,6 +1030,7 @@ let lastTickTimestamp = performance.now();
 async function tick(timestamp: number): Promise<void> {
   const deltaMs = Math.min(Math.max(timestamp - lastTickTimestamp, 0), 250);
   lastTickTimestamp = timestamp;
+  updateCameraRig(deltaMs);
   maybeSubmitMovement(timestamp);
 
   if (localSandbox && !manualFrameOverride) {
@@ -810,13 +1060,13 @@ async function renderCurrentFrame(timestamp: number): Promise<void> {
 
   if (latestFrame) {
     if (liveFrameSource === "threejs") {
-      await renderer.applyFrame(
-        typeof latestFrame === "string" ? parseThreeJsWebGpuFrame(latestFrame) : latestFrame
-      );
+      const frame =
+        typeof latestFrame === "string" ? parseThreeJsWebGpuFrame(latestFrame) : latestFrame;
+      await renderer.applyFrame(renderableThreeFrame(frame));
     } else if (typeof latestFrame === "string") {
       await renderer.applyLegacyFrame(parseRenderFrame(latestFrame));
     } else {
-      await renderer.applyFrame(latestFrame);
+      await renderer.applyFrame(renderableThreeFrame(latestFrame));
     }
   } else {
     await renderer.applyFrame(createDemoFrame(timestamp / 1000));
@@ -825,7 +1075,9 @@ async function renderCurrentFrame(timestamp: number): Promise<void> {
   const stats = renderer.getStats();
   runtimeStatsLabel.textContent = `${stats.drawCalls} calls · ${stats.triangles} tris · ${stats.pixelRatio.toFixed(
     2
-  )}x DPR · ${stats.frameMs.toFixed(1)}ms · ${stats.renderThread} thread · chunks ${
+  )}x DPR · ${stats.frameMs.toFixed(1)}ms · ${stats.renderThread} thread · ${stats.environmentPreset} ${stats.timeOfDayHours.toFixed(
+    1
+  )}h · ${stats.landscapeMode} · ${stats.waterMode} · chunks ${
     stats.visibleWorldChunks
   } visible / ${stats.preloadedWorldChunks} warm · assets ${
     stats.residentGeometryAssets + stats.residentSpriteAssets

--- a/apps/pod-web/src/main.ts
+++ b/apps/pod-web/src/main.ts
@@ -493,6 +493,7 @@ function applyAuthoritativeEventBatch(batch: NetworkEventBatch): void {
     return;
   }
 
+  renderer.notifyWorldEvents(batch.events);
   recentWorldEvents = [...recentWorldEvents, ...batch.events].slice(-6);
 
   const controlledId = liveConnectionStatus?.controlledEntity ?? null;

--- a/apps/pod-web/src/render-runtime.ts
+++ b/apps/pod-web/src/render-runtime.ts
@@ -1,4 +1,5 @@
 import type {
+  NetworkGameEvent,
   RenderFrame,
   TelemetryTrajectorySample,
   ThreeJsWebGpuFrame
@@ -25,6 +26,7 @@ export interface PodThreeRenderRuntime {
   readonly renderThread: PodRenderThread;
   applyFrame(frame: ThreeJsWebGpuFrame): Promise<void>;
   applyLegacyFrame(frame: RenderFrame): Promise<void>;
+  notifyWorldEvents(events: NetworkGameEvent[]): void | Promise<void>;
   setTelemetryTrail(samples: TelemetryTrajectorySample[]): void | Promise<void>;
   clearTelemetryTrail(): void | Promise<void>;
   getStats(): PodThreeRendererStats;
@@ -66,6 +68,10 @@ export type RenderWorkerRequest =
   | {
       type: "applyLegacyFrame";
       frame: RenderFrame;
+    }
+  | {
+      type: "notifyWorldEvents";
+      events: NetworkGameEvent[];
     }
   | {
       type: "setTelemetryTrail";
@@ -168,6 +174,10 @@ class MainThreadPodRenderRuntime implements PodThreeRenderRuntime {
 
   async applyLegacyFrame(frame: RenderFrame): Promise<void> {
     await this.renderer.applyLegacyFrame(frame);
+  }
+
+  notifyWorldEvents(events: NetworkGameEvent[]): void {
+    this.renderer.notifyWorldEvents(events);
   }
 
   setTelemetryTrail(samples: TelemetryTrajectorySample[]): void {
@@ -293,6 +303,13 @@ class WorkerPodRenderRuntime implements PodThreeRenderRuntime {
     this.worker.postMessage({
       type: "applyLegacyFrame",
       frame
+    } satisfies RenderWorkerRequest);
+  }
+
+  notifyWorldEvents(events: NetworkGameEvent[]): void {
+    this.worker.postMessage({
+      type: "notifyWorldEvents",
+      events
     } satisfies RenderWorkerRequest);
   }
 

--- a/apps/pod-web/src/render-worker.ts
+++ b/apps/pod-web/src/render-worker.ts
@@ -38,6 +38,9 @@ async function handleMessage(message: RenderWorkerRequest): Promise<void> {
       case "setTelemetryTrail":
         renderer?.setTelemetryTrail(message.samples);
         return;
+      case "notifyWorldEvents":
+        renderer?.notifyWorldEvents(message.events);
+        return;
       case "clearTelemetryTrail":
         renderer?.clearTelemetryTrail();
         return;

--- a/apps/pod-web/src/renderer.test.ts
+++ b/apps/pod-web/src/renderer.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  describeEnvironmentPreset,
+  sampleLakeMask,
+  sampleTerrainHeight,
+  sampleTimeLapseEnvironment,
+  WATER_LEVEL
+} from "./landscape";
+
+describe("pod-web renderer landscape helpers", () => {
+  test("classifies bright flagship environments as daylight", () => {
+    expect(
+      describeEnvironmentPreset({
+        biomeId: "verdant-hollow",
+        skyColor: [0.64, 0.8, 0.98, 1],
+        fogColor: [0.72, 0.84, 0.78, 1],
+        fogNear: 30,
+        fogFar: 196,
+        ambientColor: [0.82, 0.92, 0.88],
+        ambientIntensity: 1.4,
+        sunColor: [1, 0.96, 0.84],
+        sunIntensity: 2.95,
+        sunDirection: [30, 48, 18],
+        fillColor: [0.48, 0.76, 0.94],
+        fillIntensity: 0.88,
+        fillDirection: [-18, 14, -10],
+        rimColor: [0.4, 0.88, 0.78],
+        rimIntensity: 8.5,
+        groundColor: [0.19, 0.33, 0.21, 1],
+        starfieldIntensity: 0.08
+      })
+    ).toBe("daylight");
+  });
+
+  test("builds a deterministic non-flat heightfield for the terrain mesh", () => {
+    expect(sampleTerrainHeight(0, 0)).toBeCloseTo(sampleTerrainHeight(0, 0), 6);
+    expect(sampleTerrainHeight(0, 0)).not.toBeCloseTo(sampleTerrainHeight(42, -18), 3);
+    expect(sampleTerrainHeight(-36, 24)).not.toBeCloseTo(sampleTerrainHeight(68, 64), 3);
+  });
+
+  test("carves a lagoon basin below the waterline", () => {
+    expect(sampleLakeMask(18, -14)).toBeGreaterThan(0.8);
+    expect(sampleTerrainHeight(18, -14)).toBeLessThan(WATER_LEVEL);
+  });
+
+  test("animates the flagship environment through a daylight cycle", () => {
+    const morning = sampleTimeLapseEnvironment(
+      {
+        biomeId: "verdant-hollow",
+        skyColor: [0.64, 0.8, 0.98, 1],
+        fogColor: [0.72, 0.84, 0.78, 1],
+        fogNear: 30,
+        fogFar: 196,
+        ambientColor: [0.82, 0.92, 0.88],
+        ambientIntensity: 1.4,
+        sunColor: [1, 0.96, 0.84],
+        sunIntensity: 2.95,
+        sunDirection: [30, 48, 18],
+        fillColor: [0.48, 0.76, 0.94],
+        fillIntensity: 0.88,
+        fillDirection: [-18, 14, -10],
+        rimColor: [0.4, 0.88, 0.78],
+        rimIntensity: 8.5,
+        groundColor: [0.19, 0.33, 0.21, 1],
+        starfieldIntensity: 0.08
+      },
+      0
+    );
+    const noon = sampleTimeLapseEnvironment(morning.environment, 45);
+
+    expect(morning.timeOfDayHours).toBeGreaterThanOrEqual(0);
+    expect(noon.environment.sunDirection[1]).toBeGreaterThan(morning.environment.sunDirection[1]);
+  });
+});

--- a/apps/pod-web/src/renderer.test.ts
+++ b/apps/pod-web/src/renderer.test.ts
@@ -37,6 +37,8 @@ describe("pod-web renderer landscape helpers", () => {
     expect(sampleTerrainHeight(0, 0)).toBeCloseTo(sampleTerrainHeight(0, 0), 6);
     expect(sampleTerrainHeight(0, 0)).not.toBeCloseTo(sampleTerrainHeight(42, -18), 3);
     expect(sampleTerrainHeight(-36, 24)).not.toBeCloseTo(sampleTerrainHeight(68, 64), 3);
+    expect(sampleTerrainHeight(18, -82)).toBeGreaterThan(sampleTerrainHeight(0, 0));
+    expect(sampleTerrainHeight(-74, 4)).toBeGreaterThan(sampleTerrainHeight(12, 12));
   });
 
   test("carves a lagoon basin below the waterline", () => {

--- a/apps/pod-web/src/renderer.ts
+++ b/apps/pod-web/src/renderer.ts
@@ -12,6 +12,7 @@ import {
 import {
   buildCameraPose,
   buildFramePlan,
+  composeAnimatedInstanceMatrix,
   planningOptionsFromQuality,
   type PodThreeCameraRigOptions,
   type PlannedMeshBatch,
@@ -19,6 +20,7 @@ import {
 } from "./frame-plan";
 import {
   legacyFrameToThreeJsFrame,
+  type NetworkGameEvent,
   type RenderCommand,
   type RenderFrame,
   type TelemetryTrajectorySample,
@@ -478,6 +480,7 @@ export class PodThreeWorldRenderer {
   private lastCameraUpdateAt = 0;
   private telemetryTrail: THREE.Line<THREE.BufferGeometry, THREE.LineBasicMaterial> | null =
     null;
+  private readonly entityPulseUntilMs = new Map<number, number>();
 
   constructor(
     private readonly canvas: HTMLCanvasElement | OffscreenCanvas,
@@ -544,6 +547,29 @@ export class PodThreeWorldRenderer {
 
   async applyLegacyFrame(frame: RenderFrame): Promise<void> {
     await this.applyFrame(legacyFrameToThreeJsFrame(frame));
+  }
+
+  notifyWorldEvents(events: NetworkGameEvent[]): void {
+    if (events.length === 0) {
+      return;
+    }
+
+    const now =
+      typeof performance !== "undefined" && typeof performance.now === "function"
+        ? performance.now()
+        : Date.now();
+
+    for (const event of events) {
+      const durationMs = pulseDurationForEvent(event);
+      if (durationMs <= 0) {
+        continue;
+      }
+
+      for (const entityId of event.entityIds) {
+        const existing = this.entityPulseUntilMs.get(entityId) ?? 0;
+        this.entityPulseUntilMs.set(entityId, Math.max(existing, now + durationMs));
+      }
+    }
   }
 
   dispose(): void {
@@ -938,6 +964,12 @@ export class PodThreeWorldRenderer {
 
   private async syncMeshBatches(batches: PlannedMeshBatch[]): Promise<void> {
     const activeKeys = new Set<string>();
+    const now =
+      typeof performance !== "undefined" && typeof performance.now === "function"
+        ? performance.now()
+        : Date.now();
+    const elapsedSeconds = now / 1000;
+    pruneExpiredPulses(this.entityPulseUntilMs, now);
 
     for (const planned of batches) {
       if (planned.visibleCount === 0) {
@@ -962,20 +994,31 @@ export class PodThreeWorldRenderer {
         existing,
         geometry,
         material,
-        planned.matrices.length,
+        planned.instances.length,
         planned.key
       );
 
       entry.mesh.castShadow = planned.batch.castShadows;
       entry.mesh.receiveShadow = planned.batch.receiveShadows;
-      entry.mesh.count = planned.matrices.length;
+      entry.mesh.count = planned.instances.length;
       entry.mesh.renderOrder = planned.batch.renderOrder;
       entry.mesh.visible = true;
       entry.mesh.name = planned.key;
       entry.mesh.frustumCulled = false;
 
-      for (let index = 0; index < planned.matrices.length; index += 1) {
-        entry.mesh.setMatrixAt(index, planned.matrices[index]);
+      for (let index = 0; index < planned.instances.length; index += 1) {
+        const instance = planned.instances[index];
+        if (!instance) {
+          continue;
+        }
+        entry.mesh.setMatrixAt(
+          index,
+          composeAnimatedInstanceMatrix(
+            instance,
+            elapsedSeconds,
+            pulseStrengthForEntity(this.entityPulseUntilMs, instance.sourceEntity, now)
+          )
+        );
       }
       entry.mesh.instanceMatrix.needsUpdate = true;
       this.meshEntries.set(planned.key, entry);
@@ -986,6 +1029,11 @@ export class PodThreeWorldRenderer {
 
   private async syncSpriteBatches(batches: PlannedSpriteBatch[]): Promise<void> {
     const activeKeys = new Set<string>();
+    const now =
+      typeof performance !== "undefined" && typeof performance.now === "function"
+        ? performance.now()
+        : Date.now();
+    const elapsedSeconds = now / 1000;
 
     for (const planned of batches) {
       if (planned.visibleCount === 0) {
@@ -1005,19 +1053,31 @@ export class PodThreeWorldRenderer {
         existing,
         SPRITE_PLANE_GEOMETRY,
         material,
-        planned.matrices.length,
+        planned.instances.length,
         planned.key
       );
 
       entry.mesh.castShadow = false;
       entry.mesh.receiveShadow = false;
-      entry.mesh.count = planned.matrices.length;
+      entry.mesh.count = planned.instances.length;
       entry.mesh.renderOrder = planned.batch.renderOrder;
       entry.mesh.visible = true;
       entry.mesh.frustumCulled = false;
 
-      for (let index = 0; index < planned.matrices.length; index += 1) {
-        entry.mesh.setMatrixAt(index, planned.matrices[index]);
+      for (let index = 0; index < planned.instances.length; index += 1) {
+        const instance = planned.instances[index];
+        if (!instance) {
+          continue;
+        }
+        entry.mesh.setMatrixAt(
+          index,
+          composeAnimatedInstanceMatrix(
+            instance,
+            elapsedSeconds,
+            pulseStrengthForEntity(this.entityPulseUntilMs, instance.sourceEntity, now),
+            planned.batch.billboard ? this.camera.quaternion : undefined
+          )
+        );
       }
       entry.mesh.instanceMatrix.needsUpdate = true;
       this.spriteEntries.set(planned.key, entry);
@@ -1440,6 +1500,55 @@ function cleanupUnusedEntries(
     disposeInstancedEntry(entry);
     entries.delete(key);
   }
+}
+
+function pruneExpiredPulses(pulses: Map<number, number>, now: number): void {
+  for (const [entityId, untilMs] of pulses) {
+    if (untilMs <= now) {
+      pulses.delete(entityId);
+    }
+  }
+}
+
+function pulseStrengthForEntity(
+  pulses: Map<number, number>,
+  entityId: number | undefined,
+  now: number
+): number {
+  if (entityId == null) {
+    return 0;
+  }
+
+  const untilMs = pulses.get(entityId);
+  if (!untilMs || untilMs <= now) {
+    return 0;
+  }
+
+  return clamp((untilMs - now) / 260, 0, 1);
+}
+
+function pulseDurationForEvent(event: NetworkGameEvent): number {
+  const kind = event.kind.toLowerCase();
+  if (
+    kind.includes("damage") ||
+    kind.includes("attack") ||
+    kind.includes("hit") ||
+    kind.includes("capture") ||
+    kind.includes("defeat")
+  ) {
+    return 260;
+  }
+
+  if (
+    kind.includes("loot") ||
+    kind.includes("gather") ||
+    kind.includes("summon") ||
+    kind.includes("command")
+  ) {
+    return 180;
+  }
+
+  return 0;
 }
 
 function disposeInstancedEntry(entry: InstancedEntry): void {

--- a/apps/pod-web/src/renderer.ts
+++ b/apps/pod-web/src/renderer.ts
@@ -26,6 +26,24 @@ import {
   type ThreeJsWebGpuFrame
 } from "./contracts";
 import {
+  LANDSCAPE_PROFILE_ID,
+  LANDSCAPE_WORLD_SIZE,
+  WATER_CENTER,
+  WATER_LEVEL,
+  WATER_PROFILE_ID,
+  WATER_RADII,
+  clamp,
+  describeEnvironmentPreset,
+  fractalNoise,
+  mixScalar,
+  mixVec3,
+  sampleLakeMask,
+  sampleTerrainHeight,
+  sampleTerrainSlope,
+  sampleTimeLapseEnvironment,
+  smoothstep
+} from "./landscape";
+import {
   resolveQualityProfile,
   type PodThreeQualityPreset,
   type PodThreeQualityProfile
@@ -55,14 +73,192 @@ const INLINE_TSL_FN_WARNING =
 let installedThreeConsoleFilter = false;
 let didReportInlineFnWarning = false;
 
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(Math.max(value, min), max);
+function createPaintSurface(width: number, height: number): PaintSurface {
+  if (typeof OffscreenCanvas === "function") {
+    return new OffscreenCanvas(width, height);
+  }
+
+  if (typeof document === "object") {
+    const canvas = document.createElement("canvas");
+    canvas.width = width;
+    canvas.height = height;
+    return canvas;
+  }
+
+  throw new Error("Canvas surface creation is unavailable in this environment");
+}
+
+function getPaintContext(surface: PaintSurface): OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D {
+  const context = surface.getContext("2d");
+  if (!context) {
+    throw new Error("2D canvas context is unavailable");
+  }
+  return context;
+}
+
+function createTerrainGeometry(
+  size = LANDSCAPE_WORLD_SIZE,
+  segments = 168
+): THREE.PlaneGeometry {
+  const geometry = new THREE.PlaneGeometry(size, size, segments, segments);
+  const positions = geometry.attributes.position;
+
+  for (let index = 0; index < positions.count; index += 1) {
+    const x = positions.getX(index);
+    const y = positions.getY(index);
+    const radialFalloff = clamp(1 - Math.hypot(x, y) / (size * 0.82), 0, 1);
+    const height = sampleTerrainHeight(x, y) * (0.84 + (1 - radialFalloff) * 0.22);
+    positions.setZ(index, height);
+  }
+
+  geometry.computeVertexNormals();
+  return geometry;
+}
+
+function paintTerrainTexture(
+  surface: PaintSurface,
+  environment: ThreeJsEnvironment
+): void {
+  const context = getPaintContext(surface);
+  const width = "width" in surface ? surface.width : 512;
+  const height = "height" in surface ? surface.height : 512;
+  const grass = mixVec3(
+    environment.groundColor.slice(0, 3) as [number, number, number],
+    [0.2, 0.35, 0.22],
+    0.45
+  );
+  const moss = mixVec3(grass, [0.36, 0.49, 0.24], 0.52);
+  const cliff = mixVec3(grass, [0.38, 0.35, 0.31], 0.78);
+  const sand: [number, number, number] = [0.72, 0.66, 0.48];
+  const imageData = context.createImageData(width, height);
+  const worldHalfSize = LANDSCAPE_WORLD_SIZE * 0.5;
+
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const worldX = (x / Math.max(width - 1, 1) - 0.5) * LANDSCAPE_WORLD_SIZE;
+      const worldZ = (y / Math.max(height - 1, 1) - 0.5) * LANDSCAPE_WORLD_SIZE;
+      const terrainHeight = sampleTerrainHeight(worldX, worldZ);
+      const slope = sampleTerrainSlope(worldX, worldZ);
+      const lake = sampleLakeMask(worldX, worldZ);
+      const shore = lake * (1 - smoothstep(2.4, 8.4, Math.abs(terrainHeight - WATER_LEVEL)));
+      const cliffMask = clamp((slope - 0.55) / 1.9 + Math.max(terrainHeight - 10, 0) / 18, 0, 1);
+      const meadowNoise = fractalNoise(worldX * 0.12 + 8, worldZ * 0.12 - 12);
+      const distanceFalloff = 1 - clamp(Math.hypot(worldX, worldZ) / worldHalfSize, 0, 1);
+
+      let tint = mixVec3(grass, moss, meadowNoise * 0.75 + distanceFalloff * 0.15);
+      tint = mixVec3(tint, sand, shore * 0.82);
+      tint = mixVec3(tint, cliff, cliffMask);
+
+      const brightness = clamp(
+        0.74 + terrainHeight * 0.012 - cliffMask * 0.08 + meadowNoise * 0.12,
+        0.36,
+        1.18
+      );
+      const index = (y * width + x) * 4;
+      imageData.data[index] = Math.round(tint[0] * brightness * 255);
+      imageData.data[index + 1] = Math.round(tint[1] * brightness * 255);
+      imageData.data[index + 2] = Math.round(tint[2] * brightness * 255);
+      imageData.data[index + 3] = 255;
+    }
+  }
+
+  context.putImageData(imageData, 0, 0);
+}
+
+function paintWaterTexture(surface: PaintSurface): void {
+  const context = getPaintContext(surface);
+  const width = "width" in surface ? surface.width : 512;
+  const height = "height" in surface ? surface.height : 512;
+  const gradient = context.createLinearGradient(0, 0, 0, height);
+  gradient.addColorStop(0, "rgb(162, 223, 239)");
+  gradient.addColorStop(0.45, "rgb(77, 162, 204)");
+  gradient.addColorStop(1, "rgb(18, 77, 119)");
+  context.fillStyle = gradient;
+  context.fillRect(0, 0, width, height);
+
+  context.strokeStyle = "rgba(255, 255, 255, 0.16)";
+  context.lineWidth = 3;
+  for (let stripe = 0; stripe < 18; stripe += 1) {
+    const offsetY = (stripe / 18) * height;
+    context.beginPath();
+    for (let x = 0; x <= width; x += 16) {
+      const waveY =
+        offsetY +
+        Math.sin((x / width) * Math.PI * 4 + stripe * 0.9) * (6 + (stripe % 3) * 2);
+      if (x === 0) {
+        context.moveTo(x, waveY);
+      } else {
+        context.lineTo(x, waveY);
+      }
+    }
+    context.stroke();
+  }
+}
+
+function createLakeGeometry(pointCount = 56): THREE.ShapeGeometry {
+  const shape = new THREE.Shape();
+
+  for (let index = 0; index <= pointCount; index += 1) {
+    const angle = (index / pointCount) * Math.PI * 2;
+    const noise = 0.86 + fractalNoise(Math.cos(angle) * 12, Math.sin(angle) * 12) * 0.24;
+    const x = WATER_CENTER[0] + Math.cos(angle) * WATER_RADII[0] * noise;
+    const z = WATER_CENTER[1] + Math.sin(angle) * WATER_RADII[1] * noise;
+
+    if (index === 0) {
+      shape.moveTo(x, z);
+    } else {
+      shape.lineTo(x, z);
+    }
+  }
+
+  const geometry = new THREE.ShapeGeometry(shape, 18);
+  geometry.rotateX(-Math.PI / 2);
+  return geometry;
+}
+
+function paintSkyTexture(surface: PaintSurface, environment: ThreeJsEnvironment): void {
+  const context = getPaintContext(surface);
+  const width = "width" in surface ? surface.width : 512;
+  const height = "height" in surface ? surface.height : 512;
+  const top = mixVec3(environment.skyColor.slice(0, 3) as [number, number, number], [0.9, 0.97, 1], 0.28);
+  const horizon = mixVec3(environment.fogColor.slice(0, 3) as [number, number, number], [0.97, 0.91, 0.72], 0.38);
+
+  const gradient = context.createLinearGradient(0, 0, 0, height);
+  gradient.addColorStop(0, `rgb(${Math.round(top[0] * 255)}, ${Math.round(top[1] * 255)}, ${Math.round(top[2] * 255)})`);
+  gradient.addColorStop(0.68, `rgb(${Math.round(horizon[0] * 255)}, ${Math.round(horizon[1] * 255)}, ${Math.round(horizon[2] * 255)})`);
+  gradient.addColorStop(1, `rgb(${Math.round(environment.groundColor[0] * 255)}, ${Math.round(environment.groundColor[1] * 255)}, ${Math.round(environment.groundColor[2] * 255)})`);
+  context.fillStyle = gradient;
+  context.fillRect(0, 0, width, height);
+
+  const sunGradient = context.createRadialGradient(width * 0.72, height * 0.28, 0, width * 0.72, height * 0.28, width * 0.18);
+  sunGradient.addColorStop(0, "rgba(255, 246, 220, 0.92)");
+  sunGradient.addColorStop(0.22, "rgba(255, 229, 162, 0.48)");
+  sunGradient.addColorStop(1, "rgba(255, 229, 162, 0)");
+  context.fillStyle = sunGradient;
+  context.fillRect(0, 0, width, height);
+}
+
+function environmentSignature(environment: ThreeJsEnvironment): string {
+  return [
+    ...environment.skyColor.slice(0, 3),
+    ...environment.fogColor.slice(0, 3),
+    ...environment.groundColor.slice(0, 3),
+    ...environment.sunColor,
+    environment.sunIntensity,
+    environment.starfieldIntensity
+  ]
+    .map((value) => value.toFixed(3))
+    .join("|");
 }
 
 export interface PodThreeRendererStats {
   backend: "webgpu" | "webgl2";
   renderThread: "main" | "worker";
   qualityPreset: PodThreeQualityPreset;
+  environmentPreset: "daylight" | "twilight" | "night";
+  landscapeMode: typeof LANDSCAPE_PROFILE_ID;
+  waterMode: typeof WATER_PROFILE_ID;
+  timeOfDayHours: number;
   pixelRatio: number;
   drawCalls: number;
   triangles: number;
@@ -93,6 +289,8 @@ export interface PodThreeWorldRendererOptions {
   maxPixelRatio?: number;
   surfaceMetrics?: RenderSurfaceMetrics;
 }
+
+type PaintSurface = OffscreenCanvas | HTMLCanvasElement;
 
 export class PodThreeWorldRenderer {
   static async create(
@@ -132,6 +330,17 @@ export class PodThreeWorldRenderer {
   private fillLight: THREE.DirectionalLight | null = null;
   private rimLight: THREE.PointLight | null = null;
   private groundMaterial: THREE.MeshStandardMaterial | null = null;
+  private terrainMesh: THREE.Mesh<THREE.PlaneGeometry, THREE.MeshStandardMaterial> | null =
+    null;
+  private terrainTexture: THREE.Texture | null = null;
+  private terrainTextureSurface: PaintSurface | null = null;
+  private waterMesh: THREE.Mesh<THREE.ShapeGeometry, THREE.MeshStandardMaterial> | null = null;
+  private waterTexture: THREE.Texture | null = null;
+  private waterTextureSurface: PaintSurface | null = null;
+  private skyDome: THREE.Mesh<THREE.SphereGeometry, THREE.MeshBasicMaterial> | null = null;
+  private skyTexture: THREE.Texture | null = null;
+  private skyTextureSurface: PaintSurface | null = null;
+  private sunOrb: THREE.Mesh<THREE.SphereGeometry, THREE.MeshBasicMaterial> | null = null;
   private starfieldMaterial: THREE.PointsMaterial | null = null;
   private adaptivePixelRatio: number;
   private smoothedFrameMs = 16.7;
@@ -139,6 +348,13 @@ export class PodThreeWorldRenderer {
   private surfaceMetrics: RenderSurfaceMetrics | null;
   private visibleWorldChunks = 0;
   private preloadedWorldChunks = 0;
+  private environmentPreset: "daylight" | "twilight" | "night" = "daylight";
+  private timeOfDayHours = 12;
+  private lastEnvironmentSignature: string | null = null;
+  private baseEnvironment: ThreeJsEnvironment | null = null;
+  private readonly smoothedCameraTarget = new THREE.Vector3();
+  private cameraPoseInitialized = false;
+  private lastCameraUpdateAt = 0;
   private telemetryTrail: THREE.Line<THREE.BufferGeometry, THREE.LineBasicMaterial> | null =
     null;
 
@@ -239,6 +455,26 @@ export class PodThreeWorldRenderer {
     this.scene.fog = new THREE.Fog(0x09111b, 28, 180);
     this.scene.backgroundIntensity = 0.8;
 
+    const defaultEnvironment: ThreeJsEnvironment = {
+      biomeId: "verdant-hollow",
+      skyColor: [0.64, 0.8, 0.98, 1],
+      fogColor: [0.73, 0.84, 0.78, 1],
+      fogNear: 30,
+      fogFar: 196,
+      ambientColor: [0.82, 0.92, 0.88],
+      ambientIntensity: 1.4,
+      sunColor: [1, 0.96, 0.84],
+      sunIntensity: 2.9,
+      sunDirection: [30, 48, 18],
+      fillColor: [0.44, 0.74, 0.94],
+      fillIntensity: 0.88,
+      fillDirection: [-18, 14, -10],
+      rimColor: [0.42, 0.88, 0.78],
+      rimIntensity: 9,
+      groundColor: [0.19, 0.33, 0.21, 1],
+      starfieldIntensity: 0.08
+    };
+
     const hemisphere = new THREE.HemisphereLight(0xa8d1ff, 0x14263f, 1.2);
     this.scene.add(hemisphere);
     this.hemisphereLight = hemisphere;
@@ -266,16 +502,81 @@ export class PodThreeWorldRenderer {
     this.scene.add(rim);
     this.rimLight = rim;
 
+    this.skyTextureSurface = createPaintSurface(512, 512);
+    paintSkyTexture(this.skyTextureSurface, defaultEnvironment);
+    const skyTexture = new THREE.CanvasTexture(this.skyTextureSurface);
+    skyTexture.colorSpace = THREE.SRGBColorSpace;
+    this.skyTexture = skyTexture;
+    const skyMaterial = new THREE.MeshBasicMaterial({
+      map: skyTexture,
+      side: THREE.BackSide,
+      depthWrite: false,
+      fog: false
+    });
+    const skyDome = new THREE.Mesh(new THREE.SphereGeometry(280, 40, 24), skyMaterial);
+    this.scene.add(skyDome);
+    this.skyDome = skyDome;
+
+    const sunOrb = new THREE.Mesh(
+      new THREE.SphereGeometry(8, 24, 24),
+      new THREE.MeshBasicMaterial({
+        color: new THREE.Color(1, 0.95, 0.82),
+        transparent: true,
+        opacity: 0.94,
+        fog: false
+      })
+    );
+    this.scene.add(sunOrb);
+    this.sunOrb = sunOrb;
+
+    this.terrainTextureSurface = createPaintSurface(512, 512);
+    paintTerrainTexture(this.terrainTextureSurface, defaultEnvironment);
+    const terrainTexture = new THREE.CanvasTexture(this.terrainTextureSurface);
+    terrainTexture.colorSpace = THREE.SRGBColorSpace;
+    terrainTexture.wrapS = THREE.RepeatWrapping;
+    terrainTexture.wrapT = THREE.RepeatWrapping;
+    terrainTexture.repeat.set(1, 1);
+    this.terrainTexture = terrainTexture;
     const groundMaterial = new THREE.MeshStandardMaterial({
-      color: 0x0e1724,
-      roughness: 0.95,
+      color: 0xffffff,
+      map: terrainTexture,
+      roughness: 0.96,
       metalness: 0.02
     });
     this.groundMaterial = groundMaterial;
-    const ground = new THREE.Mesh(new THREE.CircleGeometry(140, 64), groundMaterial);
+    const ground = new THREE.Mesh(createTerrainGeometry(), groundMaterial);
     ground.rotation.x = -Math.PI / 2;
     ground.receiveShadow = true;
+    ground.castShadow = false;
     this.scene.add(ground);
+    this.terrainMesh = ground;
+
+    this.waterTextureSurface = createPaintSurface(384, 384);
+    paintWaterTexture(this.waterTextureSurface);
+    const waterTexture = new THREE.CanvasTexture(this.waterTextureSurface);
+    waterTexture.colorSpace = THREE.SRGBColorSpace;
+    waterTexture.wrapS = THREE.RepeatWrapping;
+    waterTexture.wrapT = THREE.RepeatWrapping;
+    waterTexture.repeat.set(1.4, 1.4);
+    this.waterTexture = waterTexture;
+    const waterMaterial = new THREE.MeshStandardMaterial({
+      color: new THREE.Color(0.24, 0.62, 0.76),
+      map: waterTexture,
+      transparent: true,
+      opacity: 0.84,
+      roughness: 0.14,
+      metalness: 0.04,
+      emissive: new THREE.Color(0.04, 0.12, 0.18),
+      emissiveIntensity: 0.5,
+      side: THREE.DoubleSide,
+      depthWrite: false
+    });
+    const water = new THREE.Mesh(createLakeGeometry(), waterMaterial);
+    water.position.y = WATER_LEVEL + 0.06;
+    water.receiveShadow = true;
+    water.renderOrder = 2;
+    this.scene.add(water);
+    this.waterMesh = water;
 
     if (this.quality.showGrid) {
       const grid = new THREE.GridHelper(180, 60, 0x5fa7ff, 0x173049);
@@ -295,6 +596,7 @@ export class PodThreeWorldRenderer {
     const skyline = new THREE.Points(createStarfieldGeometry(640, 220), starfieldMaterial);
     skyline.position.y = 36;
     this.scene.add(skyline);
+    this.applyEnvironment(defaultEnvironment);
 
     this.overlayScene.background = null;
     this.overlayCamera.position.set(0, 0, 5);
@@ -302,6 +604,28 @@ export class PodThreeWorldRenderer {
   }
 
   private applyEnvironment(environment: ThreeJsEnvironment): void {
+    this.baseEnvironment = environment;
+    const signature = environmentSignature(environment);
+    if (signature !== this.lastEnvironmentSignature) {
+      if (this.skyTextureSurface && this.skyTexture) {
+        paintSkyTexture(this.skyTextureSurface, environment);
+        this.skyTexture.needsUpdate = true;
+      }
+      if (this.terrainTextureSurface && this.terrainTexture) {
+        paintTerrainTexture(this.terrainTextureSurface, environment);
+        this.terrainTexture.needsUpdate = true;
+      }
+      this.lastEnvironmentSignature = signature;
+    }
+
+    this.applyDynamicEnvironment(
+      sampleTimeLapseEnvironment(environment, performance.now() / 1000).environment
+    );
+  }
+
+  private applyDynamicEnvironment(environment: ThreeJsEnvironment): void {
+    this.environmentPreset = describeEnvironmentPreset(environment);
+
     this.scene.background = new THREE.Color(...environment.skyColor.slice(0, 3));
     const fog = this.scene.fog;
     if (fog instanceof THREE.Fog) {
@@ -362,6 +686,27 @@ export class PodThreeWorldRenderer {
       environment.groundColor[1],
       environment.groundColor[2]
     );
+    if (this.waterMesh) {
+      this.waterMesh.material.color.setRGB(0.18, 0.48 + environment.skyColor[1] * 0.18, 0.62 + environment.skyColor[2] * 0.1);
+      this.waterMesh.material.emissive.setRGB(
+        0.04 + environment.skyColor[0] * 0.05,
+        0.08 + environment.skyColor[1] * 0.08,
+        0.12 + environment.skyColor[2] * 0.08
+      );
+      this.waterMesh.material.emissiveIntensity = 0.4 + environment.sunIntensity * 0.03;
+    }
+    if (this.sunOrb) {
+      const sunDirection = new THREE.Vector3(...environment.sunDirection)
+        .normalize()
+        .multiplyScalar(210);
+      this.sunOrb.position.copy(sunDirection);
+      this.sunOrb.material.color.setRGB(
+        environment.sunColor[0],
+        environment.sunColor[1],
+        environment.sunColor[2]
+      );
+      this.sunOrb.material.opacity = clamp(0.18 + environment.sunIntensity * 0.22, 0.18, 0.96);
+    }
     if (this.starfieldMaterial) {
       this.starfieldMaterial.opacity = clamp(environment.starfieldIntensity, 0, 1);
     }
@@ -371,12 +716,33 @@ export class PodThreeWorldRenderer {
     pose: ReturnType<typeof buildCameraPose>,
     frameCamera: ThreeJsWebGpuFrame["camera"]
   ): void {
-    this.camera.position.set(...pose.position);
-    this.camera.quaternion.copy(pose.quaternion);
+    const targetPosition = new THREE.Vector3(...pose.position);
+    const targetLookAt = new THREE.Vector3(...pose.target);
+    const now =
+      typeof performance !== "undefined" && typeof performance.now === "function"
+        ? performance.now()
+        : Date.now();
+    const deltaSeconds =
+      this.lastCameraUpdateAt === 0
+        ? 1 / 60
+        : clamp((now - this.lastCameraUpdateAt) / 1000, 1 / 240, 0.12);
+    this.lastCameraUpdateAt = now;
+    const positionAlpha = 1 - Math.exp(-deltaSeconds * 10);
+    const targetAlpha = 1 - Math.exp(-deltaSeconds * 14);
+
+    if (!this.cameraPoseInitialized) {
+      this.camera.position.copy(targetPosition);
+      this.smoothedCameraTarget.copy(targetLookAt);
+      this.cameraPoseInitialized = true;
+    } else {
+      this.camera.position.lerp(targetPosition, positionAlpha);
+      this.smoothedCameraTarget.lerp(targetLookAt, targetAlpha);
+    }
+
     this.camera.fov = pose.fov;
     this.camera.near = pose.near;
     this.camera.far = pose.far;
-    this.camera.lookAt(...pose.target);
+    this.camera.lookAt(this.smoothedCameraTarget);
     this.camera.updateProjectionMatrix();
 
     const halfWidth = frameCamera.viewportWidth / 2;
@@ -558,7 +924,7 @@ export class PodThreeWorldRenderer {
       (sample, index) =>
         new THREE.Vector3(
           sample.position[0],
-          0.22 + index * 0.0035,
+          sampleTerrainHeight(sample.position[0], sample.position[1]) + 0.22 + index * 0.0035,
           sample.position[1]
         )
     );
@@ -588,6 +954,17 @@ export class PodThreeWorldRenderer {
 
   private async renderFrame(): Promise<void> {
     const frameStart = performance.now();
+    if (this.baseEnvironment) {
+      const timeLapse = sampleTimeLapseEnvironment(this.baseEnvironment, frameStart / 1000);
+      this.timeOfDayHours = timeLapse.timeOfDayHours;
+      this.applyDynamicEnvironment(timeLapse.environment);
+    }
+    if (this.waterTexture) {
+      this.waterTexture.offset.set(
+        (frameStart * 0.000045) % 1,
+        (frameStart * 0.00003) % 1
+      );
+    }
     const previousAutoClear = this.renderer.autoClear;
     this.renderer.autoClear = true;
     await renderWithFallback(this.renderer, this.scene, this.camera);
@@ -608,6 +985,23 @@ export class PodThreeWorldRenderer {
     this.renderer.setSize(width, height, false);
     this.camera.aspect = width / Math.max(height, 1);
     this.camera.updateProjectionMatrix();
+
+    const rendererWithCapabilities = this.renderer as RuntimeRenderer & {
+      capabilities?: { getMaxAnisotropy?: () => number };
+    };
+    const anisotropy =
+      typeof rendererWithCapabilities.capabilities?.getMaxAnisotropy === "function"
+        ? Math.min(rendererWithCapabilities.capabilities.getMaxAnisotropy(), 8)
+        : 1;
+    if (this.terrainTexture) {
+      this.terrainTexture.anisotropy = anisotropy;
+    }
+    if (this.skyTexture) {
+      this.skyTexture.anisotropy = anisotropy;
+    }
+    if (this.waterTexture) {
+      this.waterTexture.anisotropy = anisotropy;
+    }
   }
 
   getStats(): PodThreeRendererStats {
@@ -617,11 +1011,19 @@ export class PodThreeWorldRenderer {
       pendingGeometryAssets: 0,
       pendingSpriteAssets: 0
     };
+    const landscapeMode =
+      this.terrainMesh && this.skyDome
+        ? LANDSCAPE_PROFILE_ID
+        : LANDSCAPE_PROFILE_ID;
 
     return {
       backend: this.backend,
       renderThread: "main",
       qualityPreset: this.quality.preset,
+      environmentPreset: this.environmentPreset,
+      landscapeMode,
+      waterMode: WATER_PROFILE_ID,
+      timeOfDayHours: Number(this.timeOfDayHours.toFixed(2)),
       pixelRatio: this.renderer.getPixelRatio(),
       drawCalls: this.renderer.info.render.calls,
       triangles: this.renderer.info.render.triangles,

--- a/apps/pod-web/src/renderer.ts
+++ b/apps/pod-web/src/renderer.ts
@@ -70,6 +70,7 @@ interface InstancedEntry {
 
 const INLINE_TSL_FN_WARNING =
   "THREE.TSL: Return statement used in an inline 'Fn()'. Define a layout struct to allow return values.";
+const DAYLIGHT_START_OFFSET_SECONDS = 86.25;
 let installedThreeConsoleFilter = false;
 let didReportInlineFnWarning = false;
 
@@ -129,6 +130,8 @@ function paintTerrainTexture(
   );
   const moss = mixVec3(grass, [0.36, 0.49, 0.24], 0.52);
   const cliff = mixVec3(grass, [0.38, 0.35, 0.31], 0.78);
+  const basalt: [number, number, number] = [0.22, 0.24, 0.28];
+  const highland: [number, number, number] = [0.54, 0.52, 0.46];
   const sand: [number, number, number] = [0.72, 0.66, 0.48];
   const imageData = context.createImageData(width, height);
   const worldHalfSize = LANDSCAPE_WORLD_SIZE * 0.5;
@@ -143,15 +146,26 @@ function paintTerrainTexture(
       const shore = lake * (1 - smoothstep(2.4, 8.4, Math.abs(terrainHeight - WATER_LEVEL)));
       const cliffMask = clamp((slope - 0.55) / 1.9 + Math.max(terrainHeight - 10, 0) / 18, 0, 1);
       const meadowNoise = fractalNoise(worldX * 0.12 + 8, worldZ * 0.12 - 12);
+      const ridgeNoise = fractalNoise(worldX * 0.032 - 14, worldZ * 0.032 + 21);
       const distanceFalloff = 1 - clamp(Math.hypot(worldX, worldZ) / worldHalfSize, 0, 1);
+      const highlandMask = clamp((terrainHeight - 16) / 16, 0, 1);
+      const rockMask = clamp(cliffMask * 0.7 + highlandMask * 0.8 + ridgeNoise * 0.24, 0, 1);
+      const foamMask = clamp(shore * 1.35, 0, 1);
 
       let tint = mixVec3(grass, moss, meadowNoise * 0.75 + distanceFalloff * 0.15);
-      tint = mixVec3(tint, sand, shore * 0.82);
-      tint = mixVec3(tint, cliff, cliffMask);
+      tint = mixVec3(tint, sand, shore * 0.7);
+      tint = mixVec3(tint, cliff, cliffMask * 0.72);
+      tint = mixVec3(tint, highland, highlandMask * 0.52);
+      tint = mixVec3(tint, basalt, rockMask * 0.58);
+      tint = mixVec3(tint, [0.92, 0.9, 0.82], foamMask * 0.14);
 
       const brightness = clamp(
-        0.74 + terrainHeight * 0.012 - cliffMask * 0.08 + meadowNoise * 0.12,
-        0.36,
+        0.72 +
+          terrainHeight * 0.011 -
+          cliffMask * 0.06 +
+          meadowNoise * 0.12 +
+          foamMask * 0.08,
+        0.34,
         1.18
       );
       const index = (y * width + x) * 4;
@@ -170,21 +184,36 @@ function paintWaterTexture(surface: PaintSurface): void {
   const width = "width" in surface ? surface.width : 512;
   const height = "height" in surface ? surface.height : 512;
   const gradient = context.createLinearGradient(0, 0, 0, height);
-  gradient.addColorStop(0, "rgb(162, 223, 239)");
-  gradient.addColorStop(0.45, "rgb(77, 162, 204)");
-  gradient.addColorStop(1, "rgb(18, 77, 119)");
+  gradient.addColorStop(0, "rgb(178, 235, 244)");
+  gradient.addColorStop(0.3, "rgb(92, 182, 214)");
+  gradient.addColorStop(0.68, "rgb(29, 104, 152)");
+  gradient.addColorStop(1, "rgb(10, 42, 78)");
   context.fillStyle = gradient;
   context.fillRect(0, 0, width, height);
 
-  context.strokeStyle = "rgba(255, 255, 255, 0.16)";
-  context.lineWidth = 3;
-  for (let stripe = 0; stripe < 18; stripe += 1) {
-    const offsetY = (stripe / 18) * height;
+  const radial = context.createRadialGradient(
+    width * 0.52,
+    height * 0.42,
+    width * 0.08,
+    width * 0.5,
+    height * 0.5,
+    width * 0.56
+  );
+  radial.addColorStop(0, "rgba(255,255,255,0.16)");
+  radial.addColorStop(0.45, "rgba(170,232,255,0.08)");
+  radial.addColorStop(1, "rgba(0,0,0,0)");
+  context.fillStyle = radial;
+  context.fillRect(0, 0, width, height);
+
+  context.strokeStyle = "rgba(255, 255, 255, 0.14)";
+  context.lineWidth = 2.5;
+  for (let stripe = 0; stripe < 22; stripe += 1) {
+    const offsetY = (stripe / 22) * height;
     context.beginPath();
     for (let x = 0; x <= width; x += 16) {
       const waveY =
         offsetY +
-        Math.sin((x / width) * Math.PI * 4 + stripe * 0.9) * (6 + (stripe % 3) * 2);
+        Math.sin((x / width) * Math.PI * 4 + stripe * 0.9) * (5 + (stripe % 3) * 1.6);
       if (x === 0) {
         context.moveTo(x, waveY);
       } else {
@@ -193,17 +222,40 @@ function paintWaterTexture(surface: PaintSurface): void {
     }
     context.stroke();
   }
+
+  context.strokeStyle = "rgba(210, 246, 255, 0.24)";
+  context.lineWidth = 1.5;
+  for (let ring = 0; ring < 5; ring += 1) {
+    const radius = width * (0.16 + ring * 0.11);
+    context.beginPath();
+    context.ellipse(width * 0.52, height * 0.5, radius, radius * 0.62, 0, 0, Math.PI * 2);
+    context.stroke();
+  }
 }
 
-function createLakeGeometry(pointCount = 56): THREE.ShapeGeometry {
-  const shape = new THREE.Shape();
+function buildLakeOutline(
+  pointCount = 56,
+  radialScale = 1
+): Array<[number, number]> {
+  const points = new Array<[number, number]>();
 
-  for (let index = 0; index <= pointCount; index += 1) {
+  for (let index = 0; index < pointCount; index += 1) {
     const angle = (index / pointCount) * Math.PI * 2;
     const noise = 0.86 + fractalNoise(Math.cos(angle) * 12, Math.sin(angle) * 12) * 0.24;
-    const x = WATER_CENTER[0] + Math.cos(angle) * WATER_RADII[0] * noise;
-    const z = WATER_CENTER[1] + Math.sin(angle) * WATER_RADII[1] * noise;
+    points.push([
+      WATER_CENTER[0] + Math.cos(angle) * WATER_RADII[0] * noise * radialScale,
+      WATER_CENTER[1] + Math.sin(angle) * WATER_RADII[1] * noise * radialScale
+    ]);
+  }
 
+  return points;
+}
+
+function createClosedShape(points: Array<[number, number]>): THREE.Shape {
+  const shape = new THREE.Shape();
+
+  for (let index = 0; index <= points.length; index += 1) {
+    const [x, z] = points[index % points.length] ?? points[0] ?? [0, 0];
     if (index === 0) {
       shape.moveTo(x, z);
     } else {
@@ -211,8 +263,73 @@ function createLakeGeometry(pointCount = 56): THREE.ShapeGeometry {
     }
   }
 
+  return shape;
+}
+
+function createLakeGeometry(pointCount = 56): THREE.ShapeGeometry {
+  const shape = createClosedShape(buildLakeOutline(pointCount));
+
   const geometry = new THREE.ShapeGeometry(shape, 18);
   geometry.rotateX(-Math.PI / 2);
+  return geometry;
+}
+
+function createShorelineGeometry(pointCount = 56): THREE.ShapeGeometry {
+  const outerShape = createClosedShape(buildLakeOutline(pointCount, 1.08));
+  const innerPath = new THREE.Path();
+  const innerPoints = buildLakeOutline(pointCount, 0.98);
+
+  for (let index = innerPoints.length; index >= 0; index -= 1) {
+    const [x, z] = innerPoints[index % innerPoints.length] ?? innerPoints[0] ?? [0, 0];
+    if (index === innerPoints.length) {
+      innerPath.moveTo(x, z);
+    } else {
+      innerPath.lineTo(x, z);
+    }
+  }
+
+  outerShape.holes.push(innerPath);
+  const geometry = new THREE.ShapeGeometry(outerShape, 18);
+  geometry.rotateX(-Math.PI / 2);
+  return geometry;
+}
+
+function createMountainBackdropGeometry(
+  radius = LANDSCAPE_WORLD_SIZE * 0.68,
+  width = 42,
+  segments = 88
+): THREE.BufferGeometry {
+  const positions = new Float32Array((segments + 1) * 2 * 3);
+  const indices = new Array<number>();
+
+  for (let index = 0; index <= segments; index += 1) {
+    const angle = (index / segments) * Math.PI * 2;
+    const ridgeNoise = fractalNoise(Math.cos(angle) * 7 + 4, Math.sin(angle) * 7 - 9);
+    const peakHeight = 28 + ridgeNoise * 42;
+    const innerRadius = radius;
+    const outerRadius = radius + width + ridgeNoise * 18;
+    const sin = Math.sin(angle);
+    const cos = Math.cos(angle);
+    const offset = index * 6;
+
+    positions[offset] = cos * innerRadius;
+    positions[offset + 1] = -6;
+    positions[offset + 2] = sin * innerRadius;
+
+    positions[offset + 3] = cos * outerRadius;
+    positions[offset + 4] = peakHeight;
+    positions[offset + 5] = sin * outerRadius;
+
+    if (index < segments) {
+      const base = index * 2;
+      indices.push(base, base + 1, base + 2, base + 1, base + 3, base + 2);
+    }
+  }
+
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute("position", new THREE.BufferAttribute(positions, 3));
+  geometry.setIndex(indices);
+  geometry.computeVertexNormals();
   return geometry;
 }
 
@@ -335,8 +452,12 @@ export class PodThreeWorldRenderer {
   private terrainTexture: THREE.Texture | null = null;
   private terrainTextureSurface: PaintSurface | null = null;
   private waterMesh: THREE.Mesh<THREE.ShapeGeometry, THREE.MeshStandardMaterial> | null = null;
+  private shorelineMesh: THREE.Mesh<THREE.ShapeGeometry, THREE.MeshStandardMaterial> | null = null;
   private waterTexture: THREE.Texture | null = null;
   private waterTextureSurface: PaintSurface | null = null;
+  private mountainBackdrop:
+    | THREE.Mesh<THREE.BufferGeometry, THREE.MeshStandardMaterial>
+    | null = null;
   private skyDome: THREE.Mesh<THREE.SphereGeometry, THREE.MeshBasicMaterial> | null = null;
   private skyTexture: THREE.Texture | null = null;
   private skyTextureSurface: PaintSurface | null = null;
@@ -540,8 +661,8 @@ export class PodThreeWorldRenderer {
     const groundMaterial = new THREE.MeshStandardMaterial({
       color: 0xffffff,
       map: terrainTexture,
-      roughness: 0.96,
-      metalness: 0.02
+      roughness: 0.9,
+      metalness: 0.03
     });
     this.groundMaterial = groundMaterial;
     const ground = new THREE.Mesh(createTerrainGeometry(), groundMaterial);
@@ -563,11 +684,11 @@ export class PodThreeWorldRenderer {
       color: new THREE.Color(0.24, 0.62, 0.76),
       map: waterTexture,
       transparent: true,
-      opacity: 0.84,
-      roughness: 0.14,
-      metalness: 0.04,
+      opacity: 0.9,
+      roughness: 0.08,
+      metalness: 0.12,
       emissive: new THREE.Color(0.04, 0.12, 0.18),
-      emissiveIntensity: 0.5,
+      emissiveIntensity: 0.56,
       side: THREE.DoubleSide,
       depthWrite: false
     });
@@ -577,6 +698,39 @@ export class PodThreeWorldRenderer {
     water.renderOrder = 2;
     this.scene.add(water);
     this.waterMesh = water;
+
+    const shorelineMaterial = new THREE.MeshStandardMaterial({
+      color: new THREE.Color(0.82, 0.79, 0.66),
+      transparent: true,
+      opacity: 0.54,
+      roughness: 0.92,
+      metalness: 0,
+      emissive: new THREE.Color(0.12, 0.14, 0.12),
+      emissiveIntensity: 0.12,
+      side: THREE.DoubleSide,
+      depthWrite: false
+    });
+    const shoreline = new THREE.Mesh(createShorelineGeometry(), shorelineMaterial);
+    shoreline.position.y = WATER_LEVEL + 0.08;
+    shoreline.receiveShadow = true;
+    shoreline.renderOrder = 3;
+    this.scene.add(shoreline);
+    this.shorelineMesh = shoreline;
+
+    const mountainBackdrop = new THREE.Mesh(
+      createMountainBackdropGeometry(),
+      new THREE.MeshStandardMaterial({
+        color: new THREE.Color(0.17, 0.24, 0.32),
+        roughness: 1,
+        metalness: 0,
+        fog: true
+      })
+    );
+    mountainBackdrop.position.y = -4;
+    mountainBackdrop.receiveShadow = false;
+    mountainBackdrop.castShadow = false;
+    this.scene.add(mountainBackdrop);
+    this.mountainBackdrop = mountainBackdrop;
 
     if (this.quality.showGrid) {
       const grid = new THREE.GridHelper(180, 60, 0x5fa7ff, 0x173049);
@@ -694,6 +848,31 @@ export class PodThreeWorldRenderer {
         0.12 + environment.skyColor[2] * 0.08
       );
       this.waterMesh.material.emissiveIntensity = 0.4 + environment.sunIntensity * 0.03;
+    }
+    if (this.shorelineMesh) {
+      this.shorelineMesh.material.color.setRGB(
+        0.68 + environment.sunColor[0] * 0.1,
+        0.62 + environment.sunColor[1] * 0.1,
+        0.54 + environment.sunColor[2] * 0.04
+      );
+      this.shorelineMesh.material.opacity = 0.3 + environment.sunIntensity * 0.05;
+      this.shorelineMesh.material.emissive.setRGB(
+        0.08 + environment.skyColor[0] * 0.04,
+        0.08 + environment.skyColor[1] * 0.04,
+        0.07 + environment.skyColor[2] * 0.03
+      );
+    }
+    if (this.mountainBackdrop) {
+      this.mountainBackdrop.material.color.setRGB(
+        environment.fogColor[0] * 0.5,
+        environment.fogColor[1] * 0.48,
+        environment.fogColor[2] * 0.58
+      );
+      this.mountainBackdrop.material.emissive.setRGB(
+        environment.fillColor[0] * 0.05,
+        environment.fillColor[1] * 0.05,
+        environment.fillColor[2] * 0.06
+      );
     }
     if (this.sunOrb) {
       const sunDirection = new THREE.Vector3(...environment.sunDirection)
@@ -955,7 +1134,10 @@ export class PodThreeWorldRenderer {
   private async renderFrame(): Promise<void> {
     const frameStart = performance.now();
     if (this.baseEnvironment) {
-      const timeLapse = sampleTimeLapseEnvironment(this.baseEnvironment, frameStart / 1000);
+      const timeLapse = sampleTimeLapseEnvironment(
+        this.baseEnvironment,
+        frameStart / 1000 + DAYLIGHT_START_OFFSET_SECONDS
+      );
       this.timeOfDayHours = timeLapse.timeOfDayHours;
       this.applyDynamicEnvironment(timeLapse.environment);
     }

--- a/progress.md
+++ b/progress.md
@@ -8,3 +8,6 @@ Original prompt: its the graphics and the worlds scene, everything is piled up o
   - spread the authored sandbox hub and landmark props
   - demote debug heatmaps/details out of the primary gameplay HUD
   - remove the accidental render-space compression that collapsed world coordinates by 0.08x
+- Implemented a real browser-side third-person camera controller: right-drag orbit, wheel zoom, independent camera yaw, terrain-aware spring-arm collision, and velocity lead so movement no longer feels welded to the player facing.
+- Smoothed local sandbox locomotion with acceleration, deceleration, and turn easing instead of instantaneous velocity snaps.
+- Verified in Playwright that click-to-move still advances the player, assets fully warm, and keyboard movement follows the rotated camera after orbit input.

--- a/progress.md
+++ b/progress.md
@@ -11,3 +11,5 @@ Original prompt: its the graphics and the worlds scene, everything is piled up o
 - Implemented a real browser-side third-person camera controller: right-drag orbit, wheel zoom, independent camera yaw, terrain-aware spring-arm collision, and velocity lead so movement no longer feels welded to the player facing.
 - Smoothed local sandbox locomotion with acceleration, deceleration, and turn easing instead of instantaneous velocity snaps.
 - Verified in Playwright that click-to-move still advances the player, assets fully warm, and keyboard movement follows the rotated camera after orbit input.
+- Added a stronger flagship biome read: elevated ridge/backdrop shaping, brighter shoreline separation, richer water texture, and a less dominant main HUD.
+- Fixed the timelapse boot state so the world now starts in readable daylight instead of sometimes loading into near-night on first paint.


### PR DESCRIPTION
## Summary
- carry actor animation metadata through the authoritative web frame contract
- animate instanced actors and combat rings in the renderer instead of drawing static transforms
- trigger short-lived render pulses from authoritative world events on both main-thread and worker runtimes

## Validation
- cd apps/pod-web && bun test ./src/frame-plan.test.ts ./src/contracts.test.ts ./src/render-runtime.test.ts ./src/renderer.test.ts
- cd apps/pod-web && bun run typecheck
- cd apps/pod-web && bun run build
- Playwright smoke on http://127.0.0.1:4176/ and http://127.0.0.1:4176/?renderThread=worker


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Third-person camera system with right-drag orbit, scroll zoom, and terrain-aware collision detection
  * Click-to-move: click terrain to walk toward target location
  * Smoother movement with acceleration and deceleration
  * Enhanced biome visuals with improved terrain, water, and dynamic lighting
  * Day-night cycle with environmental progression

* **Bug Fixes**
  * Fixed startup visibility in daylight conditions

* **UI/UX Updates**
  * Refined HUD layout with adjusted sizing and spacing
  * Updated controls guidance and page branding

<!-- end of auto-generated comment: release notes by coderabbit.ai -->