### PR TITLE
Add pod-web interaction markers

### DIFF
--- a/apps/pod-web/src/contracts.test.ts
+++ b/apps/pod-web/src/contracts.test.ts
@@ -19,7 +19,8 @@ import {
   parseTickTelemetryEnvelope,
   summarizeAgentTickRollup,
   summarizeAgentToolCallEvent,
-  summarizeReplayFile
+  summarizeReplayFile,
+  withInteractionMarkers
 } from "./contracts";
 
 function entityMetadata(kind: string, overrides: Record<string, unknown> = {}) {
@@ -820,6 +821,100 @@ describe("TOON contract parsing", () => {
     );
     expect(criticalRing?.instances[0]?.scale).toEqual([4.2, 4.2, 1]);
     expect(criticalRing?.instances[0]?.color).toEqual([1, 0.18, 0.16, 0.5]);
+  });
+
+  test("adds point-click and target selection markers without mutating the base frame", () => {
+    const target = {
+      id: 12,
+      position: [14, -6],
+      velocity: [0, 0],
+      rotation: 0,
+      health: 18,
+      maxHealth: 24,
+      movementSpeed: 4,
+      label: "Verdant Lynx",
+      metadata: typedEntityMetadata("WildCreature", {
+        actorPresentation: {
+          profileId: "lynx",
+          meshAssetId: "rift-beast",
+          materialPaletteId: "default",
+          animationSetId: "beast-stalker",
+          scaleMultiplier: 1,
+          footprintRadius: 1.2,
+          selectionRingScale: 2.8,
+          auraColor: [0, 0, 0, 0]
+        }
+      })
+    } satisfies NetworkWorldSnapshot["entities"][number];
+    const baseFrame = {
+      camera: {
+        x: 0,
+        y: 0,
+        zoom: 1,
+        rotation: 0.4,
+        viewportWidth: 1280,
+        viewportHeight: 720
+      },
+      backgroundColor: [0, 0, 0, 1],
+      environment: {
+        biomeId: "verdant-hollow",
+        skyColor: [0.64, 0.8, 0.98, 1],
+        fogColor: [0.72, 0.84, 0.78, 1],
+        fogNear: 30,
+        fogFar: 196,
+        ambientColor: [0.82, 0.92, 0.88],
+        ambientIntensity: 1.4,
+        sunColor: [1, 0.96, 0.84],
+        sunIntensity: 2.95,
+        sunDirection: [30, 48, 18],
+        fillColor: [0.48, 0.76, 0.94],
+        fillIntensity: 0.88,
+        fillDirection: [-18, 14, -10],
+        rimColor: [0.4, 0.88, 0.78],
+        rimIntensity: 8.5,
+        groundColor: [0.19, 0.33, 0.21, 1],
+        starfieldIntensity: 0.08
+      },
+      overlayCommands: [],
+      meshBatches: [],
+      spriteBatches: [],
+      hints: {
+        renderer: "three/webgpu",
+        preferredBackend: "webgpu",
+        fallbackBackend: "webgl2",
+        useInstancing: true,
+        sortMetric: "world-z",
+        sortOpaqueFrontToBack: true,
+        preserveInstanceOrder: true,
+        sortTransparentBackToFront: true,
+        transparentInstancingStrategy: "shared-sort-depth",
+        opaqueDepthWrite: true,
+        transparentDepthWrite: false,
+        maxPixelRatio: 2
+      }
+    } satisfies Parameters<typeof withInteractionMarkers>[0];
+
+    const decorated = withInteractionMarkers(baseFrame, {
+      moveTarget: [6, -4],
+      selectedTarget: target,
+      controlledEntity: 1
+    });
+
+    expect(baseFrame.spriteBatches).toHaveLength(0);
+    expect(decorated.spriteBatches).toHaveLength(2);
+    expect(
+      decorated.spriteBatches.some((batch) =>
+        batch.instances.some((instance) => instance.animationSetId === "destination-ring")
+      )
+    ).toBe(true);
+    expect(
+      decorated.spriteBatches.some((batch) =>
+        batch.instances.some(
+          (instance) =>
+            instance.animationSetId === "target-ring" && instance.sourceEntity === 12
+        )
+      )
+    ).toBe(true);
   });
 
   test("encodes browser direct-connect client messages with Rust enum tags", () => {

--- a/apps/pod-web/src/contracts.ts
+++ b/apps/pod-web/src/contracts.ts
@@ -2894,6 +2894,96 @@ export function buildAuthoritativeWorldFrame(
   };
 }
 
+export interface InteractionMarkerOptions {
+  moveTarget?: Vec2Tuple | null;
+  selectedTarget?: NetworkEntitySnapshot | null;
+  controlledEntity?: number | null;
+}
+
+export function withInteractionMarkers(
+  frame: ThreeJsWebGpuFrame,
+  options: InteractionMarkerOptions
+): ThreeJsWebGpuFrame {
+  const markers = new Array<ThreeJsSpriteBatch>();
+  const controlledEntity = options.controlledEntity ?? null;
+
+  if (options.moveTarget) {
+    const worldX = options.moveTarget[0] * WORLD_TO_RENDER_SCALE;
+    const worldZ = options.moveTarget[1] * WORLD_TO_RENDER_SCALE;
+    markers.push({
+      texture: "selection-ring",
+      frame: 0,
+      layer: 7,
+      billboard: false,
+      phase: "transparent",
+      sortDepth: worldZ,
+      renderOrder: 18,
+      transparent: true,
+      depthWrite: false,
+      depthTest: true,
+      instances: [
+        {
+          position: [worldX, sampleTerrainHeight(worldX, worldZ) + 0.05, worldZ],
+          rotation: GROUND_RING_ROTATION,
+          scale: [1.65, 1.65, 1],
+          color: [0.86, 0.96, 1, 0.24],
+          animationSetId: "destination-ring"
+        }
+      ]
+    });
+  }
+
+  if (options.selectedTarget && options.selectedTarget.id !== controlledEntity) {
+    const target = options.selectedTarget;
+    const worldX = target.position[0] * WORLD_TO_RENDER_SCALE;
+    const worldZ = target.position[1] * WORLD_TO_RENDER_SCALE;
+    const interaction = target.metadata.interaction;
+    const scale = target.metadata.actorPresentation?.selectionRingScale ?? 2.4;
+    const useDangerRing = interaction.canAttack;
+    const color: RgbaTuple = interaction.canCapture
+      ? [0.46, 0.96, 0.72, 0.34]
+      : interaction.canGather
+        ? [0.94, 0.78, 0.36, 0.32]
+        : interaction.canAttack
+          ? [1, 0.38, 0.32, 0.34]
+          : interaction.canInteract
+            ? [0.54, 0.88, 1, 0.28]
+            : [0.76, 0.86, 1, 0.24];
+    markers.push({
+      texture: useDangerRing ? "danger-ring" : "selection-ring",
+      frame: 0,
+      layer: 8,
+      billboard: false,
+      phase: "transparent",
+      sortDepth: worldZ,
+      renderOrder: 22,
+      transparent: true,
+      depthWrite: false,
+      depthTest: true,
+      instances: [
+        {
+          position: [worldX, sampleTerrainHeight(worldX, worldZ) + 0.07, worldZ],
+          rotation: GROUND_RING_ROTATION,
+          scale: [scale * 1.08, scale * 1.08, 1],
+          color,
+          sourceEntity: target.id,
+          animationSetId: "target-ring",
+          healthRatio: healthRatio(target)
+        }
+      ]
+    });
+  }
+
+  if (markers.length === 0) {
+    return frame;
+  }
+
+  return {
+    ...frame,
+    spriteBatches: [...frame.spriteBatches, ...markers]
+  };
+}
+
 export function legacyFrameToThreeJsFrame(frame: RenderFrame): ThreeJsWebGpuFrame {
   return {
     camera: frame.camera,

--- a/apps/pod-web/src/main.ts
+++ b/apps/pod-web/src/main.ts
@@ -15,6 +15,7 @@ import {
   summarizeAgentTickRollup,
   summarizeAgentToolCallEvent,
   summarizeReplayFile,
+  withInteractionMarkers,
   type ThreeJsWebGpuFrame,
   type TickRollupSummary,
   type ToolCallEventSummary,
@@ -451,6 +452,7 @@ function currentCameraYaw(): number {
 function renderableThreeFrame(baseFrame: ThreeJsWebGpuFrame): ThreeJsWebGpuFrame {
   syncCameraRig(baseFrame.camera);
   const controlled = controlledEntity();
+  const target = selectedTarget();
   const speed = controlled
     ? Math.hypot(controlled.velocity[0], controlled.velocity[1])
     : 0;
@@ -460,7 +462,8 @@ function renderableThreeFrame(baseFrame: ThreeJsWebGpuFrame): ThreeJsWebGpuFrame
   const leadY =
     controlled && speed > 0.05 ? (controlled.velocity[1] / speed) * leadDistance : 0;
 
-  return {
+  return withInteractionMarkers(
+    {
     ...baseFrame,
     camera: {
       ...baseFrame.camera,
@@ -473,7 +476,13 @@ function renderableThreeFrame(baseFrame: ThreeJsWebGpuFrame): ThreeJsWebGpuFrame
       leadX,
       leadY
     }
-  };
+    },
+    {
+      moveTarget: clickMoveTarget,
+      selectedTarget: target,
+      controlledEntity: liveConnectionStatus?.controlledEntity ?? null
+    }
+  );
 }
 
 function selectedTarget(): NetworkEntitySnapshot | null {


### PR DESCRIPTION
## Summary
- add pure frame decoration helpers for click-to-move and selected-target markers
- render point-click and target affordances directly into the world instead of only the HUD
- keep the marker path deterministic and covered by contract tests

## Validation
- cd apps/pod-web && bun test ./src/contracts.test.ts ./src/frame-plan.test.ts ./src/render-runtime.test.ts ./src/renderer.test.ts
- cd apps/pod-web && bun run typecheck
- cd apps/pod-web && bun run build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive visual markers to improve tactical awareness during gameplay.
  * Destination rings now appear when navigating to target locations.
  * Target selection indicators display with color-coded rings representing available interactions: capture, gather, attack, or interact.
  * Health information now visible on selected targets for better strategic decision-making.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->