### PR TITLE
Fix pod-web boot shell state

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -927,5 +927,15 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cd apps/pod-web && bun run build`
   - `git diff --check`
 
-**Last updated**: Iteration 93
-**Current focus**: Iteration 94 worker-route gameplay-input parity proof, then richer authored traversal/combat presentation on top of the differentiated actor motion pass
+### Iteration 94
+- [x] Added a real `pod-web` boot-state model so the browser shard no longer flashes misleading `demo frame` / `offline demo` placeholders while the local sandbox or direct-connect client is still initializing.
+- [x] Applied that boot state both in the module bootstrap path and in an inline pre-module HTML script, so first paint matches the actual mode before the renderer and local world finish booting.
+- [x] Added deterministic Bun coverage for local-sandbox and direct-connect boot-state selection in `direct-connect.test.ts`.
+- [x] Validated touched targets:
+  - `cd apps/pod-web && bun test ./src/direct-connect.test.ts ./src/frame-plan.test.ts ./src/contracts.test.ts ./src/renderer.test.ts ./src/controls.test.ts ./src/render-runtime.test.ts`
+  - `cd apps/pod-web && bun run typecheck`
+  - `cd apps/pod-web && bun run build`
+  - `git diff --check`
+
+**Last updated**: Iteration 94
+**Current focus**: Iteration 95 worker-route gameplay-input parity proof, then richer traversal/combat feedback and less intrusive flagship HUD chrome

--- a/apps/pod-web/index.html
+++ b/apps/pod-web/index.html
@@ -295,17 +295,17 @@
         </div>
         <h1>Playable browser shard</h1>
         <p id="feedback-label">
-          Awaiting authoritative outcomes
+          Starting local browser shard
         </p>
         <div class="hud__badge-row">
-          <span class="hud__badge" id="connection-label">offline demo / bridge mode</span>
+          <span class="hud__badge" id="connection-label">local sandbox booting</span>
           <span class="hud__badge" id="quality-label">auto</span>
         </div>
         <div class="hud__stack">
           <div class="hud__card">
             <span class="hud__card-label">World</span>
-            <strong class="hud__card-value" id="world-label">demo scene</strong>
-            <span class="hud__card-meta" id="population-label">No authoritative population state yet</span>
+            <strong class="hud__card-value" id="world-label">booting Verdant Hollow</strong>
+            <span class="hud__card-meta" id="population-label">Seeding local region population</span>
           </div>
           <div class="hud__card">
             <span class="hud__card-label">Target</span>
@@ -333,7 +333,7 @@
           </div>
           <dl>
             <dt>Source</dt>
-            <dd id="frame-source">demo frame</dd>
+            <dd id="frame-source">bootstrapping local sandbox</dd>
             <dt>Stats</dt>
             <dd id="stats-label">warming up…</dd>
             <dt>Controls</dt>
@@ -377,6 +377,30 @@
         </dl>
       </section>
     </div>
+    <script>
+      (() => {
+        const params = new URLSearchParams(window.location.search);
+        const directConnect = params.has("ws") || params.has("server");
+        if (!directConnect) {
+          return;
+        }
+
+        const setText = (id, value) => {
+          const node = document.getElementById(id);
+          if (node) {
+            node.textContent = value;
+          }
+        };
+
+        const server = params.get("server");
+        const websocketUrl = params.get("ws") || (server ? (/^wss?:\/\//i.test(server) ? server : `ws://${server}`) : "authoritative shard");
+        setText("feedback-label", `Connecting to ${websocketUrl}`);
+        setText("connection-label", "connecting to shard");
+        setText("world-label", "waiting for shard snapshot");
+        setText("population-label", "Awaiting authoritative population state");
+        setText("frame-source", "bootstrapping direct-connect shard");
+      })();
+    </script>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/apps/pod-web/src/direct-connect.test.ts
+++ b/apps/pod-web/src/direct-connect.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
-import { PodWebDirectConnectClient, runtimeConfigFromLocation } from "./direct-connect";
+import {
+  initialHudStateFromLocation,
+  PodWebDirectConnectClient,
+  runtimeConfigFromLocation
+} from "./direct-connect";
 
 class MockWebSocket {
   static CONNECTING = 0;
@@ -67,6 +71,26 @@ describe("direct-connect runtime config", () => {
     } as Location);
 
     expect(config).toBeNull();
+  });
+
+  test("describes local sandbox boot state when no runtime config is present", () => {
+    const state = initialHudStateFromLocation({
+      search: ""
+    } as Location);
+
+    expect(state.connectionBadge).toBe("local sandbox booting");
+    expect(state.worldLabel).toBe("booting Verdant Hollow");
+    expect(state.frameSourceLabel).toBe("bootstrapping local sandbox");
+  });
+
+  test("describes direct-connect boot state from query params", () => {
+    const state = initialHudStateFromLocation({
+      search: "?server=127.0.0.1:7778"
+    } as Location);
+
+    expect(state.feedback).toBe("Connecting to ws://127.0.0.1:7778");
+    expect(state.connectionBadge).toBe("connecting to shard");
+    expect(state.worldLabel).toBe("waiting for shard snapshot");
   });
 
   test("submits websocket action batches after an authoritative welcome", () => {

--- a/apps/pod-web/src/direct-connect.ts
+++ b/apps/pod-web/src/direct-connect.ts
@@ -46,6 +46,14 @@ export interface DirectConnectActionState {
   lastActionSummary: string | null;
 }
 
+export interface InitialHudState {
+  feedback: string;
+  connectionBadge: string;
+  worldLabel: string;
+  populationLabel: string;
+  frameSourceLabel: string;
+}
+
 interface DirectConnectHandlers {
   onFrame: (
     snapshot: NetworkWorldSnapshot,
@@ -83,6 +91,29 @@ export function runtimeConfigFromLocation(
     playerName: params.get("player")?.trim() || DEFAULT_PLAYER_NAME,
     debugTelemetry: parseBooleanParam(params.get("debug")),
     reconnectDelayMs: parsePositiveInt(params.get("reconnectMs")) ?? DEFAULT_RECONNECT_DELAY_MS
+  };
+}
+
+export function initialHudStateFromLocation(
+  location: Pick<Location, "search">
+): InitialHudState {
+  const runtimeConfig = runtimeConfigFromLocation(location);
+  if (runtimeConfig) {
+    return {
+      feedback: `Connecting to ${runtimeConfig.url}`,
+      connectionBadge: "connecting to shard",
+      worldLabel: "waiting for shard snapshot",
+      populationLabel: "Awaiting authoritative population state",
+      frameSourceLabel: "bootstrapping direct-connect shard"
+    };
+  }
+
+  return {
+    feedback: "Starting local browser shard",
+    connectionBadge: "local sandbox booting",
+    worldLabel: "booting Verdant Hollow",
+    populationLabel: "Seeding local region population",
+    frameSourceLabel: "bootstrapping local sandbox"
   };
 }
 

--- a/apps/pod-web/src/main.ts
+++ b/apps/pod-web/src/main.ts
@@ -35,6 +35,7 @@ import {
   resolvePointerTarget
 } from "./controls";
 import {
+  initialHudStateFromLocation,
   PodWebDirectConnectClient,
   type DirectConnectActionState,
   runtimeConfigFromLocation,
@@ -188,6 +189,13 @@ const rollupSummaryNode = rollupSummaryLabel;
 const telemetryPanelNode = telemetryPanel;
 const telemetryPrevButton = telemetryPrev;
 const telemetryNextButton = telemetryNext;
+const bootHudState = initialHudStateFromLocation(window.location);
+
+feedbackNode.textContent = bootHudState.feedback;
+connectionNode.textContent = bootHudState.connectionBadge;
+worldNode.textContent = bootHudState.worldLabel;
+populationNode.textContent = bootHudState.populationLabel;
+frameSourceNode.textContent = bootHudState.frameSourceLabel;
 
 const renderer = await createPodRenderRuntime(renderCanvas);
 backendLabel.textContent = renderer.backend;

--- a/progress.md
+++ b/progress.md
@@ -17,3 +17,4 @@ Original prompt: its the graphics and the worlds scene, everything is piled up o
 - Verified live in Playwright that the flagship sandbox now renders with ambient density on WebGPU (`ambient 14`, `117277 tris`, `14 resident assets`, `0 pending`) while staying in daylight and loading cleanly.
 - Added browser-side world-event markers driven from authoritative shard events, so combat/action outcomes now decorate the scene in world space instead of only appearing as HUD text.
 - Differentiated the browser animation sampler so critical rings, destination breadcrumbs, companions, beasts, idle humanoids, and moving humanoids each read with distinct motion cues instead of all sharing one generic wobble profile.
+- Reworked the browser boot shell so first paint now reflects the actual startup mode: local sandbox pages no longer flash `demo` / `offline bridge` placeholders, and direct-connect URLs prelabel themselves as shard boot before the module finishes loading.


### PR DESCRIPTION
## Summary
- add a pure boot HUD state model for local sandbox and direct-connect startup
- apply that state before renderer creation and at first paint in index.html
- add deterministic tests for the local and direct-connect boot modes

## Testing
- cd apps/pod-web && bun test ./src/direct-connect.test.ts ./src/frame-plan.test.ts ./src/contracts.test.ts ./src/renderer.test.ts ./src/controls.test.ts ./src/render-runtime.test.ts
- cd apps/pod-web && bun run typecheck
- cd apps/pod-web && bun run build
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added direct-connect mode support via URL query parameters for connecting to websocket servers.

* **Bug Fixes**
  * Fixed initial UI state display to show correct startup mode immediately, preventing placeholder label flashing on page load.
  * Improved boot-time UI initialization to accurately reflect connection and runtime status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->