### PR TITLE
Stabilize pod-web gameplay input surface

### DIFF
--- a/apps/pod-web/src/controls.test.ts
+++ b/apps/pod-web/src/controls.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, test } from "bun:test";
 import type { CameraState, NetworkEntitySnapshot } from "./contracts";
 import {
   cameraRelativeMovementDirection,
+  focusGameplaySurface,
+  isGameplayKeyCode,
   pickWorldGroundPoint,
   resolvePointerTarget
 } from "./controls";
@@ -89,6 +91,33 @@ describe("pod-web controls", () => {
     const rotatedForward = cameraRelativeMovementDirection(["KeyW"], Math.PI / 2);
     expect(rotatedForward?.[0]).toBeCloseTo(-1, 6);
     expect(rotatedForward?.[1]).toBeCloseTo(0, 6);
+  });
+
+  test("identifies gameplay hotkeys and movement keys", () => {
+    expect(isGameplayKeyCode("KeyW")).toBe(true);
+    expect(isGameplayKeyCode("KeyE")).toBe(true);
+    expect(isGameplayKeyCode("Tab")).toBe(true);
+    expect(isGameplayKeyCode("Escape")).toBe(false);
+    expect(isGameplayKeyCode("ShiftLeft")).toBe(false);
+  });
+
+  test("focuses and labels the gameplay surface", () => {
+    let focused = false;
+    const surface = {
+      tabIndex: -1,
+      focus() {
+        focused = true;
+      },
+      setAttribute(name: string, value: string) {
+        if (name === "aria-label") {
+          expect(value).toBe("Game world");
+        }
+      }
+    };
+
+    expect(focusGameplaySurface(surface)).toBe(true);
+    expect(surface.tabIndex).toBe(0);
+    expect(focused).toBe(true);
   });
 
   test("projects a center-screen click onto the ground near the camera focus", () => {

--- a/apps/pod-web/src/controls.ts
+++ b/apps/pod-web/src/controls.ts
@@ -4,6 +4,12 @@ import type { CameraState, NetworkEntitySnapshot, Vec2Tuple } from "./contracts"
 import { buildCameraPose } from "./frame-plan";
 import { sampleTerrainHeight } from "./landscape";
 
+export interface GameplaySurface {
+  tabIndex?: number;
+  focus?: (options?: { preventScroll?: boolean }) => void;
+  setAttribute?: (name: string, value: string) => void;
+}
+
 function normalizeDirection(x: number, y: number): Vec2Tuple | null {
   const length = Math.hypot(x, y);
   if (length <= Number.EPSILON) {
@@ -38,6 +44,47 @@ export function cameraRelativeMovementDirection(
     forwardX * forwardIntent + rightX * strafeIntent,
     forwardY * forwardIntent + rightY * strafeIntent
   );
+}
+
+export function isGameplayKeyCode(code: string): boolean {
+  return (
+    code === "Tab" ||
+    code === "Space" ||
+    code === "Enter" ||
+    code === "KeyE" ||
+    code === "KeyG" ||
+    code === "KeyR" ||
+    code === "KeyC" ||
+    code === "KeyF" ||
+    code === "KeyP" ||
+    code === "Digit1" ||
+    code === "KeyW" ||
+    code === "KeyA" ||
+    code === "KeyS" ||
+    code === "KeyD" ||
+    code === "ArrowUp" ||
+    code === "ArrowDown" ||
+    code === "ArrowLeft" ||
+    code === "ArrowRight"
+  );
+}
+
+export function focusGameplaySurface(surface: GameplaySurface | null | undefined): boolean {
+  if (!surface) {
+    return false;
+  }
+
+  if (typeof surface.tabIndex === "number" && surface.tabIndex < 0) {
+    surface.tabIndex = 0;
+  }
+  surface.setAttribute?.("aria-label", "Game world");
+
+  if (typeof surface.focus === "function") {
+    surface.focus({ preventScroll: true });
+    return true;
+  }
+
+  return false;
 }
 
 export function pickWorldGroundPoint(

--- a/apps/pod-web/src/main.ts
+++ b/apps/pod-web/src/main.ts
@@ -28,6 +28,8 @@ import {
 } from "./affordances";
 import {
   cameraRelativeMovementDirection,
+  focusGameplaySurface,
+  isGameplayKeyCode,
   pickWorldGroundPoint,
   resolvePointerTarget
 } from "./controls";
@@ -158,6 +160,7 @@ if (
 
 const telemetryToggleButton = telemetryToggle;
 const renderCanvas = canvas;
+focusGameplaySurface(renderCanvas);
 const frameSourceNode = frameSourceLabel;
 const connectionNode = connectionLabel;
 const worldNode = worldLabel;
@@ -682,7 +685,7 @@ function submitTargetedAction(
   submitActions([actionBuilder(target)]);
 }
 
-window.addEventListener("keydown", (event) => {
+function handleGameplayKeyDown(event: KeyboardEvent): void {
   if (isEditableTarget(event.target)) {
     return;
   }
@@ -740,10 +743,40 @@ window.addEventListener("keydown", (event) => {
   if (event.code.startsWith("Key") || event.code.startsWith("Arrow")) {
     pressedKeys.add(event.code);
   }
+}
+
+function handleGameplayKeyUp(event: KeyboardEvent): void {
+  pressedKeys.delete(event.code);
+}
+
+window.addEventListener("keydown", (event) => {
+  if (event.target === renderCanvas) {
+    return;
+  }
+  handleGameplayKeyDown(event);
 });
 
 window.addEventListener("keyup", (event) => {
-  pressedKeys.delete(event.code);
+  if (event.target === renderCanvas) {
+    return;
+  }
+  handleGameplayKeyUp(event);
+});
+
+renderCanvas.addEventListener("keydown", (event) => {
+  if (!isGameplayKeyCode(event.code)) {
+    return;
+  }
+  handleGameplayKeyDown(event);
+  event.stopPropagation();
+});
+
+renderCanvas.addEventListener("keyup", (event) => {
+  if (!isGameplayKeyCode(event.code)) {
+    return;
+  }
+  handleGameplayKeyUp(event);
+  event.stopPropagation();
 });
 
 chatFormNode.addEventListener("submit", (event) => {
@@ -765,6 +798,7 @@ chatFormNode.addEventListener("submit", (event) => {
 });
 
 renderCanvas.addEventListener("pointerdown", (event) => {
+  focusGameplaySurface(renderCanvas);
   if (event.button === 2) {
     orbitPointerId = event.pointerId;
     orbitPointer = [event.clientX, event.clientY];
@@ -843,6 +877,7 @@ renderCanvas.addEventListener("pointercancel", (event) => {
 });
 
 renderCanvas.addEventListener("wheel", (event) => {
+  focusGameplaySurface(renderCanvas);
   cameraRig.desiredZoom = Math.max(
     0.72,
     Math.min(1.65, cameraRig.desiredZoom - event.deltaY * 0.0009)


### PR DESCRIPTION
## Summary
- make the world canvas an explicit gameplay input surface with focus ownership
- route gameplay keys through shared handlers on both window and the canvas surface
- add deterministic controls coverage for key classification and gameplay-surface focus behavior

## Validation
- cd apps/pod-web && bun test ./src/controls.test.ts ./src/contracts.test.ts ./src/frame-plan.test.ts ./src/render-runtime.test.ts ./src/renderer.test.ts
- cd apps/pod-web && bun run typecheck
- cd apps/pod-web && bun run build
- Playwright smoke on http://127.0.0.1:4176/?renderThread=worker

## Note
This improves real input-surface ownership, but Playwright MCP still did not emit keyboard events into the worker route during live smoke, so that harness-level gap still needs deeper investigation.
