### PR TITLE
Add pod-web world event markers

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -896,5 +896,26 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cd apps/pod-web && bun run build`
   - `git diff --check`
 
-**Last updated**: Iteration 90
-**Current focus**: Iteration 91 character animation, combat feedback, and replacing the remaining debug-sandbox feel with authored traversal and encounter presentation
+### Iteration 91
+- [x] Added deterministic ambient chunk dressing for `pod-web`, driven from streamed visible/preloaded chunk keys instead of hand-placed demo clutter, so the flagship shard now fills warm regions with terrain-aware trees, boulders, basalt columns, and spires.
+- [x] Reused the existing chunk planner and asset residency pipeline to prewarm ambient chunk meshes before they come on screen, keeping density improvements aligned with the streamed-world runtime instead of bypassing it.
+- [x] Surfaced ambient instance counts in the runtime HUD/stats path and validated live in Playwright that the shard now renders with denser chunk presentation on WebGPU while keeping asset residency stable and pending counts at zero after warm-up.
+- [x] Added deterministic coverage for ambient planner determinism, lagoon/hub exclusion, and prewarm request generation.
+- [x] Validated touched targets:
+  - `cd apps/pod-web && bun test ./src/frame-plan.test.ts ./src/renderer.test.ts ./src/contracts.test.ts ./src/render-runtime.test.ts ./src/controls.test.ts`
+  - `cd apps/pod-web && bun run typecheck`
+  - `cd apps/pod-web && bun run build`
+  - `git diff --check`
+
+### Iteration 92
+- [x] Added browser-side world-event marker decoration in `pod-web`, so recent authoritative combat, gather, loot, capture, and summon events now render as short-lived world-space markers instead of only appearing in HUD text and event feed logs.
+- [x] Kept the marker path inside the shared frame-decoration layer by composing it after interaction markers and before renderer submission, using current snapshot tick age and authoritative event origins/entity positions instead of browser-only heuristics.
+- [x] Added deterministic coverage for recent-event filtering, origin/entity fallback positioning, and marker-style decoration without mutating the base Three.js frame contract.
+- [x] Validated touched targets:
+  - `cd apps/pod-web && bun test ./src/contracts.test.ts ./src/renderer.test.ts ./src/frame-plan.test.ts ./src/controls.test.ts ./src/render-runtime.test.ts`
+  - `cd apps/pod-web && bun run typecheck`
+  - `cd apps/pod-web && bun run build`
+  - `git diff --check`
+
+**Last updated**: Iteration 92
+**Current focus**: Iteration 93 richer authored traversal/combat presentation, including stronger animation-set differentiation, encounter readability, and worker-route gameplay-input parity proof

--- a/apps/pod-web/src/contracts.test.ts
+++ b/apps/pod-web/src/contracts.test.ts
@@ -20,7 +20,8 @@ import {
   summarizeAgentTickRollup,
   summarizeAgentToolCallEvent,
   summarizeReplayFile,
-  withInteractionMarkers
+  withInteractionMarkers,
+  withWorldEventMarkers
 } from "./contracts";
 
 function entityMetadata(kind: string, overrides: Record<string, unknown> = {}) {
@@ -928,6 +929,117 @@ describe("TOON contract parsing", () => {
           (instance) =>
             instance.animationSetId === "target-ring" && instance.sourceEntity === 12
         )
+      )
+    ).toBe(true);
+  });
+
+  test("adds recent world-event markers without mutating the base frame", () => {
+    const baseFrame = {
+      camera: {
+        x: 0,
+        y: 0,
+        zoom: 1,
+        rotation: 0,
+        viewportWidth: 1280,
+        viewportHeight: 720
+      },
+      backgroundColor: [0, 0, 0, 1],
+      environment: {
+        biomeId: "verdant-hollow",
+        skyColor: [0.64, 0.8, 0.98, 1],
+        fogColor: [0.72, 0.84, 0.78, 1],
+        fogNear: 30,
+        fogFar: 196,
+        ambientColor: [0.82, 0.92, 0.88],
+        ambientIntensity: 1.4,
+        sunColor: [1, 0.96, 0.84],
+        sunIntensity: 2.95,
+        sunDirection: [30, 48, 18],
+        fillColor: [0.48, 0.76, 0.94],
+        fillIntensity: 0.88,
+        fillDirection: [-18, 14, -10],
+        rimColor: [0.4, 0.88, 0.78],
+        rimIntensity: 8.5,
+        groundColor: [0.19, 0.33, 0.21, 1],
+        starfieldIntensity: 0.08
+      },
+      overlayCommands: [],
+      meshBatches: [],
+      spriteBatches: [],
+      hints: {
+        renderer: "three/webgpu",
+        preferredBackend: "webgpu",
+        fallbackBackend: "webgl2",
+        useInstancing: true,
+        sortMetric: "world-z",
+        sortOpaqueFrontToBack: true,
+        preserveInstanceOrder: true,
+        sortTransparentBackToFront: true,
+        transparentInstancingStrategy: "shared-sort-depth",
+        opaqueDepthWrite: true,
+        transparentDepthWrite: false,
+        maxPixelRatio: 2
+      }
+    } satisfies Parameters<typeof withWorldEventMarkers>[0];
+
+    const decorated = withWorldEventMarkers(baseFrame, {
+      currentTick: 125,
+      worldSnapshot: {
+        tick: 125,
+        entities: [
+          {
+            id: 12,
+            position: [10, -6],
+            velocity: [0, 0],
+            rotation: 0,
+            health: 20,
+            maxHealth: 30,
+            movementSpeed: 4,
+            label: "Rift Beast",
+            metadata: typedEntityMetadata("WildCreature", {})
+          }
+        ],
+        population: {
+          tick: 125,
+          chunks: [],
+          regions: []
+        }
+      },
+      events: [
+        {
+          tick: 123,
+          origin: [8, -4],
+          kind: "DamageApplied",
+          summary: "Rift Beast takes 4 damage",
+          entityIds: [12]
+        },
+        {
+          tick: 124,
+          origin: null,
+          kind: "LootOpened",
+          summary: "Supply crate opened",
+          entityIds: [12]
+        },
+        {
+          tick: 108,
+          origin: [0, 0],
+          kind: "OldEvent",
+          summary: "This one should age out",
+          entityIds: [12]
+        }
+      ]
+    });
+
+    expect(baseFrame.spriteBatches).toHaveLength(0);
+    expect(decorated.spriteBatches).toHaveLength(2);
+    expect(
+      decorated.spriteBatches.some((batch) =>
+        batch.instances.some((instance) => instance.animationSetId === "critical-ring")
+      )
+    ).toBe(true);
+    expect(
+      decorated.spriteBatches.some((batch) =>
+        batch.instances.some((instance) => instance.animationSetId === "destination-ring")
       )
     ).toBe(true);
   });

--- a/apps/pod-web/src/contracts.ts
+++ b/apps/pod-web/src/contracts.ts
@@ -2901,6 +2901,12 @@ export interface InteractionMarkerOptions {
   controlledSnapshot?: NetworkEntitySnapshot | null;
 }
 
+export interface WorldEventMarkerOptions {
+  events: NetworkGameEvent[];
+  worldSnapshot?: NetworkWorldSnapshot | null;
+  currentTick?: number | null;
+}
+
 export function withInteractionMarkers(
   frame: ThreeJsWebGpuFrame,
   options: InteractionMarkerOptions
@@ -3021,6 +3027,67 @@ export function withInteractionMarkers(
   };
 }
 
+export function withWorldEventMarkers(
+  frame: ThreeJsWebGpuFrame,
+  options: WorldEventMarkerOptions
+): ThreeJsWebGpuFrame {
+  if (options.events.length === 0) {
+    return frame;
+  }
+
+  const currentTick = options.currentTick ?? options.worldSnapshot?.tick ?? null;
+  const markers = new Array<ThreeJsSpriteBatch>();
+
+  for (const event of options.events) {
+    if (currentTick != null && currentTick - event.tick > 12) {
+      continue;
+    }
+
+    const position = resolveEventMarkerPosition(event, options.worldSnapshot);
+    if (!position) {
+      continue;
+    }
+
+    const ageTicks = currentTick == null ? 0 : Math.max(0, currentTick - event.tick);
+    const ageFade = clamp01(1 - ageTicks / 12);
+    const markerStyle = eventMarkerStyle(event.kind, ageFade);
+    markers.push({
+      texture: markerStyle.texture,
+      frame: 0,
+      layer: markerStyle.layer,
+      billboard: false,
+      phase: "transparent",
+      sortDepth: position[1],
+      renderOrder: markerStyle.renderOrder,
+      transparent: true,
+      depthWrite: false,
+      depthTest: true,
+      instances: [
+        {
+          position: [
+            position[0],
+            sampleTerrainHeight(position[0], position[1]) + markerStyle.height,
+            position[1]
+          ],
+          rotation: GROUND_RING_ROTATION,
+          scale: [markerStyle.scale, markerStyle.scale, 1],
+          color: markerStyle.color,
+          animationSetId: markerStyle.animationSetId
+        }
+      ]
+    });
+  }
+
+  if (markers.length === 0) {
+    return frame;
+  }
+
+  return {
+    ...frame,
+    spriteBatches: [...frame.spriteBatches, ...markers]
+  };
+}
+
 export function legacyFrameToThreeJsFrame(frame: RenderFrame): ThreeJsWebGpuFrame {
   return {
     camera: frame.camera,
@@ -3031,4 +3098,95 @@ export function legacyFrameToThreeJsFrame(frame: RenderFrame): ThreeJsWebGpuFram
     spriteBatches: [],
     hints: defaultFrameHints()
   };
+}
+
+function resolveEventMarkerPosition(
+  event: NetworkGameEvent,
+  worldSnapshot: NetworkWorldSnapshot | null | undefined
+): Vec2Tuple | null {
+  if (event.origin) {
+    return [event.origin[0] * WORLD_TO_RENDER_SCALE, event.origin[1] * WORLD_TO_RENDER_SCALE];
+  }
+
+  const entityPosition =
+    worldSnapshot?.entities.find((entity) => event.entityIds.includes(entity.id))?.position ?? null;
+  if (!entityPosition) {
+    return null;
+  }
+
+  return [
+    entityPosition[0] * WORLD_TO_RENDER_SCALE,
+    entityPosition[1] * WORLD_TO_RENDER_SCALE
+  ];
+}
+
+function eventMarkerStyle(kind: string, ageFade: number): {
+  texture: ThreeJsSpriteBatch["texture"];
+  animationSetId: string;
+  renderOrder: number;
+  layer: number;
+  scale: number;
+  height: number;
+  color: RgbaTuple;
+} {
+  const normalized = kind.toLowerCase();
+
+  if (
+    normalized.includes("damage") ||
+    normalized.includes("attack") ||
+    normalized.includes("hit") ||
+    normalized.includes("defeat")
+  ) {
+    return {
+      texture: "danger-ring",
+      animationSetId: "critical-ring",
+      renderOrder: 23,
+      layer: 9,
+      scale: 1.55 + ageFade * 0.32,
+      height: 0.09,
+      color: [1, 0.42, 0.34, 0.18 + ageFade * 0.28]
+    };
+  }
+
+  if (
+    normalized.includes("capture") ||
+    normalized.includes("summon") ||
+    normalized.includes("command")
+  ) {
+    return {
+      texture: "selection-ring",
+      animationSetId: "aura-ring",
+      renderOrder: 22,
+      layer: 9,
+      scale: 1.4 + ageFade * 0.26,
+      height: 0.08,
+      color: [0.48, 0.96, 0.78, 0.16 + ageFade * 0.24]
+    };
+  }
+
+  if (normalized.includes("loot") || normalized.includes("gather")) {
+    return {
+      texture: "selection-ring",
+      animationSetId: "destination-ring",
+      renderOrder: 21,
+      layer: 8,
+      scale: 1.22 + ageFade * 0.22,
+      height: 0.07,
+      color: [0.98, 0.84, 0.36, 0.14 + ageFade * 0.2]
+    };
+  }
+
+  return {
+    texture: "mist-ring",
+    animationSetId: "path-node",
+    renderOrder: 20,
+    layer: 8,
+    scale: 0.96 + ageFade * 0.18,
+    height: 0.06,
+    color: [0.7, 0.9, 1, 0.12 + ageFade * 0.16]
+  };
+}
+
+function clamp01(value: number): number {
+  return Math.min(Math.max(value, 0), 1);
 }

--- a/apps/pod-web/src/main.ts
+++ b/apps/pod-web/src/main.ts
@@ -16,6 +16,7 @@ import {
   summarizeAgentToolCallEvent,
   summarizeReplayFile,
   withInteractionMarkers,
+  withWorldEventMarkers,
   type ThreeJsWebGpuFrame,
   type TickRollupSummary,
   type ToolCallEventSummary,
@@ -465,20 +466,20 @@ function renderableThreeFrame(baseFrame: ThreeJsWebGpuFrame): ThreeJsWebGpuFrame
   const leadY =
     controlled && speed > 0.05 ? (controlled.velocity[1] / speed) * leadDistance : 0;
 
-  return withInteractionMarkers(
+  const interactionFrame = withInteractionMarkers(
     {
-    ...baseFrame,
-    camera: {
-      ...baseFrame.camera,
-      rotation: cameraRig.yaw,
-      pitch: cameraRig.pitch,
-      zoom: cameraRig.zoom,
-      focusHeight: baseFrame.camera.focusHeight ?? 2.2,
-      followDistance: baseFrame.camera.followDistance ?? 13.5,
-      shoulderOffset: baseFrame.camera.shoulderOffset ?? 0.9,
-      leadX,
-      leadY
-    }
+      ...baseFrame,
+      camera: {
+        ...baseFrame.camera,
+        rotation: cameraRig.yaw,
+        pitch: cameraRig.pitch,
+        zoom: cameraRig.zoom,
+        focusHeight: baseFrame.camera.focusHeight ?? 2.2,
+        followDistance: baseFrame.camera.followDistance ?? 13.5,
+        shoulderOffset: baseFrame.camera.shoulderOffset ?? 0.9,
+        leadX,
+        leadY
+      }
     },
     {
       moveTarget: clickMoveTarget,
@@ -487,6 +488,12 @@ function renderableThreeFrame(baseFrame: ThreeJsWebGpuFrame): ThreeJsWebGpuFrame
       controlledSnapshot: controlled
     }
   );
+
+  return withWorldEventMarkers(interactionFrame, {
+    events: recentWorldEvents,
+    worldSnapshot: latestSnapshot,
+    currentTick: latestSnapshot?.tick ?? null
+  });
 }
 
 function selectedTarget(): NetworkEntitySnapshot | null {

--- a/progress.md
+++ b/progress.md
@@ -15,3 +15,4 @@ Original prompt: its the graphics and the worlds scene, everything is piled up o
 - Fixed the timelapse boot state so the world now starts in readable daylight instead of sometimes loading into near-night on first paint.
 - Added deterministic ambient chunk dressing driven by streamed chunk keys instead of hand-placed demo clutter: trees, boulders, basalt columns, and spires now populate visible/warm regions without overlapping the lagoon or central hub.
 - Verified live in Playwright that the flagship sandbox now renders with ambient density on WebGPU (`ambient 14`, `117277 tris`, `14 resident assets`, `0 pending`) while staying in daylight and loading cleanly.
+- Added browser-side world-event markers driven from authoritative shard events, so combat/action outcomes now decorate the scene in world space instead of only appearing as HUD text.


### PR DESCRIPTION
## Summary
- add authoritative world-event marker decoration to the browser shard so recent combat and action outcomes render in world space
- update the browser flagship plan/progress tracking with the shipped ambient-density and event-marker slices
- cover the new frame decoration path with deterministic contract tests

## Testing
- cd apps/pod-web && bun test ./src/contracts.test.ts ./src/renderer.test.ts ./src/frame-plan.test.ts ./src/controls.test.ts ./src/render-runtime.test.ts
- cd apps/pod-web && bun run typecheck
- cd apps/pod-web && bun run build