### PR TITLE
Focus pod-web debug telemetry on selected entities

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1009,5 +1009,15 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cargo test -p pod-net --features spacetimedb --lib`
   - `git diff --check`
 
-**Last updated**: Iteration 101
-**Current focus**: Iteration 102 further HUD reduction, richer traversal/combat feedback, and deeper selected-entity debug telemetry consumption in browser/runtime surfaces
+### Iteration 102
+- [x] Added browser-side retained live-debug state so tool-call events and rollups stay keyed by entity instead of only exposing the latest global debug document.
+- [x] Wired the `pod-web` telemetry HUD to the focused entity (`selected target` or controlled entity), so raw selected-entity SpacetimeDB debug streams now surface meaningful focus-aware tool/rollup summaries in runtime.
+- [x] Added deterministic `pod-web` coverage for retained per-entity live-debug summaries and replay/incident stream counters.
+- [x] Revalidated touched targets:
+  - `cd apps/pod-web && bun test ./src/live-debug.test.ts ./src/contracts.test.ts ./src/controls.test.ts ./src/render-runtime.test.ts`
+  - `cd apps/pod-web && bun run typecheck`
+  - `cd apps/pod-web && bun run build`
+  - `git diff --check`
+
+**Last updated**: Iteration 102
+**Current focus**: Iteration 103 further HUD reduction, richer traversal/combat feedback, and deeper shard/runtime consumption of selected-entity debug telemetry

--- a/apps/pod-web/src/live-debug.test.ts
+++ b/apps/pod-web/src/live-debug.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from "bun:test";
+
+import type {
+  AgentTickRollupDocument,
+  AgentToolCallEventDocument,
+  LiveDebugDocument
+} from "./contracts";
+import {
+  createLiveDebugState,
+  recordLiveDebugDocument,
+  resetLiveDebugState,
+  selectedTickRollupSummary,
+  selectedToolEventSummary
+} from "./live-debug";
+
+function sampleTool(agentEntityId: number, status = "TimedOut"): AgentToolCallEventDocument {
+  return {
+    tick: 18,
+    agent_entity_id: agentEntityId,
+    trace: {
+      tick: 18,
+      tool_name: "llm.complete",
+      provider: "qwen",
+      status,
+      latency_ms: 48,
+      request_units: 120,
+      response_units: 64,
+      error_message: status === "Succeeded" ? null : "timeout"
+    }
+  };
+}
+
+function sampleRollup(agentEntityId: number, tickEnd = 60): AgentTickRollupDocument {
+  return {
+    agent_entity_id: agentEntityId,
+    tick_start: 1,
+    tick_end: tickEnd,
+    total_distance: 18.5,
+    submitted_action_count: 3,
+    executed_action_count: 2,
+    rejected_action_count: 1,
+    tool_call_count: 1,
+    tool_error_count: 1,
+    average_tool_latency_ms: 48,
+    visible_entity_count: 12,
+    audible_event_count: 3,
+    message_count: 2
+  };
+}
+
+describe("live debug state", () => {
+  test("retains entity-scoped summaries and falls back to latest when unfocused", () => {
+    const state = createLiveDebugState();
+    recordLiveDebugDocument(state, {
+      kind: "toolCallEvent",
+      documentType: "agent_tool_call_event",
+      payload: sampleTool(1001)
+    } satisfies LiveDebugDocument);
+    recordLiveDebugDocument(state, {
+      kind: "tickRollup",
+      documentType: "agent_tick_rollup",
+      payload: sampleRollup(1002)
+    } satisfies LiveDebugDocument);
+
+    expect(selectedToolEventSummary(state, 1001)?.agentEntityId).toBe(1001);
+    expect(selectedTickRollupSummary(state, 1002)?.agentEntityId).toBe(1002);
+    expect(selectedToolEventSummary(state, null)?.agentEntityId).toBe(1001);
+    expect(selectedTickRollupSummary(state, null)?.agentEntityId).toBe(1002);
+    expect(selectedToolEventSummary(state, 9999)?.agentEntityId).toBe(1001);
+  });
+
+  test("tracks replay and incident stream counts and resets cleanly", () => {
+    const state = createLiveDebugState();
+    recordLiveDebugDocument(state, {
+      kind: "replay",
+      documentType: "replay_file",
+      payload: {
+        header: {
+          name: "flagship",
+          timestamp: 1_741_315_200,
+          world_seed: 42,
+          tick_count: 22,
+          agent_count: 2,
+          notes: "debug"
+        },
+        traces: [],
+        telemetry_windows: [],
+        training_samples: []
+      }
+    } as LiveDebugDocument);
+    recordLiveDebugDocument(state, {
+      kind: "incident",
+      documentType: "shard_incident_summary",
+      payload: {
+        shard_id: "alpha-1",
+        latest_tick: 22,
+        severity: "Warning",
+        summary: "tool-call rate high",
+        tick_budget_overrun_rate: 0.08,
+        action_rejection_rate: 0.02,
+        tool_call_error_rate: 0.11,
+        average_tool_latency_ms: 820,
+        average_trajectory_distance: 3.2,
+        peak_entity_count: 512,
+        peak_agent_count: 128,
+        capture_actions: 4,
+        summon_actions: 2,
+        gather_actions: 7,
+        loot_actions: 9,
+        notes: []
+      }
+    } as LiveDebugDocument);
+
+    expect(state.liveReplayDocuments).toBe(1);
+    expect(state.liveIncidentDocuments).toBe(1);
+
+    resetLiveDebugState(state);
+
+    expect(state.liveReplayDocuments).toBe(0);
+    expect(state.liveIncidentDocuments).toBe(0);
+    expect(selectedToolEventSummary(state, null)).toBeNull();
+    expect(selectedTickRollupSummary(state, null)).toBeNull();
+  });
+});

--- a/apps/pod-web/src/live-debug.ts
+++ b/apps/pod-web/src/live-debug.ts
@@ -1,0 +1,94 @@
+import type {
+  AgentTickRollupDocument,
+  AgentToolCallEventDocument,
+  LiveDebugDocument,
+  TickRollupSummary,
+  ToolCallEventSummary
+} from "./contracts";
+import {
+  summarizeAgentTickRollup,
+  summarizeAgentToolCallEvent
+} from "./contracts";
+
+export interface LiveDebugState {
+  latestToolEventSummary: ToolCallEventSummary | null;
+  latestRollupSummary: TickRollupSummary | null;
+  liveReplayDocuments: number;
+  liveIncidentDocuments: number;
+  toolEventsByEntity: Map<number, ToolCallEventSummary>;
+  rollupsByEntity: Map<number, TickRollupSummary>;
+}
+
+export function createLiveDebugState(): LiveDebugState {
+  return {
+    latestToolEventSummary: null,
+    latestRollupSummary: null,
+    liveReplayDocuments: 0,
+    liveIncidentDocuments: 0,
+    toolEventsByEntity: new Map(),
+    rollupsByEntity: new Map()
+  };
+}
+
+export function resetLiveDebugState(state: LiveDebugState): void {
+  state.latestToolEventSummary = null;
+  state.latestRollupSummary = null;
+  state.liveReplayDocuments = 0;
+  state.liveIncidentDocuments = 0;
+  state.toolEventsByEntity.clear();
+  state.rollupsByEntity.clear();
+}
+
+export function recordLiveDebugDocument(
+  state: LiveDebugState,
+  document: LiveDebugDocument
+): void {
+  switch (document.kind) {
+    case "toolCallEvent":
+      state.latestToolEventSummary = summarizeAgentToolCallEvent(
+        document.payload as AgentToolCallEventDocument
+      );
+      state.toolEventsByEntity.set(
+        state.latestToolEventSummary.agentEntityId,
+        state.latestToolEventSummary
+      );
+      break;
+    case "tickRollup":
+      state.latestRollupSummary = summarizeAgentTickRollup(
+        document.payload as AgentTickRollupDocument
+      );
+      state.rollupsByEntity.set(
+        state.latestRollupSummary.agentEntityId,
+        state.latestRollupSummary
+      );
+      break;
+    case "replay":
+      state.liveReplayDocuments += 1;
+      break;
+    case "incident":
+      state.liveIncidentDocuments += 1;
+      break;
+    case "tickTelemetry":
+      break;
+  }
+}
+
+export function selectedToolEventSummary(
+  state: LiveDebugState,
+  entityId: number | null
+): ToolCallEventSummary | null {
+  if (entityId == null) {
+    return state.latestToolEventSummary;
+  }
+  return state.toolEventsByEntity.get(entityId) ?? state.latestToolEventSummary;
+}
+
+export function selectedTickRollupSummary(
+  state: LiveDebugState,
+  entityId: number | null
+): TickRollupSummary | null {
+  if (entityId == null) {
+    return state.latestRollupSummary;
+  }
+  return state.rollupsByEntity.get(entityId) ?? state.latestRollupSummary;
+}

--- a/apps/pod-web/src/main.ts
+++ b/apps/pod-web/src/main.ts
@@ -12,14 +12,10 @@ import {
   parseShardIncidentSummary,
   parseThreeJsWebGpuFrame,
   parseTickTelemetryEnvelope,
-  summarizeAgentTickRollup,
-  summarizeAgentToolCallEvent,
   summarizeReplayFile,
   withInteractionMarkers,
   withWorldEventMarkers,
   type ThreeJsWebGpuFrame,
-  type TickRollupSummary,
-  type ToolCallEventSummary,
   type ReplaySummary,
   type ShardIncidentSummary
 } from "./contracts";
@@ -58,6 +54,13 @@ import {
   formatPopulationHeatmapLegend,
   renderPopulationHeatmap
 } from "./population-heatmap";
+import {
+  createLiveDebugState,
+  recordLiveDebugDocument,
+  resetLiveDebugState,
+  selectedTickRollupSummary,
+  selectedToolEventSummary
+} from "./live-debug";
 
 declare global {
   interface Window {
@@ -224,10 +227,7 @@ let latestFrame: string | ReturnType<typeof buildAuthoritativeWorldFrame> | null
 let lastTelemetryRevision = -1;
 let latestReplaySummary: ReplaySummary | null = null;
 let latestIncidentSummary: ShardIncidentSummary | null = null;
-let latestToolEventSummary: ToolCallEventSummary | null = null;
-let latestRollupSummary: TickRollupSummary | null = null;
-let liveReplayDocuments = 0;
-let liveIncidentDocuments = 0;
+const liveDebugState = createLiveDebugState();
 let latestSnapshot: NetworkWorldSnapshot | null = null;
 let latestActionStatus: DirectConnectActionState = {
   pendingCount: 0,
@@ -986,10 +986,7 @@ window.podRender = {
     recentWorldEvents = [];
     latestReplaySummary = null;
     latestIncidentSummary = null;
-    latestToolEventSummary = null;
-    latestRollupSummary = null;
-    liveReplayDocuments = 0;
-    liveIncidentDocuments = 0;
+    resetLiveDebugState(liveDebugState);
     if (localSandbox) {
       localSandbox.reset();
       cameraRig.initialized = false;
@@ -1090,24 +1087,21 @@ window.advanceTime = async (ms: number) => {
 
 function applyLiveDebugDocument(document: string): void {
   const parsed = parseLiveDebugDocument(document);
+  recordLiveDebugDocument(liveDebugState, parsed);
 
   switch (parsed.kind) {
     case "tickTelemetry":
       applyTickTelemetry(telemetryState, parsed.payload);
       break;
     case "toolCallEvent":
-      latestToolEventSummary = summarizeAgentToolCallEvent(parsed.payload);
       break;
     case "tickRollup":
-      latestRollupSummary = summarizeAgentTickRollup(parsed.payload);
       break;
     case "replay":
       latestReplaySummary = summarizeReplayFile(parsed.payload);
-      liveReplayDocuments += 1;
       break;
     case "incident":
       latestIncidentSummary = parsed.payload;
-      liveIncidentDocuments += 1;
       break;
   }
 }
@@ -1199,6 +1193,9 @@ function renderTelemetryHud(): void {
   const stats = telemetryStats(telemetryState);
   const target = selectedTarget();
   const controlled = controlledEntity();
+  const debugFocusEntityId = target?.id ?? controlled?.id ?? null;
+  const focusedToolEvent = selectedToolEventSummary(liveDebugState, debugFocusEntityId);
+  const focusedRollup = selectedTickRollupSummary(liveDebugState, debugFocusEntityId);
   const populationHeatmap = currentPopulationHeatmap();
   connectionNode.textContent = liveConnectionStatus
     ? `${liveConnectionStatus.phase} · ${liveConnectionStatus.detail}`
@@ -1245,20 +1242,24 @@ function renderTelemetryHud(): void {
       )}u`
     : "No replay summary loaded";
   incidentSummaryNode.textContent = latestIncidentSummary
