### PR TITLE
Tighten pod-web traversal and swim feel

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1075,5 +1075,16 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - Playwright local browser proof on `http://127.0.0.1:4178/` for arrow-key orbit plus click-to-swim movement
   - `git diff --check`
 
-**Last updated**: Iteration 107
-**Current focus**: Iteration 108 richer traversal/combat feedback, tighter collision/interaction feel, smoother worker-route gameplay parity, and further gameplay-first HUD reduction on top of the corrected browser control/grounding path
+### Iteration 108
+- [x] Tightened flagship traversal feel by adding stronger movement response profiles, steering-aware slide resolution, and more deterministic collision progress around solid world props instead of sticky stop/start motion.
+- [x] Added actual swim presentation feel on top of the existing surface correctness: swimmer animation now glides forward with buoyancy and the camera blends toward a lower, wider swim framing with impact kick preserved for combat-heavy moments.
+- [x] Reduced main HUD weight again while keeping stronger action readability through shorter on-screen control copy and upgraded combat/world feedback labels.
+- [x] Revalidated touched targets:
+  - `cd apps/pod-web && bun test ./src/local-world.test.ts ./src/frame-plan.test.ts ./src/hud.test.ts ./src/controls.test.ts ./src/contracts.test.ts`
+  - `cd apps/pod-web && bun run typecheck`
+  - `cd apps/pod-web && bun run build`
+  - Live Playwright MCP proof on `http://127.0.0.1:4179/` for camera orbit, click/WASD traversal, and swim-state transition
+  - `git diff --check`
+
+**Last updated**: Iteration 108
+**Current focus**: Iteration 109 worker-route gameplay-input parity proof, richer close-range combat response, and further reduction of debug chrome in the flagship browser client without losing creator inspection depth

