### PR TITLE
Fix pod-web ground anchoring and smoothing

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1086,5 +1086,17 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - Live Playwright MCP proof on `http://127.0.0.1:4179/` for camera orbit, click/WASD traversal, and swim-state transition
   - `git diff --check`
 
-**Last updated**: Iteration 108
-**Current focus**: Iteration 109 worker-route gameplay-input parity proof, richer close-range combat response, and further reduction of debug chrome in the flagship browser client without losing creator inspection depth
+### Iteration 109
+- [x] Removed the debug grid as a default flagship-world surface cue by making it opt-in only (`?grid=1` / `?debugGrid=1`), so the runtime no longer looks like the player is standing under a dev board on first load.
+- [x] Added shared real mesh bounds in `apps/pod-web` and reused them for authoritative world-frame placement plus ambient chunk dressing, replacing the drift-prone hard-coded half-height guesses that were causing props and actors to intersect terrain incorrectly.
+- [x] Added renderer-side transform smoothing for mesh and sprite batches, so replicated actors and markers no longer snap between updates and the flagship shard reads more smoothly under normal movement/event churn.
+- [x] Corrected browser gameplay-state surface reporting to use the shared landscape sampler instead of animation-name inference, keeping swim/ground debug state aligned with actual terrain/water logic.
+- [x] Revalidated touched targets:
+  - `cd apps/pod-web && bun test ./src/mesh-bounds.test.ts ./src/quality.test.ts ./src/contracts.test.ts ./src/renderer.test.ts`
+  - `cd apps/pod-web && bun test ./src/controls.test.ts ./src/local-world.test.ts ./src/frame-plan.test.ts`
+  - `cd apps/pod-web && bun run typecheck`
+  - `cd apps/pod-web && bun run build`
+  - `git diff --check`
+
+**Last updated**: Iteration 109
+**Current focus**: Iteration 110 worker-route gameplay-input parity proof, richer close-range combat response, and terrain/water material polish under real browser GPU conditions

--- a/apps/pod-web/src/contracts.test.ts
+++ b/apps/pod-web/src/contracts.test.ts
@@ -25,6 +25,7 @@ import {
   withWorldEventMarkers
 } from "./contracts";
 import { sampleLandscapeSurface, sampleTerrainHeight } from "./landscape";