-    ? `${latestIncidentSummary.severity} · ${latestIncidentSummary.summary} · stream ${liveIncidentDocuments}`
+    ? `${latestIncidentSummary.severity} · ${latestIncidentSummary.summary} · stream ${liveDebugState.liveIncidentDocuments}`
     : "No shard incident summary loaded";
-  toolEventSummaryNode.textContent = latestToolEventSummary
-    ? `E(${latestToolEventSummary.agentEntityId}) · ${latestToolEventSummary.toolName} · ${latestToolEventSummary.status} · ${latestToolEventSummary.latencyMs}ms`
+  toolEventSummaryNode.textContent = focusedToolEvent
+    ? `E(${focusedToolEvent.agentEntityId}) · ${focusedToolEvent.toolName} · ${focusedToolEvent.status} · ${focusedToolEvent.latencyMs}ms${
+        debugFocusEntityId != null ? " · focus" : ""
+      }`
     : "No tool-call event loaded";
-  rollupSummaryNode.textContent = latestRollupSummary
-    ? `E(${latestRollupSummary.agentEntityId}) · ticks ${latestRollupSummary.tickStart}-${latestRollupSummary.tickEnd} · ${latestRollupSummary.totalDistance.toFixed(
+  rollupSummaryNode.textContent = focusedRollup
+    ? `E(${focusedRollup.agentEntityId}) · ticks ${focusedRollup.tickStart}-${focusedRollup.tickEnd} · ${focusedRollup.totalDistance.toFixed(
         2
-      )}u · ${latestRollupSummary.toolErrorCount} tool errors`
+      )}u · ${focusedRollup.toolErrorCount} tool errors${
+        debugFocusEntityId != null ? " · focus" : ""
+      }`
     : "No telemetry rollup loaded";
   if (latestReplaySummary) {
     replaySummaryNode.textContent = `${latestReplaySummary.name} · ${latestReplaySummary.traceCount} traces · ${latestReplaySummary.trainingSampleCount} samples · ${latestReplaySummary.totalPathDistance.toFixed(
       2
-    )}u · stream ${liveReplayDocuments}`;
+    )}u · stream ${liveDebugState.liveReplayDocuments}`;
   }
 }
 

--- a/progress.md
+++ b/progress.md
@@ -29,3 +29,4 @@ Original prompt: its the graphics and the worlds scene, everything is piled up o
 - Added a deterministic Playwright smoke harness for `pod-web` that proves both main-thread and worker-thread routes accept movement input under automation, using `?backend=webgl2` as the stable parity backend for browser CI/debug runs.
 - Wired `pod-editor` selected-entity telemetry consumption to raw SpacetimeDB tool-call and rollup docs, so narrow entity-scoped debug subscriptions still produce useful per-selection telemetry and export data even without full tick frames.
 - Added a `pod-net` helper that mirrors editor selection into the active entity-scoped SpacetimeDB debug subscription profile, reducing consumer-side profile plumbing.
+- Added retained per-entity live-debug state in `pod-web`, so browser runtime/tooling can keep focused tool-call and rollup summaries for the selected target or controlled entity instead of only showing the last global debug document.


### PR DESCRIPTION
## Summary
- retain browser live-debug tool and rollup summaries per entity instead of only tracking the last global debug document
- bind the pod-web telemetry HUD to the focused entity (selected target or controlled entity) for selected-entity raw debug streams
- record the new browser/runtime selected-entity debug telemetry slice in plan and progress docs

## Testing
- cd apps/pod-web && bun test ./src/live-debug.test.ts ./src/contracts.test.ts ./src/controls.test.ts ./src/render-runtime.test.ts
- cd apps/pod-web && bun run typecheck
- cd apps/pod-web && bun run build
- git diff --check