### PR TITLE
Add pod-web click path preview

### DIFF
--- a/apps/pod-web/src/contracts.test.ts
+++ b/apps/pod-web/src/contracts.test.ts
@@ -897,16 +897,31 @@ describe("TOON contract parsing", () => {
     const decorated = withInteractionMarkers(baseFrame, {
       moveTarget: [6, -4],
       selectedTarget: target,
-      controlledEntity: 1
+      controlledEntity: 1,
+      controlledSnapshot: {
+        id: 1,
+        position: [0, 0],
+        velocity: [0, 0],
+        rotation: 0,
+        health: 24,
+        maxHealth: 24,
+        movementSpeed: 4,
+        label: "WebPlayer",
+        metadata: typedEntityMetadata("Player", {})
+      }
     });
 
     expect(baseFrame.spriteBatches).toHaveLength(0);
-    expect(decorated.spriteBatches).toHaveLength(2);
+    expect(decorated.spriteBatches).toHaveLength(3);
     expect(
       decorated.spriteBatches.some((batch) =>
         batch.instances.some((instance) => instance.animationSetId === "destination-ring")
       )
     ).toBe(true);
+    const pathBatch = decorated.spriteBatches.find((batch) =>
+      batch.instances.some((instance) => instance.animationSetId === "path-node")
+    );
+    expect(pathBatch?.instances.length).toBeGreaterThanOrEqual(2);
     expect(
       decorated.spriteBatches.some((batch) =>
         batch.instances.some(

--- a/apps/pod-web/src/contracts.ts
+++ b/apps/pod-web/src/contracts.ts
@@ -2898,6 +2898,7 @@ export interface InteractionMarkerOptions {
   moveTarget?: Vec2Tuple | null;
   selectedTarget?: NetworkEntitySnapshot | null;
   controlledEntity?: number | null;
+  controlledSnapshot?: NetworkEntitySnapshot | null;
 }
 
 export function withInteractionMarkers(
@@ -2931,6 +2932,42 @@ export function withInteractionMarkers(
         }
       ]
     });
+
+    const moveOrigin = options.controlledSnapshot?.position ?? null;
+    if (moveOrigin) {
+      const deltaX = options.moveTarget[0] - moveOrigin[0];
+      const deltaY = options.moveTarget[1] - moveOrigin[1];
+      const distance = Math.hypot(deltaX, deltaY);
+      const breadcrumbCount = Math.min(4, Math.max(0, Math.floor(distance / 3.4)));
+
+      if (breadcrumbCount > 0) {
+        markers.push({
+          texture: "mist-ring",
+          frame: 0,
+          layer: 6,
+          billboard: false,
+          phase: "transparent",
+          sortDepth: worldZ,
+          renderOrder: 17,
+          transparent: true,
+          depthWrite: false,
+          depthTest: true,
+          instances: Array.from({ length: breadcrumbCount }, (_, index) => {
+            const t = (index + 1) / (breadcrumbCount + 1);
+            const pathX = (moveOrigin[0] + deltaX * t) * WORLD_TO_RENDER_SCALE;
+            const pathZ = (moveOrigin[1] + deltaY * t) * WORLD_TO_RENDER_SCALE;
+            const scale = 0.74 + index * 0.08;
+            return {
+              position: [pathX, sampleTerrainHeight(pathX, pathZ) + 0.04, pathZ],
+              rotation: GROUND_RING_ROTATION,
+              scale: [scale, scale, 1],
+              color: [0.72, 0.92, 1, 0.12 + index * 0.03],
+              animationSetId: "path-node"
+            };
+          })
+        });
+      }
+    }
   }
 
   if (options.selectedTarget && options.selectedTarget.id !== controlledEntity) {

--- a/apps/pod-web/src/main.ts
+++ b/apps/pod-web/src/main.ts
@@ -483,7 +483,8 @@ function renderableThreeFrame(baseFrame: ThreeJsWebGpuFrame): ThreeJsWebGpuFrame
     {
       moveTarget: clickMoveTarget,
       selectedTarget: target,
-      controlledEntity: liveConnectionStatus?.controlledEntity ?? null
+      controlledEntity: liveConnectionStatus?.controlledEntity ?? null,
+      controlledSnapshot: controlled
     }
   );
 }


### PR DESCRIPTION
## Summary
- extend the interaction-marker helper with click-move breadcrumb rings between the player and destination
- keep the breadcrumbs inside the shared authoritative frame decoration path instead of a separate HUD effect
- cover the new path-preview behavior in contract tests

## Validation
- cd apps/pod-web && bun test ./src/contracts.test.ts ./src/controls.test.ts ./src/frame-plan.test.ts ./src/render-runtime.test.ts ./src/renderer.test.ts
- cd apps/pod-web && bun run typecheck
- cd apps/pod-web && bun run build
