### PR TITLE
Polish pod-web HUD and shard debug focus summaries

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1019,5 +1019,17 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cd apps/pod-web && bun run build`
   - `git diff --check`
 
-**Last updated**: Iteration 102
-**Current focus**: Iteration 103 further HUD reduction, richer traversal/combat feedback, and deeper shard/runtime consumption of selected-entity debug telemetry
+### Iteration 103
+- [x] Reduced the `pod-web` main HUD to a shorter gameplay-facing runtime line and upgraded authoritative event copy so combat/world outcomes read more clearly than raw event kinds.
+- [x] Added shared `FocusedEntityDebugSummary` TOON-exportable primitives in `pod-core` and shard-side focused summary/document generation in `pod-server` from retained telemetry archives.
+- [x] Added deterministic coverage for compact HUD/event formatting plus focused-entity TOON summary generation.
+- [x] Revalidated touched targets:
+  - `cd apps/pod-web && bun test ./src/hud.test.ts ./src/live-debug.test.ts ./src/contracts.test.ts ./src/controls.test.ts ./src/render-runtime.test.ts`
+  - `cd apps/pod-web && bun run typecheck`
+  - `cd apps/pod-web && bun run build`
+  - `cargo test -p pod-core --lib`
+  - `cargo test -p pod-server --bin pod-server`
+  - `git diff --check`
+
+**Last updated**: Iteration 103
+**Current focus**: Iteration 104 richer traversal/combat feedback, deeper shard/runtime consumers for focused debug summaries, and further gameplay-first HUD reduction

--- a/apps/pod-server/src/main.rs
+++ b/apps/pod-server/src/main.rs
@@ -383,7 +383,8 @@ mod stats {
     use pod_core::action::Action;
     use pod_core::telemetry::ToolCallStatus;
     use pod_core::{
-        AgentTickRollup, AgentToolCallEvent, IncidentSeverity, ShardIncidentSummary,
+        AgentTickRollup, AgentToolCallEvent, FocusedEntityDebugSummary, IncidentSeverity,
+        ShardIncidentSummary,
         TelemetryArchive, TelemetryConfig, VersionedTickTelemetry,
     };
     use std::collections::{HashMap, VecDeque};
@@ -726,6 +727,101 @@ mod stats {
             self.pending_documents.drain(..).collect()
         }
 
+        pub fn focused_entity_summary(&self, entity_id: u64) -> Option<FocusedEntityDebugSummary> {
+            let mut latest_tick = 0;
+            let mut tool_call_count = 0usize;
+            let mut tool_error_count = 0usize;
+            let mut total_tool_latency_ms = 0u64;
+            let mut rejected_action_count = 0usize;
+            let mut total_distance = 0.0f32;
+            let mut visible_entity_count = 0usize;
+            let mut audible_event_count = 0usize;
+            let mut message_count = 0usize;
+            let mut latest_tool_name = None;
+            let mut latest_tool_status = None;
+            let mut latest_tool_error = None;
+
+            for frame in self.archive.frames() {
+                for agent in &frame.agents {
+                    let Some(agent_entity_id) = agent.entity_id else {
+                        continue;
+                    };
+                    if agent_entity_id.0 != entity_id {
+                        continue;
+                    }
+
+                    latest_tick = latest_tick.max(frame.tick);
+                    visible_entity_count = agent.visible_entity_count;
+                    audible_event_count = agent.audible_event_count;
+                    message_count = agent.message_count;
+                    if let Some(trajectory) = &agent.trajectory {
+                        total_distance += trajectory.distance_travelled;
+                    }
+                    rejected_action_count += agent
+                        .action_trace
+                        .iter()
+                        .filter(|trace| {
+                            matches!(trace.stage, pod_core::ActionLifecycleStage::Rejected)
+                        })
+                        .count();
+                    for trace in &agent.tool_calls {
+                        tool_call_count += 1;
+                        total_tool_latency_ms += trace.latency_ms as u64;
+                        latest_tool_name = Some(trace.tool_name.clone());
+                        latest_tool_status = Some(format!("{:?}", trace.status));
+                        latest_tool_error = trace.error_message.clone();
+                        if !matches!(
+                            trace.status,
+                            ToolCallStatus::Succeeded | ToolCallStatus::Requested
+                        ) {
+                            tool_error_count += 1;
+                        }
+                    }
+                }
+            }
+
+            if latest_tick == 0 && tool_call_count == 0 && rejected_action_count == 0 {
+                return None;
+            }
+
+            let average_tool_latency_ms = if tool_call_count == 0 {
+                0.0
+            } else {
+                total_tool_latency_ms as f32 / tool_call_count as f32
+            };
+
+            let mut notes = Vec::new();
+            if tool_error_count > 0 {
+                notes.push(format!("{tool_error_count} tool-call errors retained"));
+            }
+            if rejected_action_count > 0 {
+                notes.push(format!("{rejected_action_count} rejected actions retained"));
+            }
+
+            Some(FocusedEntityDebugSummary {
+                shard_id: self.shard_id.clone(),
+                entity_id,
+                latest_tick,
+                tool_call_count,
+                tool_error_count,
+                rejected_action_count,
+                total_distance,
+                average_tool_latency_ms,
+                visible_entity_count,
+                audible_event_count,
+                message_count,
+                latest_tool_name,
+                latest_tool_status,
+                latest_tool_error,
+                notes,
+            })
+        }
+
+        pub fn focused_entity_document(&self, entity_id: u64) -> Option<String> {
+            self.focused_entity_summary(entity_id)
+                .map(|summary| summary.to_toon_document())
+        }
+
         fn rollups_for_tick(&self, tick_end: u64) -> Vec<AgentTickRollup> {
             let tick_start = tick_end.saturating_sub(ROLLUP_WINDOW_TICKS - 1);
             let mut frames_by_agent = HashMap::<u64, Vec<pod_core::AgentTelemetryFrame>>::new();
@@ -932,6 +1028,34 @@ mod stats {
             assert!(documents.iter().any(|document| decode_toon_value(document)
                 .map(|value| value["document_type"] == "shard_incident_summary")
                 .unwrap_or(false)));
+        }
+
+        #[test]
+        fn shard_ops_debug_stream_builds_focused_entity_debug_documents() {
+            let mut stats = ServerStats::new(60);
+            let mut stream = ShardOpsDebugStream::new("overworld-a");
+
+            for tick in 0..6 {
+                let tick_result = sample_tick_at(tick);
+                stats.record_tick(&tick_result, 5, false);
+                stream.record_tick(&tick_result, &stats);
+            }
+
+            let summary = stream
+                .focused_entity_summary(41)
+                .expect("focused summary should exist");
+            assert_eq!(summary.entity_id, 41);
+            assert_eq!(summary.shard_id, "overworld-a");
+            assert!(summary.tool_call_count >= 1);
+            assert!(summary.total_distance > 0.0);
+
+            let document = stream
+                .focused_entity_document(41)
+                .expect("focused document should exist");
+            let value = decode_toon_value(&document).expect("focused document should decode");
+            assert_eq!(value["document_type"], "focused_entity_debug_summary");
+            assert_eq!(value["payload"]["entity_id"], 41);
+            assert_eq!(value["payload"]["shard_id"], "overworld-a");
         }
     }
 }

--- a/apps/pod-web/src/hud.test.ts
+++ b/apps/pod-web/src/hud.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+
+import { compactRuntimeStats, highlightEventFeedback } from "./hud";
+import type { NetworkGameEvent } from "./contracts";
+import type { PodThreeRendererStats } from "./renderer";
+
+function sampleStats(): PodThreeRendererStats {
+  return {
+    backend: "webgpu",
+    qualityPreset: "ultra",
+    renderThread: "worker",
+    environmentPreset: "daylight",
+    timeOfDayHours: 12.2,
+    landscapeMode: "cliff-lagoon-heightfield",
+    waterMode: "animated-lagoon",
+    drawCalls: 48,
+    triangles: 117277,
+    textures: 12,
+    pixelRatio: 1.92,
+    frameMs: 16.4,
+    residentGeometryAssets: 8,
+    residentSpriteAssets: 2,
+    pendingGeometryAssets: 0,
+    pendingSpriteAssets: 0,
+    ambientInstances: 14,
+    visibleWorldChunks: 4,
+    preloadedWorldChunks: 8
+  };
+}
+
+function sampleEvent(kind: string, summary: string): NetworkGameEvent {
+  return {
+    tick: 42,
+    origin: [1, 2],
+    kind,
+    summary,
+    entityIds: [1001]
+  };
+}
+
+describe("hud formatting", () => {
+  test("compacts renderer stats into a shorter gameplay-facing line", () => {
+    expect(compactRuntimeStats(sampleStats())).toBe(
+      "webgpu/worker · daylight 12.2h · 16.4ms @ 1.92x · 48 draw / 117k tris · 4/8 chunks · 10/0 assets · ambient 14"
+    );
+  });
+
+  test("maps combat and world events into stronger feedback labels", () => {
+    expect(highlightEventFeedback(sampleEvent("Damage", "12 to Rift Beast"))).toBe(
+      "Combat hit · 12 to Rift Beast"
+    );
+    expect(highlightEventFeedback(sampleEvent("Capture", "Spirit Cub captured"))).toBe(
+      "Capture result · Spirit Cub captured"
+    );
+    expect(highlightEventFeedback(sampleEvent("Summon", "Companion recalled"))).toBe(
+      "Companion active · Companion recalled"
+    );
+    expect(highlightEventFeedback(sampleEvent("Dialogue", "Merchant greeted you"))).toBe(
+      "Merchant greeted you"
+    );
+  });
+});

--- a/apps/pod-web/src/hud.ts
+++ b/apps/pod-web/src/hud.ts
@@ -1,0 +1,51 @@
+import type { NetworkGameEvent } from "./contracts";
+import type { PodThreeRendererStats } from "./renderer";
+
+function formatKilo(value: number): string {
+  if (value >= 1000) {
+    return `${(value / 1000).toFixed(value >= 10000 ? 0 : 1)}k`;
+  }
+  return `${value}`;
+}
+
+export function compactRuntimeStats(stats: PodThreeRendererStats): string {
+  return [
+    `${stats.backend}/${stats.renderThread}`,
+    `${stats.environmentPreset} ${stats.timeOfDayHours.toFixed(1)}h`,
+    `${stats.frameMs.toFixed(1)}ms @ ${stats.pixelRatio.toFixed(2)}x`,
+    `${stats.drawCalls} draw / ${formatKilo(stats.triangles)} tris`,
+    `${stats.visibleWorldChunks}/${stats.preloadedWorldChunks} chunks`,
+    `${stats.residentGeometryAssets + stats.residentSpriteAssets}/${
+      stats.pendingGeometryAssets + stats.pendingSpriteAssets
+    } assets`,
+    `ambient ${stats.ambientInstances}`
+  ].join(" · ");
+}
+
+export function highlightEventFeedback(event: NetworkGameEvent | null): string {
+  if (!event) {
+    return "No authoritative world events yet";
+  }
+
+  const kind = event.kind.toLowerCase();
+  if (kind.includes("damage")) {
+    return `Combat hit · ${event.summary}`;
+  }
+  if (kind.includes("kill")) {
+    return `Target down · ${event.summary}`;
+  }
+  if (kind.includes("capture")) {
+    return `Capture result · ${event.summary}`;
+  }
+  if (kind.includes("loot")) {
+    return `Loot secured · ${event.summary}`;
+  }
+  if (kind.includes("gather")) {
+    return `Gather progress · ${event.summary}`;
+  }
+  if (kind.includes("summon")) {
+    return `Companion active · ${event.summary}`;
+  }
+
+  return event.summary;
+}

--- a/apps/pod-web/src/main.ts
+++ b/apps/pod-web/src/main.ts
@@ -54,6 +54,7 @@ import {
   formatPopulationHeatmapLegend,
   renderPopulationHeatmap
 } from "./population-heatmap";
+import { compactRuntimeStats, highlightEventFeedback } from "./hud";
 import {
   createLiveDebugState,
   recordLiveDebugDocument,
@@ -552,7 +553,7 @@ function applyAuthoritativeEventBatch(batch: NetworkEventBatch): void {
       ) ?? batch.events.at(-1);
 
   if (highlighted) {
-    latestFeedback = `[${highlighted.kind}] ${highlighted.summary}`;
+    latestFeedback = highlightEventFeedback(highlighted);
   }
 }
 
@@ -1177,15 +1178,7 @@ async function renderCurrentFrame(timestamp: number): Promise<void> {
   }
 
   const stats = renderer.getStats();
-  runtimeStatsLabel.textContent = `${stats.drawCalls} calls · ${stats.triangles} tris · ${stats.pixelRatio.toFixed(
-    2
-  )}x DPR · ${stats.frameMs.toFixed(1)}ms · ${stats.renderThread} thread · ${stats.environmentPreset} ${stats.timeOfDayHours.toFixed(
-    1
-  )}h · ${stats.landscapeMode} · ${stats.waterMode} · ambient ${stats.ambientInstances} · chunks ${
-    stats.visibleWorldChunks
-  } visible / ${stats.preloadedWorldChunks} warm · assets ${
-    stats.residentGeometryAssets + stats.residentSpriteAssets
-  } resident / ${stats.pendingGeometryAssets + stats.pendingSpriteAssets} pending`;
+  runtimeStatsLabel.textContent = compactRuntimeStats(stats);
   renderTelemetryHud();
 }
 

--- a/crates/pod-core/src/lib.rs
+++ b/crates/pod-core/src/lib.rs
@@ -79,7 +79,7 @@ pub use observation::*;
 pub use observation_filter::{
     FilteredObservation, ObservationFilter, ObservationHistory, SalienceScore,
 };
-pub use ops::{IncidentSeverity, ShardIncidentSummary};
+pub use ops::{FocusedEntityDebugSummary, IncidentSeverity, ShardIncidentSummary};
 pub use orchestrator::{AgentBatch, AgentOrchestrator, DecisionFreshness, PriorityScore};
 pub use replay::{
     ActionOutcomeSummary, DecisionTrace, EncounterTransition, ReplayFile, ReplayHeader,

--- a/crates/pod-core/src/ops.rs
+++ b/crates/pod-core/src/ops.rs
@@ -35,3 +35,91 @@ impl ShardIncidentSummary {
         encode_toon_document("shard_incident_summary", self)
     }
 }
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct FocusedEntityDebugSummary {
+    pub shard_id: String,
+    pub entity_id: u64,
+    pub latest_tick: u64,
+    pub tool_call_count: usize,
+    pub tool_error_count: usize,
+    pub rejected_action_count: usize,
+    pub total_distance: f32,
+    pub average_tool_latency_ms: f32,
+    pub visible_entity_count: usize,
+    pub audible_event_count: usize,
+    pub message_count: usize,
+    pub latest_tool_name: Option<String>,
+    pub latest_tool_status: Option<String>,
+    pub latest_tool_error: Option<String>,
+    pub notes: Vec<String>,
+}
+
+impl FocusedEntityDebugSummary {
+    pub fn to_toon_document(&self) -> String {
+        encode_toon_document("focused_entity_debug_summary", self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::toon::decode_toon_value;
+
+    use super::{FocusedEntityDebugSummary, IncidentSeverity, ShardIncidentSummary};
+
+    #[test]
+    fn shard_incident_summary_exports_to_toon() {
+        let summary = ShardIncidentSummary {
+            shard_id: "verdant-hollow".to_string(),
+            latest_tick: 1440,
+            severity: IncidentSeverity::Warning,
+            summary: "tick budget drift".to_string(),
+            tick_budget_overrun_rate: 0.12,
+            action_rejection_rate: 0.03,
+            tool_call_error_rate: 0.01,
+            average_tool_latency_ms: 88.0,
+            average_trajectory_distance: 4.5,
+            peak_entity_count: 96,
+            peak_agent_count: 24,
+            capture_actions: 2,
+            summon_actions: 1,
+            gather_actions: 7,
+            loot_actions: 5,
+            notes: vec!["late spike".to_string()],
+        };
+
+        let value =
+            decode_toon_value(&summary.to_toon_document()).expect("incident summary should decode");
+        assert_eq!(value["document_type"], "shard_incident_summary");
+        assert_eq!(value["payload"]["shard_id"], "verdant-hollow");
+        assert_eq!(value["payload"]["severity"], "Warning");
+    }
+
+    #[test]
+    fn focused_entity_debug_summary_exports_to_toon() {
+        let summary = FocusedEntityDebugSummary {
+            shard_id: "verdant-hollow".to_string(),
+            entity_id: 41,
+            latest_tick: 1440,
+            tool_call_count: 3,
+            tool_error_count: 1,
+            rejected_action_count: 2,
+            total_distance: 18.5,
+            average_tool_latency_ms: 42.0,
+            visible_entity_count: 9,
+            audible_event_count: 2,
+            message_count: 1,
+            latest_tool_name: Some("llm.complete".to_string()),
+            latest_tool_status: Some("Succeeded".to_string()),
+            latest_tool_error: None,
+            notes: vec!["2 rejected actions retained".to_string()],
+        };
+
+        let value = decode_toon_value(&summary.to_toon_document())
+            .expect("focused entity summary should decode");
+        assert_eq!(value["document_type"], "focused_entity_debug_summary");
+        assert_eq!(value["payload"]["entity_id"], 41);
+        assert_eq!(value["payload"]["tool_call_count"], 3);
+        assert_eq!(value["payload"]["latest_tool_name"], "llm.complete");
+    }
+}

--- a/progress.md
+++ b/progress.md
@@ -30,3 +30,5 @@ Original prompt: its the graphics and the worlds scene, everything is piled up o
 - Wired `pod-editor` selected-entity telemetry consumption to raw SpacetimeDB tool-call and rollup docs, so narrow entity-scoped debug subscriptions still produce useful per-selection telemetry and export data even without full tick frames.
 - Added a `pod-net` helper that mirrors editor selection into the active entity-scoped SpacetimeDB debug subscription profile, reducing consumer-side profile plumbing.
 - Added retained per-entity live-debug state in `pod-web`, so browser runtime/tooling can keep focused tool-call and rollup summaries for the selected target or controlled entity instead of only showing the last global debug document.
+- Reduced the `pod-web` main runtime HUD to a shorter gameplay-facing line and remapped authoritative event copy so combat and world outcomes read as player feedback instead of raw protocol labels.
+- Added `FocusedEntityDebugSummary` in `pod-core` and shard-side focused summary/document generation in `pod-server`, so retained telemetry archives can produce a TOON summary for the currently inspected entity without replaying the whole shard stream.


### PR DESCRIPTION
## Summary
- compact the pod-web runtime HUD and upgrade event feedback copy for gameplay readability
- add a shared focused-entity debug summary primitive in pod-core with shard-side TOON summary generation in pod-server
- record Iteration 103 in the implementation plan and progress log

## Testing
- cd apps/pod-web && bun test ./src/hud.test.ts ./src/live-debug.test.ts ./src/contracts.test.ts ./src/controls.test.ts ./src/render-runtime.test.ts
- cd apps/pod-web && bun run typecheck
- cd apps/pod-web && bun run build
- cargo test -p pod-core --lib
- cargo test -p pod-server --bin pod-server
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-entity debug summary generation for retained telemetry archives, enabling focused entity inspection without full replay

* **Improvements**
  * Simplified HUD display with compact runtime statistics formatting
  * Event feedback now presents combat and world outcomes directly to players instead of technical protocol labels

<!-- end of auto-generated comment: release notes by coderabbit.ai -->