--- a/apps/pod-web/index.html
+++ b/apps/pod-web/index.html
@@ -47,10 +47,10 @@
       .hud {
         position: absolute;
         inset: 18px auto auto 18px;
-        width: min(292px, calc(100vw - 36px));
-        padding: 12px 12px 10px;
+        width: min(276px, calc(100vw - 36px));
+        padding: 10px 10px 9px;
         border: 1px solid var(--panel-border);
-        border-radius: 16px;
+        border-radius: 15px;
         background:
           linear-gradient(180deg, rgba(10, 16, 26, 0.76), rgba(7, 11, 18, 0.6)),
           var(--panel-bg);
@@ -60,7 +60,7 @@
 
       .hud--telemetry {
         inset: auto 20px 20px auto;
-        width: min(320px, calc(100vw - 40px));
+        width: min(296px, calc(100vw - 40px));
         max-height: min(52vh, 460px);
         overflow: auto;
       }
@@ -81,7 +81,7 @@
         align-items: center;
         justify-content: space-between;
         gap: 10px;
-        margin-bottom: 8px;
+        margin-bottom: 6px;
         color: var(--muted);
         font-size: 0.74rem;
         letter-spacing: 0.08em;
@@ -97,8 +97,8 @@
       .hud__badge-row {
         display: flex;
         flex-wrap: wrap;
-        gap: 8px;
-        margin-top: 8px;
+        gap: 6px;
+        margin-top: 7px;
       }
 
       .hud__badge {
@@ -109,21 +109,21 @@
         border-radius: 999px;
         background: rgba(138, 245, 207, 0.08);
         color: var(--copy);
-        padding: 6px 10px;
-        font-size: 0.8rem;
+        padding: 5px 9px;
+        font-size: 0.76rem;
       }
 
       .hud__stack {
         display: grid;
-        gap: 7px;
-        margin-top: 8px;
+        gap: 6px;
+        margin-top: 7px;
       }
 
       .hud__card {
         border: 1px solid rgba(130, 170, 255, 0.16);
-        border-radius: 14px;
+        border-radius: 12px;
         background: rgba(3, 7, 12, 0.38);
-        padding: 8px 10px;
+        padding: 7px 9px;
       }
 
       .hud__card-label {
@@ -135,18 +135,18 @@
 
       .hud__card-value {
         display: block;
-        margin-top: 4px;
+        margin-top: 3px;
         color: var(--copy);
-        font-size: 0.94rem;
-        line-height: 1.28;
+        font-size: 0.91rem;
+        line-height: 1.24;
       }
 
       .hud__card-meta {
         display: block;
-        margin-top: 4px;
+        margin-top: 3px;
         color: var(--muted);
-        line-height: 1.28;
-        font-size: 0.83rem;
+        line-height: 1.24;
+        font-size: 0.8rem;
       }
 
       #event-feed-label {
@@ -179,7 +179,7 @@
         align-items: center;
         justify-content: space-between;
         gap: 12px;
-        margin-top: 10px;
+        margin-top: 8px;
       }
 
       .hud__controls-group {
@@ -209,12 +209,12 @@
       .hud__chat {
         display: grid;
         grid-template-columns: 1fr auto;
-        gap: 8px;
-        margin-top: 10px;
+        gap: 7px;
+        margin-top: 8px;
       }
 
       .hud__heatmap {
-        margin-top: 12px;
+        margin-top: 10px;
       }
 
       .hud__heatmap-header {
@@ -237,9 +237,9 @@
       }
 
       .hud__details {
-        margin-top: 12px;
+        margin-top: 10px;
         border-top: 1px solid rgba(130, 170, 255, 0.14);
-        padding-top: 10px;
+        padding-top: 8px;
       }
 
       .hud__details summary {
@@ -260,7 +260,7 @@
         border-radius: 999px;
         background: rgba(5, 9, 15, 0.72);
         color: var(--copy);
-        padding: 9px 12px;
+        padding: 8px 11px;
         font: inherit;
       }
 
@@ -271,7 +271,7 @@
       #telemetry-panel[data-telemetry-enabled="false"] {
         width: auto;
         max-height: none;
-        padding: 12px 14px;
+        padding: 10px 12px;
       }
 
       #telemetry-panel[data-telemetry-enabled="false"] h1,
@@ -293,7 +293,7 @@
           <span id="backend-label">starting…</span>
         </div>
         <p class="hud__statusline" id="feedback-label">
-          Starting local browser shard
+          Verdant Hollow is coming online
         </p>
         <div class="hud__badge-row">
           <span class="hud__badge" id="connection-label">local sandbox booting</span>
@@ -308,7 +308,7 @@
           <div class="hud__card">
             <span class="hud__card-label">Target</span>
             <strong class="hud__card-value" id="target-label">No target selected</strong>
-            <span class="hud__card-meta" id="affordance-label">Tab to cycle targets</span>
+            <span class="hud__card-meta" id="affordance-label">Tab cycles targets</span>
           </div>
           <div class="hud__card">
             <span class="hud__card-label">Action</span>
@@ -321,7 +321,7 @@
           <button type="submit">Send</button>
         </form>
         <details class="hud__details">
-          <summary>Diagnostics</summary>
+          <summary>Ops + debug</summary>
           <div class="hud__heatmap">
             <div class="hud__heatmap-header">
               <span>Population heatmap</span>
@@ -335,7 +335,7 @@
             <dt>Stats</dt>
             <dd id="stats-label">warming up…</dd>
             <dt>Controls</dt>
-            <dd><code>Click</code> terrain to move · <code>WASD</code> steer · <code>Arrow keys</code> or <code>Right-drag</code> camera · <code>Tab</code> target · <code>Double-click</code> target action · <code>Enter</code> chat</dd>
+            <dd><code>Click</code> move · <code>WASD</code> travel · <code>Arrows</code>/<code>Right-drag</code> camera · <code>Tab</code> target · <code>Double-click</code> act</dd>
             <dt>Bridge</dt>
             <dd><code>window.podRender.renderThreeJsWebGpuFrame(...)</code> or <code>?server=127.0.0.1:7778&amp;debug=1</code></dd>
           </dl>

--- a/apps/pod-web/src/frame-plan.test.ts
+++ b/apps/pod-web/src/frame-plan.test.ts
@@ -618,6 +618,37 @@ describe("sampleAnimatedInstanceTransform", () => {
     expect(pulsed.position[1]).toBeGreaterThan(neutral.position[1]);
     expect(pulsed.scale[0]).toBeGreaterThan(neutral.scale[0]);
   });
+
+  test("gives swimmers forward glide while keeping beasts heavier than humanoids", () => {
+    const humanoidSwim = sampleAnimatedInstanceTransform(
+      {
+        position: [3, 1.5, 4],
+        rotation: [0, 0, 0, 1],
+        scale: [1, 1.9, 1],
+        sourceEntity: 8,
+        animationSetId: "humanoid-swim",
+        motionSpeed: 0.9,
+        controlled: true
+      },
+      1.6
+    );
+    const beastSwim = sampleAnimatedInstanceTransform(
+      {
+        position: [3, 1.5, 4],
+        rotation: [0, 0, 0, 1],
+        scale: [1.3, 1.6, 1.9],
+        sourceEntity: 8,
+        animationSetId: "rift-beast-swim",
+        motionSpeed: 0.9
+      },
+      1.6
+    );
+
+    expect(humanoidSwim.position[2]).toBeGreaterThan(4.05);
+    expect(humanoidSwim.position[1]).toBeGreaterThan(1.55);
+    expect(beastSwim.scale[0]).toBeGreaterThan(humanoidSwim.scale[0]);
+    expect(Math.abs(beastSwim.rotation[2])).toBeLessThan(Math.abs(humanoidSwim.rotation[2]));
+  });
 });
 
 describe("resolveQualityProfile", () => {

--- a/apps/pod-web/src/frame-plan.ts
+++ b/apps/pod-web/src/frame-plan.ts
@@ -356,9 +356,11 @@ export function sampleAnimatedInstanceTransform(
   let scaleX = instance.scale[0];
   let scaleY = instance.scale[1];
   let scaleZ = instance.scale[2];
+  let xOffset = 0;
   let pitchOffset = 0;
   let yawOffset = 0;
   let rollOffset = 0;
+  let zOffset = 0;
 
   if (animationSetId.includes("critical-ring")) {
     const ringPulse = Math.abs(Math.sin(elapsedSeconds * 5.1 + phase));
@@ -391,20 +393,27 @@ export function sampleAnimatedInstanceTransform(
   } else if (animationSetId.includes("swim")) {
     const stroke = Math.sin(elapsedSeconds * (1.6 + motion * 2.8) + phase);
     const glide = Math.cos(elapsedSeconds * (1.2 + motion * 1.8) + phase * 0.7);
-    yOffset += 0.06 + hoverWave * 0.05 + Math.max(motion, 0.18) * 0.04;
+    const surge = Math.max(0, Math.sin(elapsedSeconds * (1.3 + motion * 2.2) + phase * 0.9));
+    const lateralSway = Math.sin(elapsedSeconds * (1.8 + motion * 2.1) + phase * 1.2);
+    yOffset += 0.055 + hoverWave * 0.045 + Math.max(motion, 0.18) * 0.03;
+    xOffset += lateralSway * (0.04 + motion * 0.03);
+    zOffset += surge * (0.07 + motion * 0.06);
     scaleX *= 1 + Math.abs(stroke) * 0.02;
-    scaleY *= 0.93 - Math.max(motion, 0.2) * 0.03;
+    scaleY *= 0.95 - Math.max(motion, 0.2) * 0.028;
     scaleZ *= 1 + Math.abs(glide) * 0.025;
-    pitchOffset += 0.09 + Math.abs(stroke) * 0.04;
+    pitchOffset += 0.075 + Math.abs(stroke) * 0.035;
     yawOffset += glide * 0.025;
     rollOffset += stroke * 0.045;
     if (animationSetId.includes("companion")) {
-      yOffset += 0.05;
+      yOffset += 0.07;
+      zOffset += surge * 0.03;
       scaleY *= 0.97;
     } else if (animationSetId.includes("beast")) {
       scaleX *= 1.04;
       scaleZ *= 1.04;
-      pitchOffset += 0.02;
+      zOffset += surge * 0.06;
+      pitchOffset += 0.04;
+      rollOffset *= 0.72;
     }
   } else if (animationSetId.includes("companion") || animationSetId.includes("hover")) {
     const driftWave = Math.sin(elapsedSeconds * 1.15 + phase * 0.6);
@@ -485,12 +494,13 @@ export function sampleAnimatedInstanceTransform(
     new Euler(pitchOffset, yawOffset, rollOffset)
   );
   const finalRotation = baseRotation.multiply(animationRotation);
+  const animatedOffset = new Vector3(xOffset, yOffset, zOffset).applyQuaternion(baseRotation);
 
   return {
     position: [
-      instance.position[0],
-      instance.position[1] + yOffset,
-      instance.position[2]
+      instance.position[0] + animatedOffset.x,
+      instance.position[1] + animatedOffset.y,
+      instance.position[2] + animatedOffset.z
     ],
     rotation: [finalRotation.x, finalRotation.y, finalRotation.z, finalRotation.w],
     scale: [scaleX, scaleY, scaleZ]

--- a/apps/pod-web/src/hud.test.ts
+++ b/apps/pod-web/src/hud.test.ts
@@ -47,13 +47,13 @@ describe("hud formatting", () => {
 
   test("maps combat and world events into stronger feedback labels", () => {
     expect(highlightEventFeedback(sampleEvent("Damage", "12 to Rift Beast"))).toBe(
-      "Combat hit · 12 to Rift Beast"
+      "Hit confirmed · 12 to Rift Beast"
     );
     expect(highlightEventFeedback(sampleEvent("Capture", "Spirit Cub captured"))).toBe(
-      "Capture result · Spirit Cub captured"
+      "Capture secured · Spirit Cub captured"
     );
     expect(highlightEventFeedback(sampleEvent("Summon", "Companion recalled"))).toBe(
-      "Companion active · Companion recalled"
+      "Companion ready · Companion recalled"
     );
     expect(highlightEventFeedback(sampleEvent("Dialogue", "Merchant greeted you"))).toBe(
       "Merchant greeted you"

--- a/apps/pod-web/src/hud.ts
+++ b/apps/pod-web/src/hud.ts
@@ -29,22 +29,31 @@ export function highlightEventFeedback(event: NetworkGameEvent | null): string {
 
   const kind = event.kind.toLowerCase();
   if (kind.includes("damage")) {
-    return `Combat hit · ${event.summary}`;
+    return `Hit confirmed · ${event.summary}`;
   }
   if (kind.includes("kill")) {
     return `Target down · ${event.summary}`;
   }
+  if (kind.includes("spawn")) {
+    return `Back in the fight · ${event.summary}`;
+  }
   if (kind.includes("capture")) {
-    return `Capture result · ${event.summary}`;
+    return `Capture secured · ${event.summary}`;
   }
   if (kind.includes("loot")) {
-    return `Loot secured · ${event.summary}`;
+    return `Loot claimed · ${event.summary}`;
   }
   if (kind.includes("gather")) {
-    return `Gather progress · ${event.summary}`;
+    return `Resource gathered · ${event.summary}`;
   }
   if (kind.includes("summon")) {
-    return `Companion active · ${event.summary}`;
+    return `Companion ready · ${event.summary}`;
+  }
+  if (kind.includes("command")) {
+    return `Companion order · ${event.summary}`;
+  }
+  if (kind.includes("quest")) {
+    return `Quest progress · ${event.summary}`;
   }
 
   return event.summary;

--- a/apps/pod-web/src/local-world.test.ts
+++ b/apps/pod-web/src/local-world.test.ts
@@ -52,6 +52,38 @@ function moveTowardPoint(world: PodWebLocalWorld, target: [number, number], tick
   stepTicks(world, 1);
 }
 
+function moveWithinRange(
+  world: PodWebLocalWorld,
+  targetId: number,
+  range: number,
+  ticks: number
+): void {
+  let remaining = ticks;
+  while (remaining > 0) {
+    const snapshot = world.snapshotState();
+    const player = snapshot.entities.find((entity) => entity.id === 1);
+    const target = snapshot.entities.find((entity) => entity.id === targetId);
+    if (!player || !target) {
+      return;
+    }
+
+    const dx = target.position[0] - player.position[0];
+    const dy = target.position[1] - player.position[1];
+    const distance = Math.hypot(dx, dy);
+    if (distance <= range) {
+      break;
+    }
+
+    const slice = Math.min(remaining, 8);
+    world.submitActions([{ kind: "move", direction: [dx / distance, dy / distance] }]);
+    stepTicks(world, slice);
+    remaining -= slice;
+  }
+
+  world.submitActions([{ kind: "stop" }]);
+  stepTicks(world, 1);
+}
+
 describe("PodWebLocalWorld", () => {
   test("spawns a connected local sandbox with a controlled player and authored entities", () => {
     const world = new PodWebLocalWorld("Scout");
@@ -135,6 +167,8 @@ describe("PodWebLocalWorld", () => {
     const snapshot = world.snapshotState();
     const player = snapshot.entities.find((entity) => entity.id === 1);
     expect(player).not.toBeUndefined();
+    expect(player?.position[0]).toBeGreaterThan(4.5);
+    expect(player?.position[1]).toBeGreaterThan(2.4);
     expect(Math.hypot((player?.position[0] ?? 0) - 8.8, (player?.position[1] ?? 0) - 7.8)).toBeGreaterThan(
       1.55
     );
@@ -151,6 +185,7 @@ describe("PodWebLocalWorld", () => {
     expect(player).not.toBeUndefined();
     const surface = sampleLandscapeSurface(player?.position[0] ?? 0, player?.position[1] ?? 0);
     expect(surface.isSwimmable).toBe(true);
+    expect(Math.hypot((player?.position[0] ?? 0) - 18, (player?.position[1] ?? 0) + 14)).toBeLessThan(5.25);
     expect(player?.metadata.actorPresentation?.animationSetId).toBe("humanoid-swim");
   });
 
@@ -176,7 +211,7 @@ describe("PodWebLocalWorld", () => {
     const world = new PodWebLocalWorld("Scout");
     world.connect();
 
-    moveToward(world, 3, 160);
+    moveWithinRange(world, 3, 2.65, 120);
     world.submitActions([{ kind: "attackTarget", target: 3 }]);
     stepTicks(world, 2);
     world.submitActions([{ kind: "captureCreature", target: 3 }]);

--- a/apps/pod-web/src/local-world.ts
+++ b/apps/pod-web/src/local-world.ts
@@ -91,6 +91,14 @@ interface LocalActionResult {
   progressionDirty: boolean;
 }
 
+interface LocalMovementResponseProfile {
+  maxSpeedScale: number;
+  acceleration: number;
+  deceleration: number;
+  steeringBoost: number;
+  turnLerp: number;
+}
+
 interface LocalQuestStageDefinition {
   stageId: string;
   title: string;
@@ -1024,25 +1032,37 @@ export class PodWebLocalWorld {
     for (const entity of this.state.entities) {
       entity.surfaceMode = surfaceModeAtPosition(entity, entity.position);
       const desired = entity.desiredMove;
-      const movementScale = movementSpeedScale(entity);
+      const movementProfile = movementResponseProfile(entity);
       const targetVelocity: Vec2Tuple = desired
         ? [
-            desired[0] * entity.movementSpeed * movementScale,
-            desired[1] * entity.movementSpeed * movementScale
+            desired[0] * entity.movementSpeed * movementProfile.maxSpeedScale,
+            desired[1] * entity.movementSpeed * movementProfile.maxSpeedScale
           ]
         : [0, 0];
+      const previousSpeed = Math.hypot(entity.velocity[0], entity.velocity[1]);
+      const previousDirection =
+        previousSpeed > 0.0001
+          ? ([entity.velocity[0] / previousSpeed, entity.velocity[1] / previousSpeed] as Vec2Tuple)
+          : desired;
+      const steeringAlignment =
+        desired && previousDirection
+          ? desired[0] * previousDirection[0] + desired[1] * previousDirection[1]
+          : 1;
+      const steeringBoost =
+        desired != null
+          ? entity.movementSpeed *
+            movementProfile.maxSpeedScale *
+            Math.max(0, 1 - steeringAlignment) *
+            movementProfile.steeringBoost
+          : 0;
       const acceleration =
-        entity.role === "player"
-          ? entity.movementSpeed * movementScale * 0.18
-          : entity.movementSpeed * movementScale * 0.14;
+        entity.movementSpeed * movementProfile.maxSpeedScale * movementProfile.acceleration;
       const deceleration =
-        entity.role === "player"
-          ? entity.movementSpeed * movementScale * 0.24
-          : entity.movementSpeed * movementScale * 0.18;
+        entity.movementSpeed * movementProfile.maxSpeedScale * movementProfile.deceleration;
       const velocityStep =
         desired != null
-          ? Math.max(0.08, acceleration)
-          : Math.max(0.08, deceleration);
+          ? Math.max(0.08, acceleration + steeringBoost)
+          : Math.max(0.05, deceleration);
 
       entity.velocity = [
         moveScalarToward(entity.velocity[0], targetVelocity[0], velocityStep),
@@ -1072,7 +1092,7 @@ export class PodWebLocalWorld {
         entity.rotation = rotateTowardAngle(
           entity.rotation,
           Math.atan2(entity.velocity[0], entity.velocity[1]),
-          0.24
+          movementProfile.turnLerp
         );
       }
     }
@@ -1132,7 +1152,7 @@ export class PodWebLocalWorld {
         this.state.tick,
         target.position,
         "Damage",
-        `E(${attacker.id}) hit E(${target.id}) for ${damage.toFixed(1)}`,
+        `${attacker.label} hit ${target.label} for ${damage.toFixed(1)}`,
         [attacker.id, target.id]
       )
     );
@@ -1146,7 +1166,7 @@ export class PodWebLocalWorld {
         this.state.tick,
         target.position,
         "Kill",
-        `E(${attacker.id}) defeated E(${target.id})`,
+        `${attacker.label} defeated ${target.label}`,
         [attacker.id, target.id]
       )
     );
@@ -1162,7 +1182,7 @@ export class PodWebLocalWorld {
           this.state.tick,
           target.position,
           "EntitySpawned",
-          `Player E(${target.id}) respawned`,
+          `${target.label} respawned at camp`,
           [target.id]
         )
       );
@@ -2872,6 +2892,48 @@ function movementSpeedScale(entity: LocalEntity): number {
   }
 }
 
+function movementResponseProfile(entity: LocalEntity): LocalMovementResponseProfile {
+  const swimScale = movementSpeedScale(entity);
+
+  if (entity.surfaceMode === "swim") {
+    if (entity.role === "player") {
+      return {
+        maxSpeedScale: swimScale,
+        acceleration: 0.16,
+        deceleration: 0.08,
+        steeringBoost: 0.28,
+        turnLerp: 0.16
+      };
+    }
+
+    return {
+      maxSpeedScale: swimScale,
+      acceleration: 0.13,
+      deceleration: 0.09,
+      steeringBoost: 0.2,
+      turnLerp: entity.role === "companion" ? 0.19 : 0.17
+    };
+  }
+
+  if (entity.role === "player") {
+    return {
+      maxSpeedScale: 1,
+      acceleration: 0.24,
+      deceleration: 0.32,
+      steeringBoost: 0.44,
+      turnLerp: 0.3
+    };
+  }
+
+  return {
+    maxSpeedScale: 1,
+    acceleration: 0.16,
+    deceleration: 0.2,
+    steeringBoost: 0.24,
+    turnLerp: entity.role === "companion" ? 0.24 : 0.2
+  };
+}
+
 function collisionRadius(entity: LocalEntity): number {
   const footprint = entity.metadata.actorPresentation?.footprintRadius ?? 1;
   if (
@@ -2880,7 +2942,8 @@ function collisionRadius(entity: LocalEntity): number {
     entity.role === "wild" ||
     entity.role === "companion"
   ) {
-    return Math.max(0.45, footprint * 0.48);
+    const baseRadius = Math.max(0.43, footprint * 0.46);
+    return entity.surfaceMode === "swim" ? baseRadius * 0.88 : baseRadius;
   }
 
   return Math.max(0.8, footprint * 0.72);
@@ -2954,10 +3017,28 @@ function resolveSolidOverlap(
         ny /= distance;
       }
 
-      resolved = [
+      const pushed: Vec2Tuple = [
         obstacle.position[0] + nx * radius,
         obstacle.position[1] + ny * radius
       ];
+
+      const tangent: Vec2Tuple = [-ny, nx];
+      const intendedDelta: Vec2Tuple = [
+        candidate[0] - start[0],
+        candidate[1] - start[1]
+      ];
+      const tangentDistance =
+        intendedDelta[0] * tangent[0] + intendedDelta[1] * tangent[1];
+      const slideCandidate: Vec2Tuple = [
+        obstacle.position[0] + nx * radius + tangent[0] * tangentDistance * 0.92,
+        obstacle.position[1] + ny * radius + tangent[1] * tangentDistance * 0.92
+      ];
+
+      resolved =
+        Math.abs(tangentDistance) > 0.02 &&
+        !positionOverlapsSolidObstacle(entity, slideCandidate, entities)
+          ? slideCandidate
+          : pushed;
     }
   }
 
@@ -3061,6 +3142,27 @@ function describeInteraction(target: LocalEntity): string {
     default:
       return `${target.label} can be inspected`;
   }
+}
+
+function positionOverlapsSolidObstacle(
+  entity: LocalEntity,
+  position: Vec2Tuple,
+  entities: LocalEntity[]
+): boolean {
+  const moverRadius = collisionRadius(entity);
+
+  for (const obstacle of entities) {
+    if (obstacle.id === entity.id || !isSolidObstacle(obstacle)) {
+      continue;
+    }
+
+    const radius = moverRadius + collisionRadius(obstacle);
+    if (distanceBetween(position, obstacle.position) < radius - 0.001) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 function baseDamage(attacker: LocalEntity, tick: number, targetId: number): number {

--- a/apps/pod-web/src/main.ts
+++ b/apps/pod-web/src/main.ts
@@ -247,6 +247,8 @@ let latestFeedback = runtimeConfig
   : "Local sandbox ready: click terrain to move, right-drag or use arrow keys for camera, wheel to zoom, WASD steer, Tab target, and double-click targets for default actions";
 let recentWorldEvents: NetworkGameEvent[] = [];
 let manualFrameOverride = false;
+let cameraImpact = 0;
+let swimCameraBlend = 0;
 let liveConnectionStatus: DirectConnectStatus | null = runtimeConfig
   ? {
       phase: "idle",
@@ -451,6 +453,10 @@ function stepScalarToward(current: number, target: number, sharpness: number, de
   return current + (target - current) * alpha;
 }
 
+function clampScalar(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
 function syncCameraRig(camera: CameraState | null): void {
   if (!camera) {
     return;
@@ -505,26 +511,57 @@ function renderableThreeFrame(baseFrame: ThreeJsWebGpuFrame): ThreeJsWebGpuFrame
   syncCameraRig(baseFrame.camera);
   const controlled = controlledEntity();
   const target = selectedTarget();
+  const nowSeconds =
+    typeof performance !== "undefined" && typeof performance.now === "function"
+      ? performance.now() / 1000
+      : Date.now() / 1000;
   const speed = controlled
     ? Math.hypot(controlled.velocity[0], controlled.velocity[1])
     : 0;
   const leadDistance = Math.min(1.4, speed * 0.16);
+  const healthRatio =
+    controlled && controlled.maxHealth != null && controlled.maxHealth > 0
+      ? Math.max(0, Math.min(1, (controlled.health ?? controlled.maxHealth) / controlled.maxHealth))
+      : 1;
+  const lowHealthPressure = healthRatio < 0.45 ? (0.45 - healthRatio) / 0.45 : 0;
+  const targetPressure = target?.metadata.interaction.canAttack ? 0.45 : 0;
+  const combatPressure = Math.max(targetPressure, lowHealthPressure * 0.9, cameraImpact * 0.75);
+  const leadScale = 1 + swimCameraBlend * 0.14 - combatPressure * 0.06;
   const leadX =
-    controlled && speed > 0.05 ? (controlled.velocity[0] / speed) * leadDistance : 0;
+    controlled && speed > 0.05
+      ? (controlled.velocity[0] / speed) * leadDistance * leadScale
+      : 0;
   const leadY =
-    controlled && speed > 0.05 ? (controlled.velocity[1] / speed) * leadDistance : 0;
+    controlled && speed > 0.05
+      ? (controlled.velocity[1] / speed) * leadDistance * leadScale
+      : 0;
+  const shakeYaw = Math.sin(nowSeconds * 33 + 0.8) * cameraImpact * 0.022;
+  const shakePitch = Math.sin(nowSeconds * 27 + 1.7) * cameraImpact * 0.014;
+  const baseFocusHeight = baseFrame.camera.focusHeight ?? 2.2;
+  const baseFollowDistance = baseFrame.camera.followDistance ?? 13.5;
+  const baseShoulderOffset = baseFrame.camera.shoulderOffset ?? 0.9;
+  const swimPitchOffset = swimCameraBlend * 0.068;
+  const swimZoomOffset = swimCameraBlend * 0.082;
+  const swimDistanceOffset = swimCameraBlend * 1.6;
+  const swimShoulderOffset = baseShoulderOffset - swimCameraBlend * 0.42;
+  const combatFovKick = combatPressure * 2.4 + cameraImpact * 3;
+  const swimFocusHeight = baseFocusHeight + swimCameraBlend * 0.12;
+  const swimFollowDistance = baseFollowDistance + swimDistanceOffset - combatPressure * 0.65;
+  const blendedShoulderOffset =
+    baseShoulderOffset + (swimShoulderOffset - baseShoulderOffset) * swimCameraBlend;
 
   const interactionFrame = withInteractionMarkers(
     {
       ...baseFrame,
       camera: {
         ...baseFrame.camera,
-        rotation: cameraRig.yaw,
-        pitch: cameraRig.pitch,
-        zoom: cameraRig.zoom,
-        focusHeight: baseFrame.camera.focusHeight ?? 2.2,
-        followDistance: baseFrame.camera.followDistance ?? 13.5,
-        shoulderOffset: baseFrame.camera.shoulderOffset ?? 0.9,
+        rotation: cameraRig.yaw + shakeYaw,
+        pitch: clampScalar(cameraRig.pitch + swimPitchOffset + shakePitch - combatPressure * 0.012, 0.18, 0.76),
+        zoom: clampScalar(cameraRig.zoom - swimZoomOffset - combatPressure * 0.035 + cameraImpact * 0.028, 0.72, 1.65),
+        fov: clampScalar((baseFrame.camera.fov ?? 52) + combatFovKick, 50, 62),
+        focusHeight: swimFocusHeight,
+        followDistance: swimFollowDistance,
+        shoulderOffset: blendedShoulderOffset,
         leadX,
         leadY
       }
@@ -577,6 +614,23 @@ function applyAuthoritativeEventBatch(batch: NetworkEventBatch): void {
   if (highlighted) {
     latestFeedback = highlightEventFeedback(highlighted);
   }
+
+  for (const event of batch.events) {
+    if (!eventTouchesEntity(event, controlledId) && !eventTouchesEntity(event, selectedTargetId)) {
+      continue;
+    }
+    const normalized = event.kind.toLowerCase();
+    if (normalized.includes("damage") || normalized.includes("kill") || normalized.includes("defeat")) {
+      cameraImpact = Math.min(1.2, cameraImpact + 0.48);
+    } else if (
+      normalized.includes("capture") ||
+      normalized.includes("summon") ||
+      normalized.includes("loot") ||
+      normalized.includes("gather")
+    ) {
+      cameraImpact = Math.min(1.2, cameraImpact + 0.22);
+    }
+  }
 }
 
 function formatRecentEventFeed(): string {
@@ -585,8 +639,9 @@ function formatRecentEventFeed(): string {
   }
 
   return recentWorldEvents
-    .map((event) => `[${event.tick}] ${event.summary}`)
-    .join("\n");
+    .slice(-2)
+    .map((event) => highlightEventFeedback(event))
+    .join(" · ");
 }
 
 function formatActionStatus(): string {
@@ -1140,6 +1195,12 @@ async function advanceInteractiveRuntime(deltaMs: number, timestamp: number): Pr
     localSandbox.step(deltaMs);
     refreshLocalSandboxFrame();
   }
+
+  const controlled = controlledEntity();
+  const isSwimming =
+    controlled?.metadata.actorPresentation?.animationSetId?.toLowerCase().includes("swim") ?? false;
+  swimCameraBlend = stepScalarToward(swimCameraBlend, isSwimming ? 1 : 0, 6.4, deltaMs);
+  cameraImpact = stepScalarToward(cameraImpact, 0, 9.2, deltaMs);
 
   await renderCurrentFrame(timestamp);
 }

--- a/progress.md
+++ b/progress.md
@@ -40,3 +40,12 @@ Original prompt: its the graphics and the worlds scene, everything is piled up o
 - Added shared landscape surface sampling for terrain vs water and pushed it through camera collision, ground picking, world-frame anchoring, and local-world movement so the player now spawns on dry ground and swims on the lake surface instead of walking below it.
 - Unified `window.advanceTime(...)` with the real gameplay tick path, which made Playwright/browser proof match actual runtime behavior instead of skipping camera and movement updates.
 - Revalidated live in Playwright that camera yaw changes under arrow-key input and that a terrain click advances the player into `humanoid-swim` / `surfaceMode=swim` rather than burying the actor below the water plane.
+- Tightened local traversal response by tuning per-surface acceleration/deceleration/turn profiles and improving solid-prop collision resolution so the player progresses around obstacles instead of sticking against them.
+- Added a more physical swim presentation path: swimmer animation now includes forward glide + buoyancy, the main camera blends to a wider/lower swim framing, and combat impact kick still reads while the actor is in water.
+- Reduced the main HUD chrome again with smaller cards, tighter copy, and lighter diagnostics labeling, while keeping world/combat feedback readable enough for live MMO testing.
+- Revalidated the branch with targeted Bun coverage (`local-world`, `frame-plan`, `hud`, `controls`, `contracts`), clean typecheck/build, and live Playwright MCP proof on `http://127.0.0.1:4179/`.
+- Live browser proof from this pass:
+  - booted cleanly into `webgpu` on the local shard with no errors and only the known upstream Three.js TSL warning
+  - arrow keys kept camera orbit active while the gameplay surface stayed focused
+  - WASD/click movement advanced the player without terrain burial
+  - lake traversal switched the controlled actor to `humanoid-swim` with `controlledSurfaceMode=swim`


### PR DESCRIPTION
## Summary
- tighten local traversal response and solid-prop collision feel in the flagship browser shard
- add a stronger swim presentation path with buoyant animation offsets and a lower/wider camera blend
- reduce main HUD weight while keeping clearer combat and world feedback

## Validation
- cd apps/pod-web && bun test ./src/local-world.test.ts ./src/frame-plan.test.ts ./src/hud.test.ts ./src/controls.test.ts ./src/contracts.test.ts
- cd apps/pod-web && bun run typecheck
- cd apps/pod-web && bun run build
- live Playwright MCP proof on http://127.0.0.1:4179/ for camera orbit, traversal, and swim-state transition

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Swimming animations with enhanced physics and camera adjustments for water traversal
  * Camera dynamics responding to combat and interaction events with impact-driven effects

* **Bug Fixes**
  * Improved HUD chrome with reduced card sizes, tighter spacing, and clearer labels
  * Enhanced movement responsiveness with better obstacle navigation and collision resolution
  * Updated event feedback messaging for improved clarity ("Hit confirmed," "Capture secured," etc.)

* **Tests**
  * Added comprehensive test coverage for swimming behavior and movement mechanics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->