### PR TITLE
Differentiate pod-web animation sets

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -917,5 +917,15 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cd apps/pod-web && bun run build`
   - `git diff --check`
 
-**Last updated**: Iteration 92
-**Current focus**: Iteration 93 richer authored traversal/combat presentation, including stronger animation-set differentiation, encounter readability, and worker-route gameplay-input parity proof
+### Iteration 93
+- [x] Differentiated `pod-web` animation-set sampling so critical rings, target markers, destination breadcrumbs, companions, beasts, idle humanoids, and moving humanoids no longer share the same subtle debug wobble profile.
+- [x] Added stronger stance/readability cues directly in `sampleAnimatedInstanceTransform(...)`, including critical-ring urgency, companion hover drift, beast crouch/stalk motion, and calmer idle humanoid breathing versus travel gait.
+- [x] Added deterministic Bun coverage for ring differentiation and beast-versus-humanoid stance/motion separation so this presentation pass stays locked instead of regressing into one generic animation profile.
+- [x] Validated touched targets:
+  - `cd apps/pod-web && bun test ./src/frame-plan.test.ts ./src/contracts.test.ts ./src/renderer.test.ts ./src/controls.test.ts ./src/render-runtime.test.ts`
+  - `cd apps/pod-web && bun run typecheck`
+  - `cd apps/pod-web && bun run build`
+  - `git diff --check`
+
+**Last updated**: Iteration 93
+**Current focus**: Iteration 94 worker-route gameplay-input parity proof, then richer authored traversal/combat presentation on top of the differentiated actor motion pass

--- a/apps/pod-web/src/frame-plan.test.ts
+++ b/apps/pod-web/src/frame-plan.test.ts
@@ -526,6 +526,63 @@ describe("sampleAnimatedInstanceTransform", () => {
     expect(hoveringCompanion.scale[1]).not.toBeCloseTo(1.2, 4);
   });
 
+  test("differentiates critical rings from destination markers", () => {
+    const criticalRing = sampleAnimatedInstanceTransform(
+      {
+        position: [4, 0.15, -3],
+        rotation: [0, 0, 0, 1],
+        scale: [1, 1, 1],
+        sourceEntity: 0,
+        animationSetId: "critical-ring",
+        motionSpeed: 0
+      },
+      0.3
+    );
+    const destinationRing = sampleAnimatedInstanceTransform(
+      {
+        position: [4, 0.15, -3],
+        rotation: [0, 0, 0, 1],
+        scale: [1, 1, 1],
+        sourceEntity: 0,
+        animationSetId: "destination-ring",
+        motionSpeed: 0
+      },
+      0.3
+    );
+
+    expect(criticalRing.scale[0]).toBeGreaterThan(destinationRing.scale[0]);
+    expect(criticalRing.position[1]).toBeGreaterThan(destinationRing.position[1]);
+  });
+
+  test("gives beasts a lower, heavier stance than humanoids", () => {
+    const beast = sampleAnimatedInstanceTransform(
+      {
+        position: [2, 1.6, 5],
+        rotation: [0, 0, 0, 1],
+        scale: [1.4, 1.4, 2],
+        sourceEntity: 5,
+        animationSetId: "rift-beast",
+        motionSpeed: 0.8
+      },
+      1.2
+    );
+    const humanoid = sampleAnimatedInstanceTransform(
+      {
+        position: [2, 1.6, 5],
+        rotation: [0, 0, 0, 1],
+        scale: [1.4, 1.4, 2],
+        sourceEntity: 5,
+        animationSetId: "hero-runescape",
+        motionSpeed: 0.8
+      },
+      1.2
+    );
+
+    expect(beast.scale[1]).toBeLessThan(humanoid.scale[1]);
+    expect(beast.scale[2]).toBeGreaterThan(humanoid.scale[2]);
+    expect(Math.abs(beast.rotation[1])).toBeGreaterThan(Math.abs(humanoid.rotation[1]));
+  });
+
   test("adds gait bounce and event pulse response to moving humanoids", () => {
     const neutral = sampleAnimatedInstanceTransform(
       {

--- a/apps/pod-web/src/frame-plan.ts
+++ b/apps/pod-web/src/frame-plan.ts
@@ -357,26 +357,81 @@ export function sampleAnimatedInstanceTransform(
   let scaleY = instance.scale[1];
   let scaleZ = instance.scale[2];
   let pitchOffset = 0;
+  let yawOffset = 0;
   let rollOffset = 0;
 
-  if (animationSetId.includes("ring")) {
+  if (animationSetId.includes("critical-ring")) {
+    const ringPulse = Math.abs(Math.sin(elapsedSeconds * 5.1 + phase));
+    const ringScale = 1.06 + ringPulse * 0.16;
+    scaleX *= ringScale;
+    scaleY *= ringScale;
+    yOffset += ringPulse * 0.04;
+  } else if (animationSetId.includes("target-ring")) {
+    const ringPulse = Math.sin(elapsedSeconds * 3.4 + phase);
+    const ringScale = 1.02 + Math.max(ringPulse, -0.1) * 0.09;
+    scaleX *= ringScale;
+    scaleY *= ringScale;
+    yOffset += Math.max(ringPulse, 0) * 0.025;
+  } else if (animationSetId.includes("destination-ring")) {
+    const ringPulse = Math.sin(elapsedSeconds * 2.8 + phase);
+    const ringScale = 0.98 + (ringPulse + 1) * 0.05;
+    scaleX *= ringScale;
+    scaleY *= ringScale;
+  } else if (animationSetId.includes("path-node")) {
+    const nodePulse = Math.sin(elapsedSeconds * 2.6 + phase);
+    const nodeScale = 0.98 + (nodePulse + 1) * 0.04;
+    scaleX *= nodeScale;
+    scaleY *= nodeScale;
+    yOffset += Math.max(nodePulse, 0) * 0.018;
+  } else if (animationSetId.includes("ring")) {
     const ringPulse = Math.sin(elapsedSeconds * 2.2 + phase);
     const ringScale = 1 + ringPulse * 0.045;
     scaleX *= ringScale;
     scaleY *= ringScale;
   } else if (animationSetId.includes("companion") || animationSetId.includes("hover")) {
-    yOffset += 0.18 + hoverWave * 0.14;
+    const driftWave = Math.sin(elapsedSeconds * 1.15 + phase * 0.6);
+    yOffset += 0.18 + hoverWave * 0.14 + driftWave * 0.03;
     scaleX *= 1 + hoverWave * 0.025;
     scaleY *= 1 - hoverWave * 0.05;
     scaleZ *= 1 + hoverWave * 0.025;
+    yawOffset += driftWave * 0.03;
     rollOffset += hoverWave * 0.045;
   } else if (animationSetId.includes("beast")) {
+    const stalk = Math.sin(elapsedSeconds * (1.4 + motion * 2.4) + phase * 0.8);
     const stomp = Math.abs(strideWave) * Math.max(0.2, motion);
-    yOffset += idleWave * 0.04 + stomp * 0.16;
-    scaleX *= 1 + stomp * 0.035;
-    scaleY *= 1 - stomp * 0.06;
-    scaleZ *= 1 + stomp * 0.035;
-    pitchOffset += strideWave * 0.04 * Math.max(motion, 0.25);
+    yOffset += idleWave * 0.03 + stomp * 0.16;
+    scaleX *= 1 + stomp * 0.04;
+    scaleY *= 0.94 - motion * 0.04;
+    scaleZ *= 1 + stomp * 0.05;
+    pitchOffset += strideWave * 0.05 * Math.max(motion, 0.25) - 0.03;
+    yawOffset += stalk * 0.028;
+    rollOffset += stalk * 0.03 * Math.max(motion, 0.3);
+  } else if (
+    animationSetId.includes("humanoid-idle") ||
+    animationSetId.includes("npc-idle") ||
+    animationSetId.includes("merchant-idle")
+  ) {
+    const breathWave = Math.sin(elapsedSeconds * 1.8 + phase);
+    yOffset += breathWave * 0.025;
+    scaleY *= 1 + breathWave * 0.015;
+    pitchOffset += breathWave * 0.01;
+    rollOffset += Math.cos(elapsedSeconds * 1.35 + phase) * 0.012;
+  } else if (
+    animationSetId.includes("humanoid") ||
+    animationSetId.includes("hero") ||
+    animationSetId.includes("explorer") ||
+    animationSetId.includes("runescape")
+  ) {
+    const gait = clamp(motion / 0.32, 0, 1);
+    const footfall = Math.abs(strideWave) * Math.max(0.16, gait);
+    const torsoWave = Math.sin(elapsedSeconds * (1.8 + motion * 3.4) + phase);
+    yOffset += idleWave * 0.02 + footfall * 0.14;
+    scaleX *= 1 + footfall * 0.014;
+    scaleY *= 1 - footfall * 0.035;
+    scaleZ *= 1 + footfall * 0.014;
+    pitchOffset += strideWave * 0.024 * Math.max(gait, 0.25) - gait * 0.018;
+    yawOffset += torsoWave * 0.014 * Math.max(gait, 0.35);
+    rollOffset += Math.sin(elapsedSeconds * 1.9 + phase) * 0.02 * Math.max(gait, 0.2);
   } else if (!animationSetId.includes("static")) {
     const gait = Math.abs(strideWave) * Math.max(0.18, motion);
     yOffset += idleWave * 0.03 + gait * 0.12;
@@ -384,6 +439,7 @@ export function sampleAnimatedInstanceTransform(
     scaleY *= 1 - gait * 0.04;
     scaleZ *= 1 + gait * 0.018;
     pitchOffset += strideWave * 0.028 * Math.max(motion, 0.2);
+    yawOffset += Math.sin(elapsedSeconds * 1.6 + phase) * 0.014 * Math.max(motion, 0.25);
     rollOffset += Math.sin(elapsedSeconds * 1.8 + phase) * 0.012;
   }
 
@@ -408,7 +464,7 @@ export function sampleAnimatedInstanceTransform(
 
   const baseRotation = new Quaternion(...instance.rotation);
   const animationRotation = new Quaternion().setFromEuler(
-    new Euler(pitchOffset, 0, rollOffset)
+    new Euler(pitchOffset, yawOffset, rollOffset)
   );
   const finalRotation = baseRotation.multiply(animationRotation);
 

--- a/progress.md
+++ b/progress.md
@@ -16,3 +16,4 @@ Original prompt: its the graphics and the worlds scene, everything is piled up o
 - Added deterministic ambient chunk dressing driven by streamed chunk keys instead of hand-placed demo clutter: trees, boulders, basalt columns, and spires now populate visible/warm regions without overlapping the lagoon or central hub.
 - Verified live in Playwright that the flagship sandbox now renders with ambient density on WebGPU (`ambient 14`, `117277 tris`, `14 resident assets`, `0 pending`) while staying in daylight and loading cleanly.
 - Added browser-side world-event markers driven from authoritative shard events, so combat/action outcomes now decorate the scene in world space instead of only appearing as HUD text.
+- Differentiated the browser animation sampler so critical rings, destination breadcrumbs, companions, beasts, idle humanoids, and moving humanoids each read with distinct motion cues instead of all sharing one generic wobble profile.


### PR DESCRIPTION
## Summary
- differentiate pod-web animation sampling for rings, companions, beasts, and humanoids
- add deterministic coverage for the stronger presentation cues
- update the implementation plan and progress log for iteration 93

## Testing
- cd apps/pod-web && bun test ./src/frame-plan.test.ts ./src/contracts.test.ts ./src/renderer.test.ts ./src/controls.test.ts ./src/render-runtime.test.ts
- cd apps/pod-web && bun run typecheck
- cd apps/pod-web && bun run build
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced animations with distinct visual cues for different entity types: critical rings, destination markers, beasts, companions, and humanoids now have differentiated motion behaviors.
  * Improved visual stance and readability for creatures versus humanoids, with beasts displaying heavier, lower movement profiles.

* **Tests**
  * Added test coverage for animation differentiation between entity types.

* **Documentation**
  * Updated implementation plan with latest iteration targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->