### PR TITLE
Preserve replay state across resumed sessions

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1230,5 +1230,17 @@ Priority-sorted task list. One task per iteration. Mark [x] when complete.
   - `cd apps/pod-web && bun run typecheck`
   - `git diff --check`
 
-**Last updated**: Iteration 121
-**Current focus**: Iteration 122 native reconnect/session replay polish on top of the stabilized transport layer, then deeper shard-side recovery diagnostics beyond transport counters alone
+### Iteration 122
+- [x] Extended the shared `pod-net` welcome path with `acknowledged_action_tick`, so reconnect/session-resume handshakes can carry forward the server’s last processed action boundary instead of forcing clients to guess.
+- [x] Updated native and web `pod-net` clients to preserve and replay only unacknowledged prediction batches on resumed welcomes, keeping replay state alive across reconnect instead of clearing local prediction history on every resumed session.
+- [x] Propagated the welcome-contract change through the direct-connect server, SpacetimeDB adapter, and browser direct-connect parser/runtime, then added deterministic native/web parser coverage for replay-aware resumed welcomes.
+- [x] Revalidated touched targets:
+  - `cargo test -p pod-net --lib`
+  - `cargo test -p pod-net --features spacetimedb --lib`
+  - `cargo check -p pod-net --target wasm32-unknown-unknown --lib`
+  - `cd apps/pod-web && bun test ./src/contracts.test.ts ./src/direct-connect.test.ts`
+  - `cd apps/pod-web && bun run typecheck`
+  - `git diff --check`
+
+**Last updated**: Iteration 122
+**Current focus**: Iteration 123 deeper shard-side recovery diagnostics beyond transport counters alone, then further reconnect/session replay polish on top of the synchronized transport layer

