### PR TITLE
Add per-client pod-net interest filtering

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -946,5 +946,17 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cd apps/pod-web && bun run build`
   - `git diff --check`
 
-**Last updated**: Iteration 95
-**Current focus**: Iteration 96 worker-route gameplay-input parity proof, then further HUD reduction and richer traversal/combat feedback
+### Iteration 96
+- [x] Added per-client authoritative snapshot interest filtering in `pod-net`, so direct-connect and native clients no longer receive the same full-world delta when they control different shard regions.
+- [x] Introduced `SnapshotInterest` plus filtered population derivation in `snapshot.rs`, keeping controlled entities always visible while scoping chunk and region population summaries to the client’s actual interest window.
+- [x] Reworked `GameServer` session state to keep `last_sent_snapshot` per client and compute deltas against each client’s last visible world instead of one global shard baseline.
+- [x] Updated welcome and full-resync paths to send filtered authoritative snapshots, preserving digest/reconciliation correctness after reconnects and recovery requests.
+- [x] Added deterministic coverage for snapshot filtering and per-client server broadcasts, then validated native, wasm, and SpacetimeDB-enabled `pod-net` targets.
+- [x] Validated touched targets:
+  - `cargo test -p pod-net --lib`
+  - `cargo test -p pod-net --features spacetimedb --lib`
+  - `cargo check -p pod-net --target wasm32-unknown-unknown --lib`
+  - `git diff --check`
+
+**Last updated**: Iteration 96
+**Current focus**: Iteration 97 server-side event interest filtering, then worker-route gameplay-input parity proof and richer traversal/combat feedback

--- a/crates/pod-net/src/lib.rs
+++ b/crates/pod-net/src/lib.rs
@@ -71,7 +71,7 @@ pub use snapshot::{
     compose_presentation_snapshot, CatchUpDiagnostics, EntityDrift, EntityInteractionHints,
     EntityKind, EntityMetadataSnapshot, EntitySnapshot, InterpolatedSnapshot, InterpolationConfig,
     PredictedActionBatch, ReconciliationReport, RecoveryRequestState, RenderClock, RollbackPreview,
-    SnapshotInterpolationBuffer, SnapshotSampleMode, SnapshotUpdateError, StateDelta,
+    SnapshotInterest, SnapshotInterpolationBuffer, SnapshotSampleMode, SnapshotUpdateError, StateDelta,
     WorldSnapshot,
 };
 

--- a/crates/pod-net/src/server.rs
+++ b/crates/pod-net/src/server.rs
@@ -17,14 +17,14 @@ use tokio::sync::{mpsc, RwLock};
 use tokio_tungstenite::{accept_async, tungstenite::Message};
 
 use pod_core::{
-    Action, AgentTickRollup, AgentToolCallEvent, IdleAgent, TelemetryArchive, TelemetryConfig,
-    VersionedTickTelemetry, World, GameEvent,
+    Action, AgentTickRollup, AgentToolCallEvent, GameEvent, IdleAgent, TelemetryArchive,
+    TelemetryConfig, VersionedTickTelemetry, World,
 };
 
 use crate::protocol::{
     ClientId, ClientMessage, ReconnectToken, ServerConfig as ProtoServerConfig, ServerMessage,
 };
-use crate::snapshot::{StateDelta, WorldSnapshot};
+use crate::snapshot::{SnapshotInterest, StateDelta, WorldSnapshot};
 
 // ============================================================
 // CLIENT SESSION STATE
@@ -39,6 +39,7 @@ struct ClientSession {
     last_action_tick: Option<u64>,
     last_processed_action_tick: Option<u64>,
     debug_telemetry_enabled: bool,
+    last_sent_snapshot: Option<WorldSnapshot>,
 }
 
 impl ClientSession {
@@ -52,8 +53,18 @@ impl ClientSession {
             last_action_tick: None,
             last_processed_action_tick: None,
             debug_telemetry_enabled: false,
+            last_sent_snapshot: None,
         }
     }
+}
+
+#[derive(Clone)]
+struct ClientBroadcastTarget {
+    client_id: ClientId,
+    agent_id: Option<pod_core::AgentId>,
+    acknowledged_action_tick: Option<u64>,
+    debug_telemetry_enabled: bool,
+    last_sent_snapshot: Option<WorldSnapshot>,
 }
 
 #[derive(Debug)]
@@ -667,95 +678,136 @@ impl GameServer {
 
     /// Broadcast world updates to all connected clients
     async fn broadcast_updates(&mut self) -> Result<(), Box<dyn std::error::Error>> {
-        // Decide whether to send full snapshot or delta
         let should_snapshot =
             (self.tick - self.last_snapshot_tick) >= self.config.snapshot_interval;
-        let current_snapshot = WorldSnapshot::capture(&self.world);
-        let authoritative_digest = current_snapshot.digest();
-
-        let is_full_snapshot = should_snapshot || self.last_snapshot.is_none();
-        let delta = if is_full_snapshot {
-            StateDelta {
-                tick: self.tick,
-                updated: current_snapshot.entities.clone(),
-                destroyed: vec![],
-                population: current_snapshot.population.clone(),
-            }
-        } else {
-            StateDelta::diff(
-                self.last_snapshot
-                    .as_ref()
-                    .expect("last_snapshot checked above"),
-                &current_snapshot,
-            )
-        };
-
-        let has_state_update = should_snapshot || delta.change_count() > 0;
+        let authoritative_snapshot = WorldSnapshot::capture(&self.world);
+        let has_authoritative_baseline = self.last_snapshot.is_some();
         let has_event_update = !self.pending_events.is_empty();
-        let clients = self.clients.read().await;
-        let has_debug_subscribers = clients
-            .values()
-            .any(|session| session.debug_telemetry_enabled);
+        let client_targets = {
+            let clients = self.clients.read().await;
+            clients
+                .iter()
+                .map(|(client_id, session)| ClientBroadcastTarget {
+                    client_id: *client_id,
+                    agent_id: session.agent_id,
+                    acknowledged_action_tick: session.last_processed_action_tick,
+                    debug_telemetry_enabled: session.debug_telemetry_enabled,
+                    last_sent_snapshot: session.last_sent_snapshot.clone(),
+                })
+                .collect::<Vec<_>>()
+        };
+        let has_debug_subscribers = client_targets
+            .iter()
+            .any(|target| target.debug_telemetry_enabled);
 
-        if !has_state_update && !has_debug_subscribers && !has_event_update {
+        if !has_authoritative_baseline
+            && client_targets.is_empty()
+            && !has_debug_subscribers
+            && !has_event_update
+        {
             self.pending_events.clear();
             self.pending_debug_documents.clear();
             return Ok(());
         }
 
-        for (client_id, session) in clients.iter() {
-            if has_state_update {
-                let msg = ServerMessage::StateDelta {
+        let mut updated_client_snapshots = Vec::new();
+        let had_missing_client_baseline = client_targets
+            .iter()
+            .any(|target| target.last_sent_snapshot.is_none());
+        let mut any_state_update = !has_authoritative_baseline;
+
+        for target in &client_targets {
+            let filtered_snapshot =
+                self.snapshot_for_client(&authoritative_snapshot, target.agent_id);
+            let authoritative_digest = filtered_snapshot.digest();
+            let is_full_snapshot = should_snapshot || target.last_sent_snapshot.is_none();
+            let delta = if is_full_snapshot {
+                StateDelta {
                     tick: self.tick,
-                    acknowledged_action_tick: session.last_processed_action_tick,
-                    authoritative_digest,
-                    is_full_snapshot,
-                    delta: delta.clone(),
-                };
-                if let Some(tx) = self.client_tx.read().await.get(client_id) {
-                    if let Err(e) = tx.send(msg).await {
-                        error!("Failed to send update to client {}: {}", client_id.0, e);
-                    }
+                    updated: filtered_snapshot.entities.clone(),
+                    destroyed: vec![],
+                    population: filtered_snapshot.population.clone(),
+                }
+            } else {
+                StateDelta::diff(
+                    target
+                        .last_sent_snapshot
+                        .as_ref()
+                        .expect("client baseline checked above"),
+                    &filtered_snapshot,
+                )
+            };
+
+            let population_changed = target
+                .last_sent_snapshot
+                .as_ref()
+                .map(|snapshot| snapshot.population != filtered_snapshot.population)
+                .unwrap_or(true);
+            let has_state_update =
+                is_full_snapshot || delta.change_count() > 0 || population_changed;
+
+            if has_state_update {
+                any_state_update = true;
+                let sent = self
+                    .send_to_client(
+                        target.client_id,
+                        ServerMessage::StateDelta {
+                            tick: self.tick,
+                            acknowledged_action_tick: target.acknowledged_action_tick,
+                            authoritative_digest,
+                            is_full_snapshot,
+                            delta,
+                        },
+                    )
+                    .await;
+                if sent {
+                    updated_client_snapshots.push((target.client_id, filtered_snapshot));
                 }
             }
 
             if has_event_update {
-                let msg = ServerMessage::EventBatch {
-                    tick: self.tick,
-                    events: self.pending_events.clone(),
-                };
-                if let Some(tx) = self.client_tx.read().await.get(client_id) {
-                    if let Err(e) = tx.send(msg).await {
-                        error!("Failed to send event batch to client {}: {}", client_id.0, e);
-                    }
-                }
+                let _ = self
+                    .send_to_client(
+                        target.client_id,
+                        ServerMessage::EventBatch {
+                            tick: self.tick,
+                            events: self.pending_events.clone(),
+                        },
+                    )
+                    .await;
             }
 
-            if session.debug_telemetry_enabled {
-                if let Some(tx) = self.client_tx.read().await.get(client_id) {
-                    for document in &self.pending_debug_documents {
-                        if let Err(e) = tx
-                            .send(ServerMessage::DebugDocument {
+            if target.debug_telemetry_enabled {
+                for document in &self.pending_debug_documents {
+                    let sent = self
+                        .send_to_client(
+                            target.client_id,
+                            ServerMessage::DebugDocument {
                                 document: document.clone(),
-                            })
-                            .await
-                        {
-                            error!(
-                                "Failed to send debug document to client {}: {}",
-                                client_id.0, e
-                            );
-                            break;
-                        }
+                            },
+                        )
+                        .await;
+                    if !sent {
+                        break;
                     }
                 }
             }
         }
 
-        if has_state_update && is_full_snapshot {
+        if !updated_client_snapshots.is_empty() {
+            let mut clients = self.clients.write().await;
+            for (client_id, snapshot) in updated_client_snapshots {
+                if let Some(session) = clients.get_mut(&client_id) {
+                    session.last_sent_snapshot = Some(snapshot);
+                }
+            }
+        }
+
+        if should_snapshot || had_missing_client_baseline {
             self.last_snapshot_tick = self.tick;
         }
-        if has_state_update {
-            self.last_snapshot = Some(current_snapshot);
+        if any_state_update {
+            self.last_snapshot = Some(authoritative_snapshot);
         }
         self.pending_events.clear();
         self.pending_debug_documents.clear();
@@ -791,16 +843,21 @@ impl GameServer {
         info!("Client {} disconnected: {}", client_id.0, reason);
     }
 
-    async fn send_to_client(&self, client_id: ClientId, message: ServerMessage) {
+    async fn send_to_client(&self, client_id: ClientId, message: ServerMessage) -> bool {
         if let Some(tx) = self.client_tx.read().await.get(&client_id) {
             if let Err(err) = tx.send(message).await {
                 warn!("Failed to send message to {}: {}", client_id.0, err);
+                return false;
             }
         }
+        true
     }
 
-    fn build_full_snapshot_message(&self, acknowledged_action_tick: Option<u64>) -> ServerMessage {
-        let snapshot = WorldSnapshot::capture(&self.world);
+    fn build_full_snapshot_message(
+        &self,
+        snapshot: WorldSnapshot,
+        acknowledged_action_tick: Option<u64>,
+    ) -> ServerMessage {
         let authoritative_digest = snapshot.digest();
         ServerMessage::StateDelta {
             tick: self.tick,
@@ -816,18 +873,99 @@ impl GameServer {
         }
     }
 
-    async fn send_full_snapshot_to_client(&self, client_id: ClientId) {
-        let acknowledged_action_tick = self
+    fn controlled_entity_for_agent(&self, agent_id: pod_core::AgentId) -> Option<u64> {
+        self.world
+            .agents
+            .iter()
+            .find(|slot| slot.agent.id() == agent_id)
+            .and_then(|slot| slot.entity_id)
+            .map(|entity| entity.id() as u64)
+    }
+
+    fn snapshot_interest_for_controlled_entity(
+        &self,
+        authoritative_snapshot: &WorldSnapshot,
+        controlled_entity: Option<u64>,
+    ) -> SnapshotInterest {
+        let Some(controlled_entity) = controlled_entity else {
+            return SnapshotInterest::default();
+        };
+        let Some(entity) = authoritative_snapshot
+            .entities
+            .iter()
+            .find(|entity| entity.id == controlled_entity)
+        else {
+            return SnapshotInterest::default();
+        };
+
+        let mut chunk_keys = Vec::new();
+        if let Some(chunk_key) = entity.metadata.chunk_key.as_deref() {
+            chunk_keys.push(chunk_key.to_string());
+            if let Some(chunk) = self
+                .world
+                .streaming
+                .chunks
+                .iter()
+                .find(|chunk| chunk.chunk_key == chunk_key)
+            {
+                chunk_keys.extend(chunk.neighbor_chunk_keys.iter().cloned());
+            }
+        }
+        if chunk_keys.is_empty() {
+            if let Some(region_id) = entity.metadata.region_id.as_deref() {
+                if let Some(region) = self
+                    .world
+                    .streaming
+                    .regions
+                    .iter()
+                    .find(|region| region.region_id == region_id)
+                {
+                    chunk_keys.extend(region.chunk_keys.iter().cloned());
+                }
+            }
+        }
+
+        SnapshotInterest::new(
+            Some(controlled_entity),
+            Some(entity.position),
+            Some(self.world.streaming.chunk_size.max(0.001) * 1.75),
+            chunk_keys,
+        )
+    }
+
+    fn snapshot_for_client(
+        &self,
+        authoritative_snapshot: &WorldSnapshot,
+        agent_id: Option<pod_core::AgentId>,
+    ) -> WorldSnapshot {
+        let controlled_entity =
+            agent_id.and_then(|agent_id| self.controlled_entity_for_agent(agent_id));
+        let interest =
+            self.snapshot_interest_for_controlled_entity(authoritative_snapshot, controlled_entity);
+        authoritative_snapshot.for_interest(&interest)
+    }
+
+    async fn send_full_snapshot_to_client(&mut self, client_id: ClientId) {
+        let (acknowledged_action_tick, agent_id) = self
             .clients
             .read()
             .await
             .get(&client_id)
-            .and_then(|session| session.last_processed_action_tick);
-        self.send_to_client(
-            client_id,
-            self.build_full_snapshot_message(acknowledged_action_tick),
-        )
-        .await;
+            .map(|session| (session.last_processed_action_tick, session.agent_id))
+            .unwrap_or((None, None));
+        let authoritative_snapshot = WorldSnapshot::capture(&self.world);
+        let snapshot = self.snapshot_for_client(&authoritative_snapshot, agent_id);
+        let sent = self
+            .send_to_client(
+                client_id,
+                self.build_full_snapshot_message(snapshot.clone(), acknowledged_action_tick),
+            )
+            .await;
+        if sent {
+            if let Some(session) = self.clients.write().await.get_mut(&client_id) {
+                session.last_sent_snapshot = Some(snapshot);
+            }
+        }
     }
 
     async fn attach_remote_agent(
@@ -859,6 +997,7 @@ impl GameServer {
                         session.last_processed_action_tick = prev.last_processed_action_tick;
                         session.debug_telemetry_enabled = prev.debug_telemetry_enabled;
                         session.pending_actions.clear();
+                        session.last_sent_snapshot = None;
                     } else if session.player_name.is_none() {
                         session.player_name = Some(player_name.clone());
                     }
@@ -896,34 +1035,41 @@ impl GameServer {
             .is_some();
 
         if already_attached {
-            let snapshot = WorldSnapshot::capture(&self.world);
-            let authoritative_digest = snapshot.digest();
             let controlled_entity = self
                 .clients
                 .read()
                 .await
                 .get(&client_id)
                 .and_then(|session| session.agent_id)
-                .and_then(|agent_id| {
-                    self.world
-                        .agents
-                        .iter()
-                        .find(|slot| slot.agent.id() == agent_id)
-                        .and_then(|slot| slot.entity_id)
-                        .map(|entity| entity.id() as u64)
-                });
-            self.send_to_client(
-                client_id,
-                ServerMessage::Welcome {
+                .and_then(|agent_id| self.controlled_entity_for_agent(agent_id));
+            let authoritative_snapshot = WorldSnapshot::capture(&self.world);
+            let snapshot = self.snapshot_for_client(
+                &authoritative_snapshot,
+                self.clients
+                    .read()
+                    .await
+                    .get(&client_id)
+                    .and_then(|session| session.agent_id),
+            );
+            let authoritative_digest = snapshot.digest();
+            let sent = self
+                .send_to_client(
                     client_id,
-                    reconnect_token,
-                    tick: self.tick,
-                    controlled_entity,
-                    authoritative_digest,
-                    snapshot,
-                },
-            )
-            .await;
+                    ServerMessage::Welcome {
+                        client_id,
+                        reconnect_token,
+                        tick: self.tick,
+                        controlled_entity,
+                        authoritative_digest,
+                        snapshot: snapshot.clone(),
+                    },
+                )
+                .await;
+            if sent {
+                if let Some(session) = self.clients.write().await.get_mut(&client_id) {
+                    session.last_sent_snapshot = Some(snapshot);
+                }
+            }
             return Ok(());
         }
 
@@ -942,20 +1088,27 @@ impl GameServer {
             }
         }
 
-        let snapshot = WorldSnapshot::capture(&self.world);
+        let authoritative_snapshot = WorldSnapshot::capture(&self.world);
+        let snapshot = self.snapshot_for_client(&authoritative_snapshot, Some(agent_id));
         let authoritative_digest = snapshot.digest();
-        self.send_to_client(
-            client_id,
-            ServerMessage::Welcome {
+        let sent = self
+            .send_to_client(
                 client_id,
-                reconnect_token,
-                tick: self.tick,
-                controlled_entity: Some(entity.id() as u64),
-                authoritative_digest,
-                snapshot,
-            },
-        )
-        .await;
+                ServerMessage::Welcome {
+                    client_id,
+                    reconnect_token,
+                    tick: self.tick,
+                    controlled_entity: Some(entity.id() as u64),
+                    authoritative_digest,
+                    snapshot: snapshot.clone(),
+                },
+            )
+            .await;
+        if sent {
+            if let Some(session) = self.clients.write().await.get_mut(&client_id) {
+                session.last_sent_snapshot = Some(snapshot);
+            }
+        }
 
         Ok(())
     }
@@ -1019,11 +1172,11 @@ impl std::fmt::Display for ServerError {
 impl std::error::Error for ServerError {}
 
 #[cfg(test)]
-    mod tests {
-        use super::*;
-        use pod_core::decode_toon_value;
-        use tokio_tungstenite::{connect_async, tungstenite::Message};
-        use pod_core::action::SpeakVolume;
+mod tests {
+    use super::*;
+    use pod_core::action::SpeakVolume;
+    use pod_core::decode_toon_value;
+    use tokio_tungstenite::{connect_async, tungstenite::Message};
 
     fn next_available_port() -> u16 {
         std::net::TcpListener::bind("127.0.0.1:0")
@@ -1058,8 +1211,9 @@ impl std::error::Error for ServerError {}
         let config = ProtoServerConfig::default();
         let world = World::new(42);
         let server = GameServer::new(config, world);
+        let snapshot = WorldSnapshot::capture(&server.world);
 
-        let message = server.build_full_snapshot_message(Some(12));
+        let message = server.build_full_snapshot_message(snapshot, Some(12));
         match message {
             ServerMessage::StateDelta {
                 tick,
@@ -1101,6 +1255,7 @@ impl std::error::Error for ServerError {}
                 last_action_tick: None,
                 last_processed_action_tick: None,
                 debug_telemetry_enabled: true,
+                last_sent_snapshot: None,
             },
         );
 
@@ -1124,6 +1279,112 @@ impl std::error::Error for ServerError {}
     }
 
     #[tokio::test]
+    async fn test_broadcast_updates_filters_snapshots_per_client_interest() {
+        let config = ProtoServerConfig::default();
+        let mut world = World::new(42);
+        let (alpha_slot, alpha_entity) = world.add_agent(Box::new(IdleAgent::new()));
+        let (spire_slot, spire_entity) = world.add_agent(Box::new(IdleAgent::new()));
+        world
+            .ecs
+            .get::<&mut pod_core::Transform>(alpha_entity)
+            .expect("alpha transform")
+            .position = glam::Vec2::new(1.0, 1.0);
+        world
+            .ecs
+            .get::<&mut pod_core::Transform>(spire_entity)
+            .expect("spire transform")
+            .position = glam::Vec2::new(30.0, 1.0);
+        let near_resource = world
+            .spawn_at(2.0, 1.0)
+            .with_label("Near Resource", pod_core::Team::None)
+            .build();
+        let far_resource = world
+            .spawn_at(31.0, 1.0)
+            .with_label("Far Resource", pod_core::Team::None)
+            .build();
+
+        let mut server = GameServer::new(config, world);
+        let alpha_client = ClientId::new();
+        let spire_client = ClientId::new();
+        let (alpha_tx, mut alpha_rx) = mpsc::channel(8);
+        let (spire_tx, mut spire_rx) = mpsc::channel(8);
+        server
+            .client_tx
+            .write()
+            .await
+            .insert(alpha_client, alpha_tx);
+        server
+            .client_tx
+            .write()
+            .await
+            .insert(spire_client, spire_tx);
+        server.clients.write().await.insert(
+            alpha_client,
+            ClientSession {
+                player_name: Some("alpha".into()),
+                agent_id: Some(server.world.agents[alpha_slot].agent.id()),
+                pending_actions: Vec::new(),
+                reconnect_token: ReconnectToken::new(),
+                last_action_tick: None,
+                last_processed_action_tick: None,
+                debug_telemetry_enabled: false,
+                last_sent_snapshot: None,
+            },
+        );
+        server.clients.write().await.insert(
+            spire_client,
+            ClientSession {
+                player_name: Some("spire".into()),
+                agent_id: Some(server.world.agents[spire_slot].agent.id()),
+                pending_actions: Vec::new(),
+                reconnect_token: ReconnectToken::new(),
+                last_action_tick: None,
+                last_processed_action_tick: None,
+                debug_telemetry_enabled: false,
+                last_sent_snapshot: None,
+            },
+        );
+
+        server.broadcast_updates().await.unwrap();
+
+        let alpha_state = loop {
+            match alpha_rx.try_recv() {
+                Ok(ServerMessage::StateDelta { delta, .. }) => break delta,
+                Ok(_) => continue,
+                Err(err) => panic!("missing alpha state delta: {err}"),
+            }
+        };
+        let spire_state = loop {
+            match spire_rx.try_recv() {
+                Ok(ServerMessage::StateDelta { delta, .. }) => break delta,
+                Ok(_) => continue,
+                Err(err) => panic!("missing spire state delta: {err}"),
+            }
+        };
+
+        let alpha_ids = alpha_state
+            .updated
+            .iter()
+            .map(|entity| entity.id)
+            .collect::<Vec<_>>();
+        let spire_ids = spire_state
+            .updated
+            .iter()
+            .map(|entity| entity.id)
+            .collect::<Vec<_>>();
+
+        assert!(alpha_ids.contains(&(alpha_entity.id() as u64)));
+        assert!(alpha_ids.contains(&(near_resource.id() as u64)));
+        assert!(!alpha_ids.contains(&(spire_entity.id() as u64)));
+        assert!(!alpha_ids.contains(&(far_resource.id() as u64)));
+
+        assert!(spire_ids.contains(&(spire_entity.id() as u64)));
+        assert!(spire_ids.contains(&(far_resource.id() as u64)));
+        assert!(!spire_ids.contains(&(alpha_entity.id() as u64)));
+        assert!(!spire_ids.contains(&(near_resource.id() as u64)));
+    }
+
+    #[tokio::test]
     async fn test_broadcast_updates_emits_authoritative_event_batches() {
         let config = ProtoServerConfig::default();
         let world = World::new(42);
@@ -1141,6 +1402,7 @@ impl std::error::Error for ServerError {}
                 last_action_tick: None,
                 last_processed_action_tick: None,
                 debug_telemetry_enabled: false,
+                last_sent_snapshot: None,
             },
         );
         server.tick = 12;
@@ -1193,33 +1455,31 @@ impl std::error::Error for ServerError {}
                 last_action_tick: None,
                 last_processed_action_tick: None,
                 debug_telemetry_enabled: false,
+                last_sent_snapshot: None,
             },
         );
-        server
-            .world
-            .submit_external_action(
-                agent_id,
-                Action::Speak {
-                    message: "authoritative hello".into(),
-                    volume: SpeakVolume::Normal,
-                },
-            );
+        server.world.submit_external_action(
+            agent_id,
+            Action::Speak {
+                message: "authoritative hello".into(),
+                volume: SpeakVolume::Normal,
+            },
+        );
 
         server.step_tick().await.unwrap();
-        assert!(server.pending_events.iter().any(|event| matches!(
-            event.event,
-            pod_core::Event::AgentSpoke { .. }
-        )));
+        assert!(server
+            .pending_events
+            .iter()
+            .any(|event| matches!(event.event, pod_core::Event::AgentSpoke { .. })));
 
         server.broadcast_updates().await.unwrap();
 
         let mut saw_spoken_event = false;
         while let Ok(message) = rx.try_recv() {
             if let ServerMessage::EventBatch { events, .. } = message {
-                saw_spoken_event = events.iter().any(|event| matches!(
-                    event.event,
-                    pod_core::Event::AgentSpoke { .. }
-                ));
+                saw_spoken_event = events
+                    .iter()
+                    .any(|event| matches!(event.event, pod_core::Event::AgentSpoke { .. }));
             }
         }
 

--- a/crates/pod-net/src/snapshot.rs
+++ b/crates/pod-net/src/snapshot.rs
@@ -12,8 +12,8 @@ use pod_core::{
     Action, ActorPresentation, AtmosphereProfile, AtmosphereVolume, CombatLoadout,
     CombatPresentation, CombatStyle, CreatureIdentity, EncounterKind, EncounterProfile,
     EncounterState, FactionAffiliation, FactionDisposition, Health, Label, LootContainer, Movement,
-    QuestAnchor, ResourceNode, SkillKind, SpawnProfile, Team, Transform,
-    Velocity, WorldPopulationState,
+    QuestAnchor, ResourceNode, SkillKind, SpawnProfile, Team, Transform, Velocity,
+    WorldPopulationState,
 };
 
 const FIXED_TICK_DURATION_SECS: f32 = 1.0 / 60.0;
@@ -111,6 +111,72 @@ pub struct EntityMetadataSnapshot {
     pub actor_presentation: Option<ActorPresentation>,
     pub combat_presentation: Option<CombatPresentation>,
     pub interaction: EntityInteractionHints,
+}
+
+/// Per-client interest window used to derive filtered authoritative snapshots.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct SnapshotInterest {
+    pub controlled_entity: Option<u64>,
+    pub center: Option<Vec2>,
+    pub radius: Option<f32>,
+    pub chunk_keys: Vec<String>,
+}
+
+impl SnapshotInterest {
+    pub fn new(
+        controlled_entity: Option<u64>,
+        center: Option<Vec2>,
+        radius: Option<f32>,
+        chunk_keys: Vec<String>,
+    ) -> Self {
+        let mut chunk_keys = chunk_keys;
+        chunk_keys.sort();
+        chunk_keys.dedup();
+        Self {
+            controlled_entity,
+            center,
+            radius,
+            chunk_keys,
+        }
+    }
+
+    fn is_unbounded(&self) -> bool {
+        self.controlled_entity.is_none()
+            && self.center.is_none()
+            && self.radius.is_none()
+            && self.chunk_keys.is_empty()
+    }
+
+    fn chunk_key_set(&self) -> HashSet<&str> {
+        self.chunk_keys.iter().map(String::as_str).collect()
+    }
+
+    fn matches_entity(&self, entity: &EntitySnapshot) -> bool {
+        if self
+            .controlled_entity
+            .map(|controlled| controlled == entity.id)
+            .unwrap_or(false)
+        {
+            return true;
+        }
+
+        let chunk_keys = self.chunk_key_set();
+        if !chunk_keys.is_empty()
+            && entity
+                .metadata
+                .chunk_key
+                .as_deref()
+                .map(|chunk_key| chunk_keys.contains(chunk_key))
+                .unwrap_or(false)
+        {
+            return true;
+        }
+
+        self.center
+            .zip(self.radius)
+            .map(|(center, radius)| center.distance(entity.position) <= radius.max(0.0))
+            .unwrap_or(false)
+    }
 }
 
 /// Efficient delta — only changed entities
@@ -609,6 +675,27 @@ impl WorldSnapshot {
         }
     }
 
+    /// Filters an authoritative snapshot to the subset relevant for one client.
+    pub fn for_interest(&self, interest: &SnapshotInterest) -> Self {
+        if interest.is_unbounded() {
+            return self.clone();
+        }
+
+        let chunk_keys = interest.chunk_key_set();
+        let entities = self
+            .entities
+            .iter()
+            .filter(|entity| interest.matches_entity(entity))
+            .cloned()
+            .collect();
+
+        Self {
+            tick: self.tick,
+            entities,
+            population: filter_population_for_interest(&self.population, &chunk_keys),
+        }
+    }
+
     /// Apply a snapshot to a world (for client-side reconciliation)
     pub fn apply(&self, _world: &mut pod_core::World) {
         // For now, we'll just log this — full reconciliation
@@ -770,6 +857,107 @@ fn entity_changed(old: &EntitySnapshot, new: &EntitySnapshot) -> bool {
         || old.movement_speed != new.movement_speed
         || old.label != new.label
         || old.metadata != new.metadata
+}
+
+fn filter_population_for_interest(
+    population: &WorldPopulationState,
+    chunk_keys: &HashSet<&str>,
+) -> WorldPopulationState {
+    if chunk_keys.is_empty() {
+        return population.clone();
+    }
+
+    let chunks = population
+        .chunks
+        .iter()
+        .filter(|chunk| chunk_keys.contains(chunk.chunk_key.as_str()))
+        .cloned()
+        .collect::<Vec<_>>();
+    let chunk_map = chunks
+        .iter()
+        .map(|chunk| (chunk.chunk_key.as_str(), chunk))
+        .collect::<HashMap<_, _>>();
+
+    let regions = population
+        .regions
+        .iter()
+        .filter_map(|region| {
+            let matched_chunks = region
+                .chunk_keys
+                .iter()
+                .filter_map(|chunk_key| chunk_map.get(chunk_key.as_str()).copied())
+                .collect::<Vec<_>>();
+
+            if matched_chunks.is_empty() {
+                return None;
+            }
+
+            let mut filtered = region.clone();
+            filtered.chunk_keys = matched_chunks
+                .iter()
+                .map(|chunk| chunk.chunk_key.clone())
+                .collect();
+            filtered.active_chunk_count = filtered.chunk_keys.len() as u32;
+            filtered.counts = aggregate_population_breakdown(&matched_chunks);
+            filtered.ambient_population_cap = matched_chunks
+                .iter()
+                .map(|chunk| chunk.ambient_population_cap)
+                .sum();
+            filtered.pending_respawns = matched_chunks
+                .iter()
+                .map(|chunk| chunk.pending_respawns)
+                .sum();
+            filtered.next_respawn_tick = matched_chunks
+                .iter()
+                .filter_map(|chunk| chunk.next_respawn_tick)
+                .min();
+            refresh_region_metrics(&mut filtered);
+            Some(filtered)
+        })
+        .collect();
+
+    WorldPopulationState {
+        tick: population.tick,
+        chunks,
+        regions,
+    }
+}
+
+fn aggregate_population_breakdown(
+    chunks: &[&pod_core::ChunkPopulationState],
+) -> pod_core::PopulationBreakdown {
+    let mut total = pod_core::PopulationBreakdown::default();
+    for chunk in chunks {
+        total.players += chunk.counts.players;
+        total.npcs += chunk.counts.npcs;
+        total.wild_creatures += chunk.counts.wild_creatures;
+        total.companions += chunk.counts.companions;
+        total.resource_nodes += chunk.counts.resource_nodes;
+        total.loot_containers += chunk.counts.loot_containers;
+        total.scenery += chunk.counts.scenery;
+    }
+    total
+}
+
+fn refresh_region_metrics(region: &mut pod_core::RegionPopulationState) {
+    region.active_entity_count = region.counts.players
+        + region.counts.npcs
+        + region.counts.wild_creatures
+        + region.counts.companions
+        + region.counts.resource_nodes
+        + region.counts.loot_containers
+        + region.counts.scenery;
+
+    let active_spawned = region.counts.players
+        + region.counts.npcs
+        + region.counts.wild_creatures
+        + region.counts.companions;
+    region.spawn_budget_remaining = region.ambient_population_cap.saturating_sub(active_spawned);
+    region.population_pressure = if region.ambient_population_cap == 0 {
+        0.0
+    } else {
+        active_spawned as f32 / region.ambient_population_cap as f32
+    };
 }
 
 /// Applies an authoritative state update and validates its digest.
@@ -1498,6 +1686,18 @@ mod tests {
         }
     }
 
+    fn snapshot_with_population(
+        tick: u64,
+        entities: Vec<EntitySnapshot>,
+        population: WorldPopulationState,
+    ) -> WorldSnapshot {
+        WorldSnapshot {
+            tick,
+            entities,
+            population,
+        }
+    }
+
     fn delta_with_updates(
         tick: u64,
         updated: Vec<EntitySnapshot>,
@@ -1516,6 +1716,170 @@ mod tests {
         let snap = WorldSnapshot::default();
         assert_eq!(snap.tick, 0);
         assert_eq!(snap.entity_count(), 0);
+    }
+
+    #[test]
+    fn test_snapshot_interest_filters_entities_and_population_by_chunk_window() {
+        let population = WorldPopulationState {
+            tick: 9,
+            chunks: vec![
+                pod_core::ChunkPopulationState {
+                    chunk_key: "0:0".into(),
+                    region_id: Some("verdant-heart".into()),
+                    region_name: Some("Verdant Heart".into()),
+                    counts: pod_core::PopulationBreakdown {
+                        players: 1,
+                        npcs: 1,
+                        ..Default::default()
+                    },
+                    active_entity_count: 2,
+                    ambient_population_cap: 6,
+                    spawn_budget_remaining: 4,
+                    population_pressure: 0.33,
+                    ..Default::default()
+                },
+                pod_core::ChunkPopulationState {
+                    chunk_key: "1:0".into(),
+                    region_id: Some("verdant-heart".into()),
+                    region_name: Some("Verdant Heart".into()),
+                    counts: pod_core::PopulationBreakdown {
+                        wild_creatures: 2,
+                        ..Default::default()
+                    },
+                    active_entity_count: 2,
+                    ambient_population_cap: 4,
+                    spawn_budget_remaining: 2,
+                    population_pressure: 0.5,
+                    ..Default::default()
+                },
+                pod_core::ChunkPopulationState {
+                    chunk_key: "3:0".into(),
+                    region_id: Some("spirewatch".into()),
+                    region_name: Some("Spirewatch".into()),
+                    counts: pod_core::PopulationBreakdown {
+                        npcs: 3,
+                        ..Default::default()
+                    },
+                    active_entity_count: 3,
+                    ambient_population_cap: 3,
+                    spawn_budget_remaining: 0,
+                    population_pressure: 1.0,
+                    ..Default::default()
+                },
+            ],
+            regions: vec![
+                pod_core::RegionPopulationState {
+                    region_id: "verdant-heart".into(),
+                    region_name: "Verdant Heart".into(),
+                    primary_biome_id: "verdant-hollow".into(),
+                    chunk_keys: vec!["0:0".into(), "1:0".into()],
+                    active_chunk_count: 2,
+                    counts: pod_core::PopulationBreakdown {
+                        players: 1,
+                        npcs: 1,
+                        wild_creatures: 2,
+                        ..Default::default()
+                    },
+                    active_entity_count: 4,
+                    ambient_population_cap: 10,
+                    spawn_budget_remaining: 6,
+                    population_pressure: 0.4,
+                    ..Default::default()
+                },
+                pod_core::RegionPopulationState {
+                    region_id: "spirewatch".into(),
+                    region_name: "Spirewatch".into(),
+                    primary_biome_id: "spirewatch".into(),
+                    chunk_keys: vec!["3:0".into()],
+                    active_chunk_count: 1,
+                    counts: pod_core::PopulationBreakdown {
+                        npcs: 3,
+                        ..Default::default()
+                    },
+                    active_entity_count: 3,
+                    ambient_population_cap: 3,
+                    spawn_budget_remaining: 0,
+                    population_pressure: 1.0,
+                    ..Default::default()
+                },
+            ],
+        };
+        let snapshot = snapshot_with_population(
+            9,
+            vec![
+                EntitySnapshot {
+                    id: 10,
+                    position: Vec2::new(1.0, 1.0),
+                    velocity: Vec2::ZERO,
+                    rotation: 0.0,
+                    health: None,
+                    max_health: None,
+                    movement_speed: Some(200.0),
+                    label: Some("player".into()),
+                    metadata: EntityMetadataSnapshot {
+                        chunk_key: Some("0:0".into()),
+                        region_id: Some("verdant-heart".into()),
+                        ..EntityMetadataSnapshot::default()
+                    },
+                },
+                EntitySnapshot {
+                    id: 11,
+                    position: Vec2::new(8.5, 1.0),
+                    velocity: Vec2::ZERO,
+                    rotation: 0.0,
+                    health: None,
+                    max_health: None,
+                    movement_speed: None,
+                    label: Some("neighbor".into()),
+                    metadata: EntityMetadataSnapshot {
+                        chunk_key: Some("1:0".into()),
+                        region_id: Some("verdant-heart".into()),
+                        ..EntityMetadataSnapshot::default()
+                    },
+                },
+                EntitySnapshot {
+                    id: 12,
+                    position: Vec2::new(30.0, 1.0),
+                    velocity: Vec2::ZERO,
+                    rotation: 0.0,
+                    health: None,
+                    max_health: None,
+                    movement_speed: None,
+                    label: Some("far".into()),
+                    metadata: EntityMetadataSnapshot {
+                        chunk_key: Some("3:0".into()),
+                        region_id: Some("spirewatch".into()),
+                        ..EntityMetadataSnapshot::default()
+                    },
+                },
+            ],
+            population,
+        );
+
+        let filtered = snapshot.for_interest(&SnapshotInterest::new(
+            Some(10),
+            Some(Vec2::new(1.0, 1.0)),
+            Some(12.0),
+            vec!["0:0".into(), "1:0".into()],
+        ));
+
+        let retained_ids = filtered
+            .entities
+            .iter()
+            .map(|entity| entity.id)
+            .collect::<Vec<_>>();
+        assert_eq!(retained_ids, vec![10, 11]);
+        assert_eq!(filtered.population.chunks.len(), 2);
+        assert_eq!(filtered.population.regions.len(), 1);
+        assert_eq!(
+            filtered.population.regions[0].chunk_keys,
+            vec!["0:0".to_string(), "1:0".to_string()]
+        );
+        assert_eq!(filtered.population.regions[0].counts.players, 1);
+        assert_eq!(filtered.population.regions[0].counts.npcs, 1);
+        assert_eq!(filtered.population.regions[0].counts.wild_creatures, 2);
+        assert_eq!(filtered.population.regions[0].ambient_population_cap, 10);
+        assert_eq!(filtered.population.regions[0].spawn_budget_remaining, 6);
     }
 
     #[test]

--- a/progress.md
+++ b/progress.md
@@ -19,3 +19,6 @@ Original prompt: its the graphics and the worlds scene, everything is piled up o
 - Differentiated the browser animation sampler so critical rings, destination breadcrumbs, companions, beasts, idle humanoids, and moving humanoids each read with distinct motion cues instead of all sharing one generic wobble profile.
 - Reworked the browser boot shell so first paint now reflects the actual startup mode: local sandbox pages no longer flash `demo` / `offline bridge` placeholders, and direct-connect URLs prelabel themselves as shard boot before the module finishes loading.
 - Corrected world-frame terrain anchoring for centered sample meshes by calibrating lift against each shipped asset’s real half-height, which removes the major “loaded below the ground” placement error for heroes, beasts, props, and structures.
+- Added per-client interest-filtered authoritative snapshots in `pod-net`, so shard clients now diff against their own visible world instead of one global full-world baseline.
+- Welcome and full-resync snapshot paths now use the same filtered authoritative interest window, keeping reconnect/recovery correctness aligned with the new network scaling path.
+- Added deterministic network coverage for chunk-window snapshot filtering and server-side per-client broadcast partitioning, and revalidated native, wasm, and SpacetimeDB-enabled `pod-net` targets.


### PR DESCRIPTION
## Summary
- add per-client snapshot interest filtering to pod-net
- keep last-sent snapshots per session and diff against each client's own baseline
- send filtered welcome/full-resync snapshots and cover the path with deterministic tests

## Validation
- cargo test -p pod-net --lib
- cargo test -p pod-net --features spacetimedb --lib
- cargo check -p pod-net --target wasm32-unknown-unknown --lib
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Per-client snapshot filtering provides targeted state synchronization, optimizing bandwidth usage and server efficiency.

* **Refactoring**
  * Enhanced state delta computation to operate per-client instead of globally, improving overall server performance and scalability across multiple concurrent connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->