### PR TITLE
Improve pod-web close-range combat response

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1108,5 +1108,16 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cd apps/pod-web && bun run build`
   - `git diff --check`
 
-**Last updated**: Iteration 110
-**Current focus**: Iteration 111 richer close-range combat response, terrain/water material polish under real browser GPU conditions, and further shard/runtime observability improvements beyond browser-only smoke
+### Iteration 111
+- [x] Added a pure close-range combat camera-pressure model in `apps/pod-web` so target proximity now tightens framing and camera pressure based on actual engagement distance instead of only generic event shake and low-health state.
+- [x] Upgraded actor pulse response in `frame-plan` so combat pulses drive forward lunge/weight for humanoids and heavier forward drive for beasts instead of only vertical bob and uniform scale pop.
+- [x] Revalidated both main-thread and worker-route gameplay smoke after the camera/combat change, proving the flagship browser client still accepts movement input on both render paths.
+- [x] Revalidated touched targets:
+  - `cd apps/pod-web && bun test ./src/frame-plan.test.ts ./src/contracts.test.ts ./src/renderer.test.ts`
+  - `cd apps/pod-web && bun run typecheck`
+  - `cd apps/pod-web && bun run build`
+  - `cd apps/pod-web && bun run test:smoke`
+  - `git diff --check`
+
+**Last updated**: Iteration 111
+**Current focus**: Iteration 112 terrain/water material polish under real browser GPU conditions, closer-range combat readability in the flagship shard, and further shard/runtime observability improvements beyond browser-only smoke

--- a/apps/pod-web/src/direct-connect.ts
+++ b/apps/pod-web/src/direct-connect.ts
@@ -127,7 +127,7 @@ export function initialHudStateFromLocation(
 
 export class PodWebDirectConnectClient {
   private socket: WebSocket | null = null;
-  private reconnectTimer: number | null = null;
+  private reconnectTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
   private reconnectToken: string | null = null;
   private snapshot: NetworkWorldSnapshot | null = null;
   private controlledEntity: number | null = null;
@@ -137,7 +137,7 @@ export class PodWebDirectConnectClient {
   private closedExplicitly = false;
   private debugTelemetryEnabled: boolean;
   private debugFocusEntity: number | null = null;
-  private pingTimer: number | null = null;
+  private pingTimer: ReturnType<typeof globalThis.setInterval> | null = null;
   private lastRoundTripSampleMs: number | null = null;
   private status: DirectConnectStatus;
   private actionState: DirectConnectActionState;

--- a/apps/pod-web/src/frame-plan.test.ts
+++ b/apps/pod-web/src/frame-plan.test.ts
@@ -4,6 +4,7 @@ import type { ThreeJsWebGpuFrame } from "./contracts";
 import {
   buildCameraPose,
   buildFramePlan,
+  computeCombatCameraPressure,
   sampleAnimatedInstanceTransform,
   splitSpriteBatchesByTint
 } from "./frame-plan";
@@ -616,7 +617,38 @@ describe("sampleAnimatedInstanceTransform", () => {
     expect(neutral.position[1]).toBeGreaterThan(2);
     expect(neutral.scale[1]).toBeLessThan(2);
     expect(pulsed.position[1]).toBeGreaterThan(neutral.position[1]);
+    expect(pulsed.position[2]).toBeGreaterThan(neutral.position[2]);
     expect(pulsed.scale[0]).toBeGreaterThan(neutral.scale[0]);
+  });
+
+  test("gives pulsed beasts a heavier forward drive than pulsed humanoids", () => {
+    const beast = sampleAnimatedInstanceTransform(
+      {
+        position: [0, 1.8, 0],
+        rotation: [0, 0, 0, 1],
+        scale: [1.4, 1.4, 1.8],
+        sourceEntity: 5,
+        animationSetId: "rift-beast",
+        motionSpeed: 0.9
+      },
+      1.4,
+      1
+    );
+    const humanoid = sampleAnimatedInstanceTransform(
+      {
+        position: [0, 1.8, 0],
+        rotation: [0, 0, 0, 1],
+        scale: [1.1, 1.9, 1.1],
+        sourceEntity: 5,
+        animationSetId: "hero-runescape",
+        motionSpeed: 0.9
+      },
+      1.4,
+      1
+    );
+
+    expect(beast.position[2]).toBeGreaterThan(humanoid.position[2]);
+    expect(beast.scale[2]).toBeGreaterThan(humanoid.scale[2]);
   });
 
   test("gives swimmers forward glide while keeping beasts heavier than humanoids", () => {
@@ -648,6 +680,54 @@ describe("sampleAnimatedInstanceTransform", () => {
     expect(humanoidSwim.position[1]).toBeGreaterThan(1.55);
     expect(beastSwim.scale[0]).toBeGreaterThan(humanoidSwim.scale[0]);
     expect(Math.abs(beastSwim.rotation[2])).toBeLessThan(Math.abs(humanoidSwim.rotation[2]));
+  });
+});
+
+describe("computeCombatCameraPressure", () => {
+  test("raises camera pressure for close attackable targets", () => {
+    const close = computeCombatCameraPressure(
+      {
+        position: [0, 0],
+        health: 82,
+        maxHealth: 100
+      },
+      {
+        position: [2.5, 0],
+        canAttack: true
+      },
+      0.1
+    );
+    const far = computeCombatCameraPressure(
+      {
+        position: [0, 0],
+        health: 82,
+        maxHealth: 100
+      },
+      {
+        position: [16, 0],
+        canAttack: true
+      },
+      0.1
+    );
+
+    expect(close.closeRangeBlend).toBeGreaterThan(far.closeRangeBlend);
+    expect(close.targetPressure).toBeGreaterThan(far.targetPressure);
+    expect(close.combatPressure).toBeGreaterThan(far.combatPressure);
+  });
+
+  test("still raises pressure from low health without an attackable target", () => {
+    const pressured = computeCombatCameraPressure(
+      {
+        position: [0, 0],
+        health: 12,
+        maxHealth: 100
+      },
+      null,
+      0
+    );
+
+    expect(pressured.lowHealthPressure).toBeGreaterThan(0.7);
+    expect(pressured.combatPressure).toBeGreaterThan(0.6);
   });
 });
 

--- a/apps/pod-web/src/frame-plan.ts
+++ b/apps/pod-web/src/frame-plan.ts
@@ -39,6 +39,13 @@ export interface PodThreePlanningOptions extends PodThreeCameraRigOptions {
 
 export const DEFAULT_WORLD_CHUNK_SIZE = 24;
 
+export interface CombatCameraSubject {
+  position: [number, number];
+  health?: number | null;
+  maxHealth?: number | null;
+  canAttack?: boolean;
+}
+
 export interface PlannedCameraPose {
   position: [number, number, number];
   target: [number, number, number];
@@ -88,6 +95,46 @@ export interface PlannedFrame {
   preloadedWorldChunks: string[];
   prewarmMeshRequests: PlannedMeshPrewarmRequest[];
   prewarmSpriteRequests: PlannedSpritePrewarmRequest[];
+}
+
+export function computeCombatCameraPressure(
+  controlled: CombatCameraSubject | null,
+  target: CombatCameraSubject | null,
+  cameraImpact: number
+): {
+  lowHealthPressure: number;
+  closeRangeBlend: number;
+  targetPressure: number;
+  combatPressure: number;
+} {
+  const healthRatio =
+    controlled && controlled.maxHealth != null && controlled.maxHealth > 0
+      ? clamp((controlled.health ?? controlled.maxHealth) / controlled.maxHealth, 0, 1)
+      : 1;
+  const lowHealthPressure = healthRatio < 0.45 ? (0.45 - healthRatio) / 0.45 : 0;
+
+  let closeRangeBlend = 0;
+  if (controlled && target?.canAttack) {
+    const distance = Math.hypot(
+      target.position[0] - controlled.position[0],
+      target.position[1] - controlled.position[1]
+    );
+    closeRangeBlend = clamp(1 - (distance - 1.8) / 7.2, 0, 1);
+  }
+
+  const targetPressure = target?.canAttack ? 0.28 + closeRangeBlend * 0.44 : 0;
+  const combatPressure = Math.max(
+    targetPressure,
+    lowHealthPressure * 0.9,
+    clamp(cameraImpact, 0, 1.4) * 0.75
+  );
+
+  return {
+    lowHealthPressure,
+    closeRangeBlend,
+    targetPressure,
+    combatPressure
+  };
 }
 
 export function buildCameraPose(
@@ -351,6 +398,16 @@ export function sampleAnimatedInstanceTransform(
   const strideWave = Math.sin(elapsedSeconds * (2.8 + motion * 5.4) + phase);
   const hoverWave = Math.sin(elapsedSeconds * 2.35 + phase);
   const pulseAmount = clamp(pulse, 0, 1);
+  const isBeast = animationSetId.includes("beast");
+  const isHumanoid =
+    animationSetId.includes("humanoid") ||
+    animationSetId.includes("hero") ||
+    animationSetId.includes("explorer") ||
+    animationSetId.includes("runescape");
+  const isRingLike =
+    animationSetId.includes("ring") ||
+    animationSetId.includes("path-node") ||
+    animationSetId.includes("destination");
 
   let yOffset = 0;
   let scaleX = instance.scale[0];
@@ -487,6 +544,20 @@ export function sampleAnimatedInstanceTransform(
     scaleY *= 1 - easedPulse * 0.08;
     scaleZ *= 1 + easedPulse * 0.12;
     pitchOffset += easedPulse * 0.05;
+    if (!isRingLike) {
+      if (isBeast) {
+        zOffset += easedPulse * (0.18 + motion * 0.07);
+        yOffset += easedPulse * 0.05;
+        scaleZ *= 1 + easedPulse * 0.05;
+        rollOffset += Math.sin(elapsedSeconds * 14 + phase) * 0.018 * easedPulse;
+        pitchOffset += easedPulse * 0.045;
+      } else if (isHumanoid) {
+        zOffset += easedPulse * (0.12 + motion * 0.06);
+        xOffset += Math.sin(elapsedSeconds * 10.5 + phase) * 0.018 * easedPulse;
+        rollOffset += Math.cos(elapsedSeconds * 12.2 + phase) * 0.016 * easedPulse;
+        pitchOffset += easedPulse * 0.03;
+      }
+    }
   }
 
   const baseRotation = new Quaternion(...instance.rotation);

--- a/apps/pod-web/src/main.ts
+++ b/apps/pod-web/src/main.ts
@@ -55,6 +55,7 @@ import {
   formatPopulationHeatmapLegend,
   renderPopulationHeatmap
 } from "./population-heatmap";
+import { computeCombatCameraPressure } from "./frame-plan";
 import {
   compactRuntimeStats,
   formatConnectionSummary,
@@ -535,13 +536,24 @@ function renderableThreeFrame(baseFrame: ThreeJsWebGpuFrame): ThreeJsWebGpuFrame
     ? Math.hypot(controlled.velocity[0], controlled.velocity[1])
     : 0;
   const leadDistance = Math.min(1.4, speed * 0.16);
-  const healthRatio =
-    controlled && controlled.maxHealth != null && controlled.maxHealth > 0
-      ? Math.max(0, Math.min(1, (controlled.health ?? controlled.maxHealth) / controlled.maxHealth))
-      : 1;
-  const lowHealthPressure = healthRatio < 0.45 ? (0.45 - healthRatio) / 0.45 : 0;
-  const targetPressure = target?.metadata.interaction.canAttack ? 0.45 : 0;
-  const combatPressure = Math.max(targetPressure, lowHealthPressure * 0.9, cameraImpact * 0.75);
+  const combatCamera = computeCombatCameraPressure(
+    controlled
+      ? {
+          position: controlled.position,
+          health: controlled.health,
+          maxHealth: controlled.maxHealth
+        }
+      : null,
+    target
+      ? {
+          position: target.position,
+          canAttack: target.metadata.interaction.canAttack
+        }
+      : null,
+    cameraImpact
+  );
+  const combatPressure = combatCamera.combatPressure;
+  const closeRangeBlend = combatCamera.closeRangeBlend;
   const leadScale = 1 + swimCameraBlend * 0.14 - combatPressure * 0.06;
   const leadX =
     controlled && speed > 0.05
@@ -560,11 +572,17 @@ function renderableThreeFrame(baseFrame: ThreeJsWebGpuFrame): ThreeJsWebGpuFrame
   const swimZoomOffset = swimCameraBlend * 0.082;
   const swimDistanceOffset = swimCameraBlend * 1.6;
   const swimShoulderOffset = baseShoulderOffset - swimCameraBlend * 0.42;
-  const combatFovKick = combatPressure * 2.4 + cameraImpact * 3;
-  const swimFocusHeight = baseFocusHeight + swimCameraBlend * 0.12;
-  const swimFollowDistance = baseFollowDistance + swimDistanceOffset - combatPressure * 0.65;
+  const combatFovKick = combatPressure * 2.4 + cameraImpact * 3 + closeRangeBlend * 0.9;
+  const swimFocusHeight = baseFocusHeight + swimCameraBlend * 0.12 + closeRangeBlend * 0.08;
+  const swimFollowDistance =
+    baseFollowDistance +
+    swimDistanceOffset -
+    combatPressure * 0.65 -
+    closeRangeBlend * 0.95;
   const blendedShoulderOffset =
-    baseShoulderOffset + (swimShoulderOffset - baseShoulderOffset) * swimCameraBlend;
+    baseShoulderOffset +
+    (swimShoulderOffset - baseShoulderOffset) * swimCameraBlend +
+    closeRangeBlend * 0.14;
 
   const interactionFrame = withInteractionMarkers(
     {
@@ -572,8 +590,24 @@ function renderableThreeFrame(baseFrame: ThreeJsWebGpuFrame): ThreeJsWebGpuFrame
       camera: {
         ...baseFrame.camera,
         rotation: cameraRig.yaw + shakeYaw,
-        pitch: clampScalar(cameraRig.pitch + swimPitchOffset + shakePitch - combatPressure * 0.012, 0.18, 0.76),
-        zoom: clampScalar(cameraRig.zoom - swimZoomOffset - combatPressure * 0.035 + cameraImpact * 0.028, 0.72, 1.65),
+        pitch: clampScalar(
+          cameraRig.pitch +
+            swimPitchOffset +
+            shakePitch -
+            combatPressure * 0.012 -
+            closeRangeBlend * 0.018,
+          0.18,
+          0.76
+        ),
+        zoom: clampScalar(
+          cameraRig.zoom -
+            swimZoomOffset -
+            combatPressure * 0.035 -
+            closeRangeBlend * 0.045 +
+            cameraImpact * 0.028,
+          0.72,
+          1.65
+        ),
         fov: clampScalar((baseFrame.camera.fov ?? 52) + combatFovKick, 50, 62),
         focusHeight: swimFocusHeight,
         followDistance: swimFollowDistance,

--- a/progress.md
+++ b/progress.md
@@ -56,3 +56,6 @@ Original prompt: its the graphics and the worlds scene, everything is piled up o
 - Added live direct-connect RTT/jitter sampling in the flagship browser client by finally using the existing ping/pong protocol, so developers can tell whether perceived roughness is coming from render/update presentation or actual shard network conditions.
 - Surfaced the network sample compactly in the main connection summary (`net Xms rtt / Yms jitter`) instead of bolting on another heavy HUD card.
 - Hardened the direct-connect timer path to use `globalThis` scheduling, which keeps the runtime portable across browser and test environments and makes the network client tests deterministic again.
+- Added a real close-range combat camera-pressure model in `pod-web`, so the camera now tightens framing from actual target proximity instead of relying only on generic event shake and low-health pressure.
+- Upgraded combat pulse animation so humanoids lunge forward and beasts drive heavier through impact moments instead of every pulse reading like the same neutral bounce.
+- Revalidated the browser smoke harness after the change, and both the main-thread and worker render routes still accept gameplay input cleanly.


### PR DESCRIPTION
## Summary
- tighten flagship combat framing based on actual target proximity instead of generic shake alone
- make combat pulses drive forward lunge/weight for humanoids and beasts in the browser client
- keep the browser network client portable by typing timer handles against globalThis

## Validation
- cd apps/pod-web && bun test ./src/frame-plan.test.ts ./src/contracts.test.ts ./src/renderer.test.ts
- cd apps/pod-web && bun run typecheck
- cd apps/pod-web && bun run build
- cd apps/pod-web && bun run test:smoke

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented close-range combat camera system that tightens framing based on target proximity.
  * Enhanced creature pulse animations with humanoids lunging forward and beasts driving heavier on impact.

* **Tests**
  * Added test coverage for camera pressure calculations and animation adjustments.
  * Validated rendering and input handling pathways.

* **Documentation**
  * Updated implementation planning and iteration tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->