--- a/apps/pod-web/src/contracts.test.ts
+++ b/apps/pod-web/src/contracts.test.ts
@@ -461,6 +461,7 @@ describe("TOON contract parsing", () => {
           reconnect_token: "reconnect-1",
           tick: 12,
           controlled_entity: 44,
+          acknowledged_action_tick: 11,
           authoritative_digest: 991,
           snapshot: {
             tick: 12,
@@ -561,6 +562,11 @@ describe("TOON contract parsing", () => {
     if (delta.kind !== "stateDelta") {
       throw new Error("expected delta");
     }
+    expect(welcome.kind).toBe("welcome");
+    if (welcome.kind !== "welcome") {
+      throw new Error("expected welcome");
+    }
+    expect(welcome.acknowledgedActionTick).toBe(11);
     expect(delta.delta.updated[0]?.position).toEqual([14, 19]);
     expect(delta.acknowledgedActionTick).toBe(12);
     expect(delta.delta.updated[0]?.metadata.teamId).toBe(2);
@@ -1497,6 +1503,7 @@ describe("TOON contract parsing", () => {
           reconnect_token: "resume-1",
           tick: 24,
           controlled_entity: 1,
+          acknowledged_action_tick: 23,
           authoritative_digest: 77,
           snapshot: {
             tick: 24,

--- a/apps/pod-web/src/contracts.ts
+++ b/apps/pod-web/src/contracts.ts
@@ -715,6 +715,7 @@ export type DirectConnectServerMessage =
       reconnectToken: string;
       tick: number;
       controlledEntity: number | null;
+      acknowledgedActionTick: number | null;
       authoritativeDigest: number;
       snapshot: NetworkWorldSnapshot;
     }
@@ -2096,6 +2097,7 @@ export function parseDirectConnectServerMessage(
         reconnectToken: welcome.reconnect_token,
         tick: welcome.tick,
         controlledEntity: optionalNumber(welcome.controlled_entity) ?? null,
+        acknowledgedActionTick: optionalNumber(welcome.acknowledged_action_tick) ?? null,
         authoritativeDigest: welcome.authoritative_digest,
         snapshot
       };

--- a/apps/pod-web/src/direct-connect.ts
+++ b/apps/pod-web/src/direct-connect.ts
@@ -329,6 +329,7 @@ export class PodWebDirectConnectClient {
         this.snapshot = message.snapshot;
         this.controlledEntity = message.controlledEntity;
         this.authoritativeDigest = message.authoritativeDigest;
+        this.reconcileAcknowledgedActions(message.acknowledgedActionTick);
         this.lastServerActivityAtMs = Date.now();
         this.updateWorldStatus("connected", `Connected as ${this.config.playerName}`);
         this.emitFrame();

--- a/crates/pod-net/src/client_native.rs
+++ b/crates/pod-net/src/client_native.rs
@@ -199,6 +199,7 @@ impl NativeClient {
 
     /// Send a connect message to the server
     async fn send_connect(&mut self) -> Result<(), ClientError> {
+        let resuming_session = self.reconnect_token.is_some();
         let msg = ClientMessage::Connect {
             player_name: self.config.player_name.clone(),
             reconnect_token: self.reconnect_token,
@@ -218,6 +219,7 @@ impl NativeClient {
                 client_id,
                 reconnect_token,
                 controlled_entity,
+                acknowledged_action_tick,
                 authoritative_digest,
                 snapshot,
                 ..
@@ -229,9 +231,19 @@ impl NativeClient {
                 self.local_snapshot = Some(snapshot);
                 self.ingest_authoritative_snapshot();
                 self.reconnect_token = Some(reconnect_token);
-                self.prediction_history.clear();
-                self.last_acknowledged_action_tick = None;
+                if resuming_session {
+                    self.prune_acknowledged_predictions(acknowledged_action_tick);
+                    self.rebuild_predicted_snapshot();
+                } else {
+                    self.prediction_history.clear();
+                    self.last_acknowledged_action_tick = None;
+                }
                 self.recovery_state.clear();
+                let replayed_action_count = self
+                    .prediction_history
+                    .iter()
+                    .map(|batch| batch.actions.len())
+                    .sum();
                 self.last_reconciliation = Some(ReconciliationReport {
                     authoritative_tick: self
                         .local_snapshot
@@ -239,9 +251,9 @@ impl NativeClient {
                         .map(|snapshot| snapshot.tick)
                         .unwrap_or_default(),
                     authoritative_digest,
-                    acknowledged_action_tick: None,
-                    pending_action_batches: 0,
-                    replayed_action_count: 0,
+                    acknowledged_action_tick,
+                    pending_action_batches: self.prediction_history.len(),
+                    replayed_action_count,
                     predicted_digest: self.local_snapshot.as_ref().map(WorldSnapshot::digest),
                     used_hard_resync: false,
                 });
@@ -435,26 +447,38 @@ impl NativeClient {
                 reconnect_token,
                 tick,
                 controlled_entity,
+                acknowledged_action_tick,
                 authoritative_digest,
                 snapshot,
             } => {
+                let resuming_session = self.reconnect_token.is_some();
                 self.client_id = Some(*client_id);
                 self.controlled_entity = *controlled_entity;
                 self.authoritative_snapshot = Some(snapshot.clone());
                 self.local_snapshot = Some(snapshot.clone());
                 self.ingest_authoritative_snapshot();
-                self.prediction_history.clear();
-                self.last_acknowledged_action_tick = None;
+                if resuming_session {
+                    self.prune_acknowledged_predictions(*acknowledged_action_tick);
+                    self.rebuild_predicted_snapshot();
+                } else {
+                    self.prediction_history.clear();
+                    self.last_acknowledged_action_tick = None;
+                }
                 self.recovery_state.clear();
                 self.last_server_tick = *tick;
                 self.last_event_tick = *tick;
                 self.reconnect_token = Some(*reconnect_token);
+                let replayed_action_count = self
+                    .prediction_history
+                    .iter()
+                    .map(|batch| batch.actions.len())
+                    .sum();
                 self.last_reconciliation = Some(ReconciliationReport {
                     authoritative_tick: *tick,
                     authoritative_digest: *authoritative_digest,
-                    acknowledged_action_tick: None,
-                    pending_action_batches: 0,
-                    replayed_action_count: 0,
+                    acknowledged_action_tick: *acknowledged_action_tick,
+                    pending_action_batches: self.prediction_history.len(),
+                    replayed_action_count,
                     predicted_digest: self.local_snapshot.as_ref().map(WorldSnapshot::digest),
                     used_hard_resync: false,
                 });
@@ -1210,6 +1234,114 @@ mod tests {
         assert_eq!(
             client.rollback_preview(Some(20)).unwrap().replayed_batches,
             1
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_resumed_welcome_replays_unacknowledged_predictions() {
+        let endpoint = Endpoint::client("0.0.0.0:0".parse().unwrap()).unwrap();
+        let (tx, rx) = mpsc::channel(1);
+        let authoritative = WorldSnapshot {
+            tick: 7,
+            entities: vec![crate::snapshot::EntitySnapshot {
+                id: 9,
+                position: glam::Vec2::ZERO,
+                velocity: glam::Vec2::ZERO,
+                rotation: 0.0,
+                health: None,
+                max_health: None,
+                movement_speed: Some(120.0),
+                label: Some("player".into()),
+                metadata: crate::snapshot::EntityMetadataSnapshot::default(),
+            }],
+            population: pod_core::WorldPopulationState {
+                tick: 7,
+                ..Default::default()
+            },
+        };
+        let reconnect_token = ReconnectToken::new();
+        let mut client = NativeClient {
+            config: ProtoClientConfig {
+                server_addr: "localhost".into(),
+                server_port: 5000,
+                player_name: "Tester".into(),
+                timeout_ms: 1000,
+                heartbeat_timeout_ms: 6500,
+                max_pending_actions: 32,
+            },
+            client_id: None,
+            connection: None,
+            endpoint,
+            runtime_state: Arc::new(Mutex::new(NativeRuntimeState::default())),
+            rx,
+            tx,
+            reader_task: None,
+            pending_updates: Vec::new(),
+            authoritative_snapshot: None,
+            local_snapshot: None,
+            controlled_entity: None,
+            pending_actions: Vec::new(),
+            prediction_history: vec![PredictedActionBatch {
+                tick: 7,
+                actions: vec![Action::Move {
+                    direction: glam::Vec2::X,
+                }],
+            }],
+            last_server_tick: 0,
+            last_acknowledged_action_tick: Some(5),
+            last_event_tick: 0,
+            reconnect_token: Some(reconnect_token),
+            last_reconciliation: None,
+            last_debug_telemetry_json: None,
+            last_debug_document: None,
+            pending_debug_documents: Vec::new(),
+            recovery_state: RecoveryRequestState::default(),
+            render_buffer: SnapshotInterpolationBuffer::default(),
+            render_clock: RenderClock::default(),
+            last_server_activity_at: std::time::Instant::now(),
+            last_ping_rtt_ms: None,
+            ping_jitter_ms: None,
+            reconnect_attempts: 0,
+            next_reconnect_at: None,
+        };
+
+        assert!(client.apply_server_message(&ServerMessage::Welcome {
+            client_id: ClientId::new(),
+            reconnect_token: ReconnectToken::new(),
+            tick: 7,
+            controlled_entity: Some(9),
+            acknowledged_action_tick: Some(6),
+            authoritative_digest: authoritative.digest(),
+            snapshot: authoritative.clone(),
+        }));
+
+        assert_eq!(client.prediction_history.len(), 1);
+        assert_eq!(client.last_acknowledged_action_tick, Some(6));
+        assert_eq!(
+            client
+                .last_reconciliation
+                .as_ref()
+                .expect("reconciliation recorded")
+                .pending_action_batches,
+            1
+        );
+        assert_eq!(
+            client
+                .last_reconciliation
+                .as_ref()
+                .expect("reconciliation recorded")
+                .acknowledged_action_tick,
+            Some(6)
+        );
+        assert!(
+            client
+                .local_snapshot
+                .as_ref()
+                .expect("predicted snapshot rebuilt")
+                .entities[0]
+                .position
+                .x
+                > authoritative.entities[0].position.x
         );
     }
 

--- a/crates/pod-net/src/client_stdb.rs
+++ b/crates/pod-net/src/client_stdb.rs
@@ -541,6 +541,7 @@ impl SpacetimeDBClient {
                                 reconnect_token: self.reconnect_token,
                                 tick,
                                 controlled_entity: None,
+                                acknowledged_action_tick: None,
                                 authoritative_digest: snapshot.digest(),
                                 snapshot,
                             });

--- a/crates/pod-net/src/client_web.rs
+++ b/crates/pod-net/src/client_web.rs
@@ -322,28 +322,40 @@ impl WebClient {
                 reconnect_token,
                 tick,
                 controlled_entity,
+                acknowledged_action_tick,
                 authoritative_digest,
                 snapshot,
             } => {
+                let resuming_session = self.reconnect_token.is_some();
                 self.client_id = Some(*client_id);
                 self.reconnect_token = Some(*reconnect_token);
                 self.controlled_entity = *controlled_entity;
                 self.authoritative_snapshot = Some(snapshot.clone());
                 self.local_snapshot = Some(snapshot.clone());
                 self.ingest_authoritative_snapshot();
-                self.prediction_history.clear();
+                if resuming_session {
+                    self.prune_acknowledged_predictions(*acknowledged_action_tick);
+                    self.rebuild_predicted_snapshot();
+                } else {
+                    self.prediction_history.clear();
+                    self.last_acknowledged_action_tick = None;
+                }
                 self.connected = true;
                 self.last_server_tick = *tick;
-                self.last_acknowledged_action_tick = None;
                 self.last_event_tick = *tick;
                 self.recovery_state.clear();
                 self.reconnect_attempts = 0;
+                let replayed_action_count = self
+                    .prediction_history
+                    .iter()
+                    .map(|batch| batch.actions.len())
+                    .sum();
                 self.last_reconciliation = Some(ReconciliationReport {
                     authoritative_tick: *tick,
                     authoritative_digest: *authoritative_digest,
-                    acknowledged_action_tick: None,
-                    pending_action_batches: 0,
-                    replayed_action_count: 0,
+                    acknowledged_action_tick: *acknowledged_action_tick,
+                    pending_action_batches: self.prediction_history.len(),
+                    replayed_action_count,
                     predicted_digest: self.local_snapshot.as_ref().map(WorldSnapshot::digest),
                     used_hard_resync: false,
                 });
@@ -818,6 +830,8 @@ impl std::error::Error for ClientError {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::snapshot::{EntityMetadataSnapshot, EntitySnapshot};
+    use pod_core::WorldPopulationState;
 
     #[test]
     fn test_client_config() {
@@ -834,5 +848,98 @@ mod tests {
         assert_eq!(config.server_port, 5001);
         assert_eq!(config.heartbeat_timeout_ms, 6500);
         assert_eq!(config.max_pending_actions, 32);
+    }
+
+    #[test]
+    fn test_resumed_welcome_replays_unacknowledged_predictions() {
+        let authoritative = WorldSnapshot {
+            tick: 7,
+            entities: vec![EntitySnapshot {
+                id: 9,
+                position: glam::Vec2::ZERO,
+                velocity: glam::Vec2::ZERO,
+                rotation: 0.0,
+                health: None,
+                max_health: None,
+                movement_speed: Some(120.0),
+                label: Some("player".into()),
+                metadata: EntityMetadataSnapshot::default(),
+            }],
+            population: WorldPopulationState {
+                tick: 7,
+                ..Default::default()
+            },
+        };
+        let mut client = WebClient {
+            config: ClientConfig {
+                server_addr: "localhost".to_string(),
+                server_port: 5001,
+                player_name: "WebPlayer".to_string(),
+                timeout_ms: 5000,
+                heartbeat_timeout_ms: 6500,
+                max_pending_actions: 32,
+            },
+            client_id: None,
+            websocket: None,
+            connected: false,
+            pending_updates: Arc::new(Mutex::new(Vec::new())),
+            runtime_state: Arc::new(Mutex::new(WebRuntimeState::default())),
+            authoritative_snapshot: None,
+            local_snapshot: None,
+            controlled_entity: None,
+            pending_actions: Vec::new(),
+            prediction_history: vec![PredictedActionBatch {
+                tick: 7,
+                actions: vec![Action::Move {
+                    direction: glam::Vec2::X,
+                }],
+            }],
+            last_server_tick: 0,
+            last_acknowledged_action_tick: Some(5),
+            last_event_tick: 0,
+            reconnect_token: Some(ReconnectToken::new()),
+            last_reconciliation: None,
+            last_debug_telemetry_json: None,
+            last_debug_document: None,
+            pending_debug_documents: Vec::new(),
+            recovery_state: RecoveryRequestState::default(),
+            render_buffer: SnapshotInterpolationBuffer::default(),
+            render_clock: RenderClock::default(),
+            reconnect_attempts: 0,
+            next_reconnect_at_ms: 0.0,
+            last_ping_rtt_ms: None,
+            ping_jitter_ms: None,
+        };
+
+        assert!(client.apply_server_message(&ServerMessage::Welcome {
+            client_id: ClientId::new(),
+            reconnect_token: ReconnectToken::new(),
+            tick: 7,
+            controlled_entity: Some(9),
+            acknowledged_action_tick: Some(6),
+            authoritative_digest: authoritative.digest(),
+            snapshot: authoritative.clone(),
+        }));
+
+        assert_eq!(client.prediction_history.len(), 1);
+        assert_eq!(client.last_acknowledged_action_tick, Some(6));
+        assert_eq!(
+            client
+                .last_reconciliation
+                .as_ref()
+                .expect("reconciliation recorded")
+                .pending_action_batches,
+            1
+        );
+        assert!(
+            client
+                .local_snapshot
+                .as_ref()
+                .expect("predicted snapshot rebuilt")
+                .entities[0]
+                .position
+                .x
+                > authoritative.entities[0].position.x
+        );
     }
 }

--- a/crates/pod-net/src/protocol.rs
+++ b/crates/pod-net/src/protocol.rs
@@ -111,6 +111,7 @@ pub enum ServerMessage {
         reconnect_token: ReconnectToken,
         tick: u64,
         controlled_entity: Option<u64>,
+        acknowledged_action_tick: Option<u64>,
         authoritative_digest: u64,
         snapshot: super::snapshot::WorldSnapshot,
     },
@@ -346,6 +347,7 @@ mod tests {
             reconnect_token: ReconnectToken::new(),
             tick: 100,
             controlled_entity: Some(42),
+            acknowledged_action_tick: Some(99),
             authoritative_digest: snapshot.digest(),
             snapshot,
         };
@@ -357,10 +359,12 @@ mod tests {
             ServerMessage::Welcome {
                 tick,
                 controlled_entity,
+                acknowledged_action_tick,
                 ..
             } => {
                 assert_eq!(tick, 100);
                 assert_eq!(controlled_entity, Some(42));
+                assert_eq!(acknowledged_action_tick, Some(99));
             }
             _ => panic!("Wrong message type"),
         }

--- a/crates/pod-net/src/server.rs
+++ b/crates/pod-net/src/server.rs
@@ -1552,6 +1552,12 @@ impl GameServer {
                 .get(&client_id)
                 .and_then(|session| session.agent_id)
                 .and_then(|agent_id| self.controlled_entity_for_agent(agent_id));
+            let acknowledged_action_tick = self
+                .clients
+                .read()
+                .await
+                .get(&client_id)
+                .and_then(|session| session.last_processed_action_tick);
             let authoritative_snapshot = WorldSnapshot::capture(&self.world);
             let snapshot = self.snapshot_for_client(
                 &authoritative_snapshot,
@@ -1570,6 +1576,7 @@ impl GameServer {
                         reconnect_token,
                         tick: self.tick,
                         controlled_entity,
+                        acknowledged_action_tick,
                         authoritative_digest,
                         snapshot: snapshot.clone(),
                     },
@@ -1613,6 +1620,7 @@ impl GameServer {
                     reconnect_token,
                     tick: self.tick,
                     controlled_entity: Some(entity.id() as u64),
+                    acknowledged_action_tick: None,
                     authoritative_digest,
                     snapshot: snapshot.clone(),
                 },

--- a/progress.md
+++ b/progress.md
@@ -107,3 +107,6 @@ Original prompt: its the graphics and the worlds scene, everything is piled up o
 - Extended shard transport observability again with explicit recovery delivery metrics (`recovery_snapshots_sent`, `recovery_delivery_failures`), so full recovery pressure is now visible as first-class transport telemetry rather than inferred from generic full-snapshot counts.
 - Updated the direct-connect server’s authoritative recovery path to count successful and failed recovery snapshot deliveries, then added deterministic `pod-net` coverage for both cases.
 - Surfaced those recovery metrics in the browser/editor shard summaries, keeping reconnect, recovery, timeout, and queue-pressure diagnosis aligned across all debug consumers.
+- Extended the shared `pod-net` welcome contract with `acknowledged_action_tick`, so resumed sessions can carry the server’s last processed action boundary through the reconnect handshake.
+- Updated native and web `pod-net` clients to preserve prediction history across resumed welcomes and replay only unacknowledged action batches instead of dropping local prediction state on session recovery.
+- Propagated the replay-aware welcome change through the direct-connect server, SpacetimeDB adapter, and `pod-web` direct-connect parser/runtime, then revalidated native, SpacetimeDB-enabled, wasm-facing, and browser parser targets.


### PR DESCRIPTION
## Summary
- preserve local prediction history across resumed pod-net sessions instead of clearing replay state on every reconnect
- carry acknowledged action ticks through the welcome handshake for replay-aware reconnects
- propagate the welcome contract change through direct-connect, SpacetimeDB adapter, and browser parser/runtime consumers

## Validation
- cargo test -p pod-net --lib
- cargo test -p pod-net --features spacetimedb --lib
- cargo check -p pod-net --target wasm32-unknown-unknown --lib
- cd apps/pod-web && bun test ./src/contracts.test.ts ./src/direct-connect.test.ts
- cd apps/pod-web && bun run typecheck
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced session recovery to preserve local action predictions during reconnection. The server now tracks the last processed action boundary, enabling clients to intelligently replay only unacknowledged actions rather than discarding local prediction state. This improves connection stability and reduces redundant action processing during recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->