+import { meshGroundAnchorHeight } from "./mesh-bounds";
 
 function entityMetadata(kind: string, overrides: Record<string, unknown> = {}) {
   return {
@@ -832,7 +833,9 @@ describe("TOON contract parsing", () => {
     expect(heroInstance?.motionSpeed).toBeGreaterThan(0.3);
     expect(heroInstance?.controlled).toBe(true);
     expect(heroInstance?.position[1]).toBeCloseTo(
-      sampleTerrainHeight(8, 10) + 1.205 * (2.0 * 1.15) + 0.1,
+      sampleTerrainHeight(8, 10) +
+        meshGroundAnchorHeight("adventurer-hero", 2.0 * 1.15) +
+        0.1,
       5
     );
     const selectionRing = frame.spriteBatches.find(
@@ -856,7 +859,7 @@ describe("TOON contract parsing", () => {
       .flatMap((batch) => batch.instances)
       .find((instance) => instance.sourceEntity === 9);
     expect(beastInstance?.position[1]).toBeCloseTo(
-      sampleTerrainHeight(12, 10) + 1.1 * 1.9 + 0.08,
+      sampleTerrainHeight(12, 10) + meshGroundAnchorHeight("rift-beast", 1.9) + 0.08,
       5
     );
   });

--- a/apps/pod-web/src/contracts.ts
+++ b/apps/pod-web/src/contracts.ts
@@ -1,6 +1,7 @@
 import { decode as decodeToon } from "@toon-format/toon";
 
 import { sampleLandscapeSurface, sampleSurfaceHeight } from "./landscape";
+import { meshGroundAnchorHeight } from "./mesh-bounds";
 
 export type Vec3Tuple = [number, number, number];
 export type Vec4Tuple = [number, number, number, number];
@@ -2770,31 +2771,6 @@ function meshBatchKey(profile: EntityRenderProfile): string {
   ].join("|");
 }
 
-function meshHalfHeight(mesh: string): number {
-  switch (mesh) {
-    case "adventurer-avatar":
-      return 1.1;
-    case "adventurer-hero":
-      return 1.205;
-    case "basalt-column":
-      return 1.6;
-    case "canopy-tree":
-      return 1.2;
-    case "glass-spire":
-      return 1.5;
-    case "rift-beast":
-      return 1.1;
-    case "spirit-companion":
-      return 0.95;
-    case "supply-crate":
-      return 0.55;
-    case "weathered-boulder":
-      return 1.0;
-    default:
-      return 0.5;
-  }
-}
-
 export function buildAuthoritativeWorldFrame(
   snapshot: NetworkWorldSnapshot,
   options: AuthoritativeWorldFrameOptions = {}
@@ -2850,10 +2826,10 @@ export function buildAuthoritativeWorldFrame(
     const worldX = entity.position[0] * WORLD_TO_RENDER_SCALE;
     const worldZ = entity.position[1] * WORLD_TO_RENDER_SCALE;
     const groundHeight = entityAnchorHeight(entity);
-    const halfHeight = meshHalfHeight(profile.mesh) * profile.scale[1];
+    const anchorHeight = meshGroundAnchorHeight(profile.mesh, profile.scale[1]);
     const position: Vec3Tuple = [
       worldX,
-      groundHeight + halfHeight + profile.groundOffset,
+      groundHeight + anchorHeight + profile.groundOffset,
       worldZ
     ];
     const instance: ThreeJsInstance = {

--- a/apps/pod-web/src/main.ts
+++ b/apps/pod-web/src/main.ts
@@ -56,6 +56,7 @@ import {
   renderPopulationHeatmap
 } from "./population-heatmap";
 import { compactRuntimeStats, highlightEventFeedback } from "./hud";
+import { sampleLandscapeSurface } from "./landscape";
 import {
   createLiveDebugState,
   recordLiveDebugDocument,
@@ -210,13 +211,21 @@ const telemetryPrevButton = telemetryPrev;
 const telemetryNextButton = telemetryNext;
 const bootHudState = initialHudStateFromLocation(window.location);
 
+function shouldShowDebugGrid(search: string): boolean {
+  const params = new URLSearchParams(search);
+  const value = params.get("grid") ?? params.get("debugGrid");
+  return value === "1" || value === "true";
+}
+
 feedbackNode.textContent = bootHudState.feedback;
 connectionNode.textContent = bootHudState.connectionBadge;
 worldNode.textContent = bootHudState.worldLabel;
 populationNode.textContent = bootHudState.populationLabel;
 frameSourceNode.textContent = bootHudState.frameSourceLabel;
 
-const renderer = await createPodRenderRuntime(renderCanvas);
+const renderer = await createPodRenderRuntime(renderCanvas, {
+  showGrid: shouldShowDebugGrid(window.location.search)
+});
 backendLabel.textContent = renderer.backend;
 qualityLabel.textContent = renderer.qualityPreset;
 const runtimeStatsLabel = statsLabel;
@@ -1139,10 +1148,11 @@ window.podRender = {
         : null,
       controlledAnimationSetId:
         controlled?.metadata.actorPresentation?.animationSetId ?? null,
-      controlledSurfaceMode:
-        controlled?.metadata.actorPresentation?.animationSetId?.includes("swim")
+      controlledSurfaceMode: controlled
+        ? sampleLandscapeSurface(controlled.position[0], controlled.position[1]).isSwimmable
           ? "swim"
-          : "ground",
+          : "ground"
+        : "ground",
       selectedTargetId,
       clickMoveTarget,
       movementSignature: lastMovementSignature,

--- a/apps/pod-web/src/mesh-bounds.test.ts
+++ b/apps/pod-web/src/mesh-bounds.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  meshGroundAnchorHeight,
+  meshVisualHeight,
+  resolveMeshBounds
+} from "./mesh-bounds";
+
+describe("pod-web mesh bounds", () => {
+  test("uses shipped mesh bounds for world anchoring", () => {
+    expect(resolveMeshBounds("adventurer-hero")).toEqual({
+      minY: -1.205,
+      maxY: 1.205,
+      footprintRadius: 0.48
+    });
+    expect(meshGroundAnchorHeight("adventurer-hero", 2)).toBeCloseTo(2.41, 6);
+    expect(meshVisualHeight("rift-beast", 1.9)).toBeCloseTo(4.18, 6);
+  });
+
+  test("falls back safely for unknown meshes", () => {
+    expect(resolveMeshBounds("unknown-placeholder")).toEqual({
+      minY: -0.5,
+      maxY: 0.5,
+      footprintRadius: 0.7
+    });
+    expect(meshGroundAnchorHeight("unknown-placeholder", 3)).toBeCloseTo(1.5, 6);
+  });
+});

--- a/apps/pod-web/src/mesh-bounds.ts
+++ b/apps/pod-web/src/mesh-bounds.ts
@@ -1,0 +1,82 @@
+export interface PodThreeMeshBounds {
+  minY: number;
+  maxY: number;
+  footprintRadius: number;
+}
+
+const DEFAULT_MESH_BOUNDS: PodThreeMeshBounds = {
+  minY: -0.5,
+  maxY: 0.5,
+  footprintRadius: 0.7
+};
+
+const SHIPPED_MESH_BOUNDS: Record<string, PodThreeMeshBounds> = {
+  "adventurer-avatar": {
+    minY: -1.1,
+    maxY: 1.1,
+    footprintRadius: 0.45
+  },
+  "adventurer-hero": {
+    minY: -1.205,
+    maxY: 1.205,
+    footprintRadius: 0.48
+  },
+  "basalt-column": {
+    minY: -1.6,
+    maxY: 1.6,
+    footprintRadius: 0.9
+  },
+  "canopy-tree": {
+    minY: -1.2,
+    maxY: 1.2,
+    footprintRadius: 1.1
+  },
+  "glass-spire": {
+    minY: -1.5,
+    maxY: 1.5,
+    footprintRadius: 0.85
+  },
+  "rift-beast": {
+    minY: -1.1,
+    maxY: 1.1,
+    footprintRadius: 1.1
+  },
+  "spirit-companion": {
+    minY: -0.8081182837486267,
+    maxY: 0.8081182837486267,
+    footprintRadius: 0.81
+  },
+  "supply-crate": {
+    minY: -0.55,
+    maxY: 0.55,
+    footprintRadius: 0.7
+  },
+  "weathered-boulder": {
+    minY: -0.9341723322868347,
+    maxY: 0.9341723322868347,
+    footprintRadius: 0.94
+  }
+};
+
+export function normalizeMeshBoundsKey(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export function resolveMeshBounds(meshId: string): PodThreeMeshBounds {
+  const normalized = normalizeMeshBoundsKey(meshId);
+  return SHIPPED_MESH_BOUNDS[normalized] ?? DEFAULT_MESH_BOUNDS;
+}
+
+export function meshGroundAnchorHeight(meshId: string, scaleY = 1): number {
+  const bounds = resolveMeshBounds(meshId);
+  return -bounds.minY * scaleY;
+}
+
+export function meshVisualHeight(meshId: string, scaleY = 1): number {
+  const bounds = resolveMeshBounds(meshId);
+  return (bounds.maxY - bounds.minY) * scaleY;
+}

--- a/apps/pod-web/src/quality.test.ts
+++ b/apps/pod-web/src/quality.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveQualityProfile } from "./quality";
+
+describe("pod-web quality defaults", () => {
+  test("does not enable the debug grid by default on flagship presets", () => {
+    expect(
+      resolveQualityProfile({
+        backend: "webgpu",
+        preferredPreset: "ultra",
+        hardwareConcurrency: 12,
+        deviceMemory: 16,
+        devicePixelRatio: 2
+      }).showGrid
+    ).toBe(false);
+
+    expect(
+      resolveQualityProfile({
+        backend: "webgpu",
+        preferredPreset: "high",
+        hardwareConcurrency: 8,
+        deviceMemory: 8,
+        devicePixelRatio: 2
+      }).showGrid
+    ).toBe(false);
+  });
+});

--- a/apps/pod-web/src/quality.ts
+++ b/apps/pod-web/src/quality.ts
@@ -50,7 +50,7 @@ const PRESETS: Record<PodThreeQualityPreset, PodThreeQualityProfile> = {
     environmentIntensity: 1.15,
     enableAdaptiveResolution: true,
     enableShadows: true,
-    showGrid: true
+    showGrid: false
   },
   high: {
     preset: "high",
@@ -69,7 +69,7 @@ const PRESETS: Record<PodThreeQualityPreset, PodThreeQualityProfile> = {
     environmentIntensity: 1.05,
     enableAdaptiveResolution: true,
     enableShadows: true,
-    showGrid: true
+    showGrid: false
   },
   balanced: {
     preset: "balanced",

--- a/apps/pod-web/src/renderer.test.ts
+++ b/apps/pod-web/src/renderer.test.ts
@@ -8,6 +8,7 @@ import {
   sampleTimeLapseEnvironment,
   WATER_LEVEL
 } from "./landscape";
+import { meshGroundAnchorHeight } from "./mesh-bounds";
 
 describe("pod-web renderer landscape helpers", () => {
   test("classifies bright flagship environments as daylight", () => {
@@ -113,9 +114,13 @@ describe("pod-web renderer landscape helpers", () => {
 
     for (const batch of left.meshBatches) {
       for (const instance of batch.instances) {
-        const [x, _y, z] = instance.position;
+        const [x, y, z] = instance.position;
         expect(Math.hypot(x, z)).toBeGreaterThan(11.99);
         expect(sampleLakeMask(x, z)).toBeLessThan(0.21);
+        expect(y).toBeCloseTo(
+          sampleTerrainHeight(x, z) + meshGroundAnchorHeight(batch.batch.mesh, instance.scale[1]),
+          5
+        );
       }
     }
   });

--- a/apps/pod-web/src/renderer.ts
+++ b/apps/pod-web/src/renderer.ts
@@ -14,11 +14,13 @@ import {
   buildCameraPose,
   buildFramePlan,
   composeAnimatedInstanceMatrix,
+  sampleAnimatedInstanceTransform,
   planningOptionsFromQuality,
   type PodThreeCameraRigOptions,
   type PlannedMeshBatch,
   type PlannedSpriteBatch
 } from "./frame-plan";
+import { meshGroundAnchorHeight } from "./mesh-bounds";
 import {
   legacyFrameToThreeJsFrame,
   type NetworkGameEvent,
@@ -69,6 +71,13 @@ interface InstancedEntry {
   capacity: number;
   mesh: THREE.InstancedMesh;
   material: THREE.Material;
+}
+
+interface SmoothedInstanceTransform {
+  position: THREE.Vector3;
+  rotation: THREE.Quaternion;
+  scale: THREE.Vector3;
+  updatedAt: number;
 }
 
 const INLINE_TSL_FN_WARNING =
@@ -491,6 +500,7 @@ export class PodThreeWorldRenderer {
   private telemetryTrail: THREE.Line<THREE.BufferGeometry, THREE.LineBasicMaterial> | null =
     null;
   private readonly entityPulseUntilMs = new Map<number, number>();
+  private readonly smoothedInstanceTransforms = new Map<string, SmoothedInstanceTransform>();
 
   constructor(
     private readonly canvas: HTMLCanvasElement | OffscreenCanvas,
@@ -988,6 +998,7 @@ export class PodThreeWorldRenderer {
 
   private async syncMeshBatches(batches: PlannedMeshBatch[]): Promise<void> {
     const activeKeys = new Set<string>();
+    const activeTransformKeys = new Set<string>();
     const now =
       typeof performance !== "undefined" && typeof performance.now === "function"
         ? performance.now()
@@ -1035,12 +1046,17 @@ export class PodThreeWorldRenderer {
         if (!instance) {
           continue;
         }
+        const transformKey = `${planned.key}:mesh:${instance.sourceEntity ?? index}`;
+        activeTransformKeys.add(transformKey);
         entry.mesh.setMatrixAt(
           index,
-          composeAnimatedInstanceMatrix(
+          composeSmoothedInstanceMatrix(
+            this.smoothedInstanceTransforms,
+            transformKey,
             instance,
             elapsedSeconds,
-            pulseStrengthForEntity(this.entityPulseUntilMs, instance.sourceEntity, now)
+            pulseStrengthForEntity(this.entityPulseUntilMs, instance.sourceEntity, now),
+            now
           )
         );
       }
@@ -1049,10 +1065,12 @@ export class PodThreeWorldRenderer {
     }
 
     cleanupUnusedEntries(this.scene, this.meshEntries, activeKeys);
+    pruneInactiveTransforms(this.smoothedInstanceTransforms, activeTransformKeys, now);
   }
 
   private async syncSpriteBatches(batches: PlannedSpriteBatch[]): Promise<void> {
     const activeKeys = new Set<string>();
+    const activeTransformKeys = new Set<string>();
     const now =
       typeof performance !== "undefined" && typeof performance.now === "function"
         ? performance.now()
@@ -1093,12 +1111,17 @@ export class PodThreeWorldRenderer {
         if (!instance) {
           continue;
         }
+        const transformKey = `${planned.key}:sprite:${instance.sourceEntity ?? index}`;
+        activeTransformKeys.add(transformKey);
         entry.mesh.setMatrixAt(
           index,
-          composeAnimatedInstanceMatrix(
+          composeSmoothedInstanceMatrix(
+            this.smoothedInstanceTransforms,
+            transformKey,
             instance,
             elapsedSeconds,
             pulseStrengthForEntity(this.entityPulseUntilMs, instance.sourceEntity, now),
+            now,
             planned.batch.billboard ? this.camera.quaternion : undefined
           )
         );
@@ -1108,6 +1131,7 @@ export class PodThreeWorldRenderer {
     }
 
     cleanupUnusedEntries(this.scene, this.spriteEntries, activeKeys);
+    pruneInactiveTransforms(this.smoothedInstanceTransforms, activeTransformKeys, now);
   }
 
   private async syncAmbientMeshBatches(batches: PlannedMeshBatch[]): Promise<void> {
@@ -1495,7 +1519,6 @@ interface AmbientChunkArchetype {
   receiveShadows: boolean;
   renderOrder: number;
   baseScale: [number, number, number];
-  halfHeight: number;
   densities: Record<PodThreeQualityPreset, number>;
   lakeMaskMax: number;
   minSlope: number;
@@ -1519,7 +1542,6 @@ const AMBIENT_CHUNK_ARCHETYPES: AmbientChunkArchetype[] = [
     receiveShadows: true,
     renderOrder: 4,
     baseScale: [1.9, 2.5, 1.9],
-    halfHeight: 1.7,
     densities: {
       ultra: 4,
       high: 3,
@@ -1545,7 +1567,6 @@ const AMBIENT_CHUNK_ARCHETYPES: AmbientChunkArchetype[] = [
     receiveShadows: true,
     renderOrder: 5,
     baseScale: [1.2, 1, 1.15],
-    halfHeight: 1,
     densities: {
       ultra: 3,
       high: 2,
@@ -1571,7 +1592,6 @@ const AMBIENT_CHUNK_ARCHETYPES: AmbientChunkArchetype[] = [
     receiveShadows: true,
     renderOrder: 5,
     baseScale: [0.82, 1.25, 0.82],
-    halfHeight: 2.6,
     densities: {
       ultra: 2,
       high: 2,
@@ -1598,7 +1618,6 @@ const AMBIENT_CHUNK_ARCHETYPES: AmbientChunkArchetype[] = [
     receiveShadows: true,
     renderOrder: 6,
     baseScale: [1.05, 1.55, 1.05],
-    halfHeight: 2.4,
     densities: {
       ultra: 1,
       high: 1,
@@ -1786,11 +1805,12 @@ function sampleAmbientChunkInstances(
         archetype.baseScale[1] * scaleVariance,
         archetype.baseScale[2] * scaleVariance
       ];
+      const anchorHeight = meshGroundAnchorHeight(archetype.mesh, scale[1]);
 
       instances.push({
         archetype,
         instance: {
-          position: [x, height + archetype.halfHeight * scale[1], z],
+          position: [x, height + anchorHeight, z],
           rotation: [rotation.x, rotation.y, rotation.z, rotation.w],
           scale,
           animationSetId: "static-prop"
@@ -1915,6 +1935,64 @@ function ensureInstancedEntry(
     mesh,
     material
   };
+}
+
+function composeSmoothedInstanceMatrix(
+  transforms: Map<string, SmoothedInstanceTransform>,
+  key: string,
+  instance: Parameters<typeof sampleAnimatedInstanceTransform>[0],
+  elapsedSeconds: number,
+  pulse: number,
+  now: number,
+  rotationOverride?: THREE.Quaternion
+): THREE.Matrix4 {
+  const sampled = sampleAnimatedInstanceTransform(instance, elapsedSeconds, pulse);
+  const targetPosition = new THREE.Vector3(...sampled.position);
+  const targetRotation = rotationOverride ?? new THREE.Quaternion(...sampled.rotation);
+  const targetScale = new THREE.Vector3(...sampled.scale);
+  const previous = transforms.get(key);
+
+  if (
+    !previous ||
+    now - previous.updatedAt > 260 ||
+    previous.position.distanceToSquared(targetPosition) > 64
+  ) {
+    transforms.set(key, {
+      position: targetPosition.clone(),
+      rotation: targetRotation.clone(),
+      scale: targetScale.clone(),
+      updatedAt: now
+    });
+  } else {
+    const deltaSeconds = clamp((now - previous.updatedAt) / 1000, 1 / 240, 0.05);
+    const alpha = 1 - Math.exp(-deltaSeconds * 22);
+    previous.position.lerp(targetPosition, alpha);
+    previous.rotation.slerp(targetRotation, alpha);
+    previous.scale.lerp(targetScale, alpha);
+    previous.updatedAt = now;
+  }
+
+  const resolved = transforms.get(key);
+  const matrix = new THREE.Matrix4();
+  matrix.compose(
+    resolved?.position ?? targetPosition,
+    resolved?.rotation ?? targetRotation,
+    resolved?.scale ?? targetScale
+  );
+  return matrix;
+}
+
+function pruneInactiveTransforms(
+  transforms: Map<string, SmoothedInstanceTransform>,
+  activeKeys: Set<string>,
+  now: number
+): void {
+  for (const [key, transform] of transforms) {
+    if (activeKeys.has(key) || now - transform.updatedAt <= 360) {
+      continue;
+    }
+    transforms.delete(key);
+  }
 }
 
 function cleanupUnusedEntries(

--- a/progress.md
+++ b/progress.md
@@ -49,3 +49,7 @@ Original prompt: its the graphics and the worlds scene, everything is piled up o
   - arrow keys kept camera orbit active while the gameplay surface stayed focused
   - WASD/click movement advanced the player without terrain burial
   - lake traversal switched the controlled actor to `humanoid-swim` with `controlledSurfaceMode=swim`
+- Fixed a real render/runtime regression in `pod-web` where the default flagship view still enabled the debug ground grid, which made the player look like they were under the world instead of on it.
+- Added shared mesh-bounds calibration for shipped asset ids (`hero`, `rift-beast`, `canopy-tree`, `weathered-boulder`, etc.) and reused it across authoritative frame placement plus ambient chunk dressing, removing the worst terrain-intersection/floating cases caused by stale half-height guesses.
+- Added renderer-side transform smoothing for mesh and sprite batches so entities and markers stop snapping between authoritative updates, which materially reduces the flagship shard’s “jerky” feel even before deeper animation/combat polish lands.
+- Corrected `getGameplayState()` surface-mode reporting to query the same terrain/water sampler the movement/runtime path uses, keeping debug inspection aligned with real ground/swim behavior.


### PR DESCRIPTION
## Summary
- remove the debug grid as the default flagship-world surface cue in pod-web
- anchor actors and ambient props from shared real mesh bounds instead of stale half-height guesses
- smooth replicated mesh and sprite transforms to reduce visible snapping in the browser client

## Validation
- cd apps/pod-web && bun test ./src/mesh-bounds.test.ts ./src/quality.test.ts ./src/contracts.test.ts ./src/renderer.test.ts
- cd apps/pod-web && bun test ./src/controls.test.ts ./src/local-world.test.ts ./src/frame-plan.test.ts
- cd apps/pod-web && bun run typecheck
- cd apps/pod-web && bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a rendering regression where the debug grid was improperly enabled, causing visual issues.
  * Reduced terrain intersection and entity floating through improved mesh bounds calibration.
  * Corrected surface-mode detection to accurately match actual gameplay behavior.

* **New Features**
  * Added optional debug grid toggle via URL parameter for developers.

* **Improvements**
  * Enhanced renderer-side transform smoothing to reduce visual snapping and improve perceived stability of entity movement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->